### PR TITLE
fix(frontend): serialize detection_args as array for scan path API

### DIFF
--- a/frontend/src/components/config/ScanPathsSection.tsx
+++ b/frontend/src/components/config/ScanPathsSection.tsx
@@ -192,19 +192,21 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
             return;
         }
 
-        // Process detection_args if present
-        if (formData.detection_args && typeof formData.detection_args === 'string') {
-            formData.detection_args = (formData.detection_args as string)
-                .split(',')
-                .map(arg => arg.trim())
-                .filter(arg => arg.length > 0) as unknown as string;
+        // Build API payload: convert detection_args from comma-separated string to string[]
+        const { detection_args, ...rest } = formData;
+        const payload: Record<string, unknown> = { ...rest };
+        if (detection_args) {
+            const args = detection_args.split(',').map(arg => arg.trim()).filter(arg => arg.length > 0);
+            if (args.length > 0) {
+                payload.detection_args = args;
+            }
         }
 
         if (editingId) {
-            updateMutation.mutate({ id: editingId, data: formData as Omit<ScanPath, 'id'> });
+            updateMutation.mutate({ id: editingId, data: payload as Omit<ScanPath, 'id'> });
             setEditingId(null);
         } else {
-            createMutation.mutate(formData as Omit<ScanPath, 'id'>);
+            createMutation.mutate(payload as Omit<ScanPath, 'id'>);
         }
         resetForm();
     };


### PR DESCRIPTION
## Summary
- Fix PUT /api/config/paths/:id returning 400 Bad Request when updating scan paths
- Convert `detection_args` from comma-separated string to `string[]` before sending to backend
- Omit the field entirely when empty, instead of sending `""` where `[]string` is expected

## Test plan
- [ ] Edit an existing scan path in Config UI, change detection method/mode, click Update — should succeed (no 400 error)
- [ ] Create a new scan path with custom detection args (comma-separated) — args should be saved correctly
- [ ] Create/update a scan path with no detection args — should succeed without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scan path configuration form now converts comma-separated detection arguments into a proper list and filters out empty entries for more reliable input handling.
  * Form submission builds and sends a cleaned payload, ensuring unspecified detection arguments are excluded and provided arguments are transmitted in the correct format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->