### PR TITLE
fix(api): correct scan path type mismatches in CRUD and export/import

### DIFF
--- a/frontend/src/components/config/ScanPathsSection.tsx
+++ b/frontend/src/components/config/ScanPathsSection.tsx
@@ -64,6 +64,10 @@ const PathValidationStatus = ({ pathId }: { pathId: number }) => {
     );
 };
 
+// Form state uses detection_args as a comma-separated string for the input field,
+// while the API returns it as string[]. This type bridges that gap.
+type ScanPathFormState = Omit<Partial<ScanPath>, 'detection_args'> & { detection_args?: string };
+
 interface ScanPathsSectionProps {
     onScrollToDetectionTools?: () => void;
 }
@@ -80,7 +84,7 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
     const [editingId, setEditingId] = useState<number | null>(null);
     const [showFileBrowser, setShowFileBrowser] = useState(false);
     const [fileBrowserTarget, setFileBrowserTarget] = useState<'new' | number>('new');
-    const [newPath, setNewPath] = useState<Partial<ScanPath>>({
+    const [newPath, setNewPath] = useState<ScanPathFormState>({
         enabled: true,
         auto_remediate: true,
         detection_method: 'ffprobe',
@@ -212,17 +216,9 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
     };
 
     const handleEdit = (path: ScanPath) => {
-        let detectionArgsStr = '';
-        if (path.detection_args) {
-            try {
-                const argsArray = JSON.parse(path.detection_args);
-                if (Array.isArray(argsArray)) {
-                    detectionArgsStr = argsArray.join(', ');
-                }
-            } catch {
-                detectionArgsStr = path.detection_args;
-            }
-        }
+        const detectionArgsStr = Array.isArray(path.detection_args)
+            ? path.detection_args.join(', ')
+            : '';
 
         setNewPath({
             local_path: path.local_path,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -255,7 +255,7 @@ export interface ScanPath {
     auto_remediate: boolean;
     dry_run?: boolean;  // Per-path dry run mode
     detection_method?: 'zero_byte' | 'ffprobe' | 'mediainfo' | 'handbrake';
-    detection_args?: string;  // JSON string from API
+    detection_args?: string[] | null;  // Array from API
     detection_mode?: 'quick' | 'thorough';
     max_retries?: number;
     verification_timeout_hours?: number | null;  // NULL = use global setting
@@ -615,8 +615,9 @@ export interface ConfigExport {
         arr_instance_id?: number;
         enabled: boolean;
         auto_remediate: boolean;
+        dry_run?: boolean;
         detection_method: string;
-        detection_args?: string;
+        detection_args?: string[];
         detection_mode: string;
         max_retries: number;
         verification_timeout_hours?: number;

--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -144,7 +144,12 @@ func (s *RESTServer) exportScanPaths() []gin.H {
 			path["arr_instance_id"] = arrInstanceID.Int64
 		}
 		if detectionArgs.Valid && detectionArgs.String != "" {
-			path["detection_args"] = detectionArgs.String
+			var args []string
+			if err := json.Unmarshal([]byte(detectionArgs.String), &args); err == nil {
+				path["detection_args"] = args
+			} else {
+				path["detection_args"] = detectionArgs.String
+			}
 		}
 		if verificationTimeout.Valid {
 			path["verification_timeout_hours"] = verificationTimeout.Int64
@@ -248,17 +253,17 @@ type importArrInstance struct {
 }
 
 type importScanPath struct {
-	LocalPath                string `json:"local_path"`
-	ArrPath                  string `json:"arr_path"`
-	ArrInstanceID            *int   `json:"arr_instance_id"`
-	Enabled                  bool   `json:"enabled"`
-	AutoRemediate            bool   `json:"auto_remediate"`
-	DryRun                   bool   `json:"dry_run"`
-	DetectionMethod          string `json:"detection_method"`
-	DetectionArgs            string `json:"detection_args"`
-	DetectionMode            string `json:"detection_mode"`
-	MaxRetries               int    `json:"max_retries"`
-	VerificationTimeoutHours *int   `json:"verification_timeout_hours"`
+	LocalPath                string          `json:"local_path"`
+	ArrPath                  string          `json:"arr_path"`
+	ArrInstanceID            *int            `json:"arr_instance_id"`
+	Enabled                  bool            `json:"enabled"`
+	AutoRemediate            bool            `json:"auto_remediate"`
+	DryRun                   bool            `json:"dry_run"`
+	DetectionMethod          string          `json:"detection_method"`
+	DetectionArgs            json.RawMessage `json:"detection_args"`
+	DetectionMode            string          `json:"detection_mode"`
+	MaxRetries               int             `json:"max_retries"`
+	VerificationTimeoutHours *int            `json:"verification_timeout_hours"`
 }
 
 type importSchedule struct {
@@ -322,6 +327,36 @@ func normalizeScanPathDefaults(path *importScanPath) {
 	}
 }
 
+// normalizeDetectionArgs converts detection_args from various import formats to the DB storage format.
+// Accepts: null/empty, []string (new format), or string containing JSON array (legacy format).
+// Returns the JSON string for DB storage, or empty string if not set.
+func normalizeDetectionArgs(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	// Try as []string (new export format: ["--verbose", "--threads 2"])
+	var args []string
+	if err := json.Unmarshal(raw, &args); err == nil {
+		if len(args) == 0 {
+			return ""
+		}
+		b, err := json.Marshal(args)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+
+	// Try as string (legacy format: "[\"--verbose\",\"--threads 2\"]")
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+
+	return ""
+}
+
 // importScanPaths imports scan paths and returns count and path ID mapping.
 // Skips duplicates based on local_path to prevent creating multiple entries for the same path.
 func (s *RESTServer) importScanPaths(paths []importScanPath) (int, map[string]int64) {
@@ -346,7 +381,7 @@ func (s *RESTServer) importScanPaths(paths []importScanPath) (int, map[string]in
 			(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			path.LocalPath, path.ArrPath, path.ArrInstanceID, path.Enabled, path.AutoRemediate, path.DryRun,
-			path.DetectionMethod, path.DetectionArgs, path.DetectionMode, path.MaxRetries, path.VerificationTimeoutHours)
+			path.DetectionMethod, normalizeDetectionArgs(path.DetectionArgs), path.DetectionMode, path.MaxRetries, path.VerificationTimeoutHours)
 		if err == nil {
 			count++
 			if newID, idErr := result.LastInsertId(); idErr == nil {

--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -1305,6 +1305,131 @@ func TestImportConfigSkipsDuplicateNotifications(t *testing.T) {
 	assert.Equal(t, 2, count, "should have 2 total notifications")
 }
 
+func TestExportConfig_DetectionArgsAsArray(t *testing.T) {
+	db, cleanup := setupConfigTestDB(t)
+	defer cleanup()
+
+	// Create path with detection_args stored as JSON string in DB
+	_, err := db.Exec(`INSERT INTO scan_paths (local_path, arr_path, enabled, detection_args)
+		VALUES (?, ?, ?, ?)`,
+		"/media/tv", "/tv", true, `["-v","error"]`)
+	require.NoError(t, err)
+
+	mockPathMapper := &testutil.MockPathMapper{}
+	router, apiKey, serverCleanup := setupConfigTestServer(t, db, mockPathMapper, false)
+	defer serverCleanup()
+
+	req, _ := http.NewRequest("GET", "/api/config/export", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	paths := response["scan_paths"].([]interface{})
+	assert.Len(t, paths, 1)
+	path := paths[0].(map[string]interface{})
+
+	// detection_args should be a JSON array, not a string
+	args, ok := path["detection_args"].([]interface{})
+	assert.True(t, ok, "exported detection_args should be an array")
+	assert.Len(t, args, 2)
+	assert.Equal(t, "-v", args[0])
+	assert.Equal(t, "error", args[1])
+}
+
+func TestImportConfig_DetectionArgsArrayFormat(t *testing.T) {
+	db, cleanup := setupConfigTestDB(t)
+	defer cleanup()
+
+	mockPathMapper := &testutil.MockPathMapper{
+		ReloadFunc: func() error { return nil },
+	}
+	router, apiKey, serverCleanup := setupConfigTestServer(t, db, mockPathMapper, false)
+	defer serverCleanup()
+
+	// Import with new array format
+	body := bytes.NewBufferString(`{
+		"scan_paths": [
+			{"local_path": "/media/tv", "arr_path": "/tv", "enabled": true,
+			 "detection_args": ["--verbose", "--threads 2"]}
+		]
+	}`)
+
+	req, _ := http.NewRequest("POST", "/api/config/import", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify detection_args stored as JSON string in DB
+	var storedArgs string
+	err := db.QueryRow("SELECT detection_args FROM scan_paths WHERE local_path = ?", "/media/tv").Scan(&storedArgs)
+	require.NoError(t, err)
+	assert.Equal(t, `["--verbose","--threads 2"]`, storedArgs)
+}
+
+func TestImportConfig_DetectionArgsLegacyFormat(t *testing.T) {
+	db, cleanup := setupConfigTestDB(t)
+	defer cleanup()
+
+	mockPathMapper := &testutil.MockPathMapper{
+		ReloadFunc: func() error { return nil },
+	}
+	router, apiKey, serverCleanup := setupConfigTestServer(t, db, mockPathMapper, false)
+	defer serverCleanup()
+
+	// Import with legacy string format (JSON-encoded string containing array)
+	body := bytes.NewBufferString(`{
+		"scan_paths": [
+			{"local_path": "/media/tv", "arr_path": "/tv", "enabled": true,
+			 "detection_args": "[\"--verbose\",\"--threads 2\"]"}
+		]
+	}`)
+
+	req, _ := http.NewRequest("POST", "/api/config/import", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Legacy format: the string value is stored as-is (it's already a valid JSON array string)
+	var storedArgs string
+	err := db.QueryRow("SELECT detection_args FROM scan_paths WHERE local_path = ?", "/media/tv").Scan(&storedArgs)
+	require.NoError(t, err)
+	assert.Equal(t, `["--verbose","--threads 2"]`, storedArgs)
+}
+
+func TestNormalizeDetectionArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    json.RawMessage
+		expected string
+	}{
+		{"nil input", nil, ""},
+		{"null JSON", json.RawMessage(`null`), ""},
+		{"empty input", json.RawMessage(``), ""},
+		{"array format", json.RawMessage(`["--verbose","--threads 2"]`), `["--verbose","--threads 2"]`},
+		{"empty array", json.RawMessage(`[]`), ""},
+		{"string format (legacy)", json.RawMessage(`"[\"--verbose\"]"`), `["--verbose"]`},
+		{"empty string", json.RawMessage(`""`), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeDetectionArgs(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 // TestNormalizeScanPathDefaults verifies the default value normalization for scan paths.
 func TestNormalizeScanPathDefaults(t *testing.T) {
 	// Save and restore config

--- a/internal/api/handlers_paths.go
+++ b/internal/api/handlers_paths.go
@@ -58,6 +58,7 @@ type scanPathRequest struct {
 	ArrInstanceID            *int     `json:"arr_instance_id"`
 	Enabled                  bool     `json:"enabled"`
 	AutoRemediate            bool     `json:"auto_remediate"`
+	DryRun                   bool     `json:"dry_run"`
 	DetectionMethod          string   `json:"detection_method"`
 	DetectionArgs            []string `json:"detection_args"`
 	DetectionMode            string   `json:"detection_mode"`
@@ -98,8 +99,8 @@ func prepareScanPathRequest(req *scanPathRequest, c *gin.Context) ([]byte, bool)
 		var err error
 		detectionArgsJSON, err = json.Marshal(req.DetectionArgs)
 		if err != nil {
-			logger.Warnf("Failed to marshal detection_args: %v, using empty object", err)
-			detectionArgsJSON = []byte("{}")
+			logger.Warnf("Failed to marshal detection_args: %v, using empty array", err)
+			detectionArgsJSON = []byte("[]")
 		}
 	}
 
@@ -107,7 +108,7 @@ func prepareScanPathRequest(req *scanPathRequest, c *gin.Context) ([]byte, bool)
 }
 
 func (s *RESTServer) getScanPaths(c *gin.Context) {
-	rows, err := s.db.Query("SELECT id, local_path, arr_path, arr_instance_id, enabled, auto_remediate, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours FROM scan_paths")
+	rows, err := s.db.Query("SELECT id, local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours FROM scan_paths")
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
@@ -119,25 +120,39 @@ func (s *RESTServer) getScanPaths(c *gin.Context) {
 		var id int
 		var localPath, arrPath string
 		var arrInstanceID sql.NullInt64
-		var enabled, autoRemediate bool
+		var enabled, autoRemediate, dryRun bool
 		var detectionMethod, detectionMode string
 		var detectionArgs sql.NullString
 		var maxRetries int
 		var verificationTimeoutHours sql.NullInt64
-		if rows.Scan(&id, &localPath, &arrPath, &arrInstanceID, &enabled, &autoRemediate, &detectionMethod, &detectionArgs, &detectionMode, &maxRetries, &verificationTimeoutHours) != nil {
+		if rows.Scan(&id, &localPath, &arrPath, &arrInstanceID, &enabled, &autoRemediate, &dryRun, &detectionMethod, &detectionArgs, &detectionMode, &maxRetries, &verificationTimeoutHours) != nil {
 			continue
 		}
 		path := gin.H{
 			"id":               id,
 			"local_path":       localPath,
 			"arr_path":         arrPath,
-			"arr_instance_id":  arrInstanceID.Int64,
 			"enabled":          enabled,
 			"auto_remediate":   autoRemediate,
+			"dry_run":          dryRun,
 			"detection_method": detectionMethod,
-			"detection_args":   detectionArgs.String,
 			"detection_mode":   detectionMode,
 			"max_retries":      maxRetries,
+		}
+		if arrInstanceID.Valid {
+			path["arr_instance_id"] = arrInstanceID.Int64
+		} else {
+			path["arr_instance_id"] = nil
+		}
+		if detectionArgs.Valid && detectionArgs.String != "" {
+			var args []string
+			if err := json.Unmarshal([]byte(detectionArgs.String), &args); err == nil {
+				path["detection_args"] = args
+			} else {
+				path["detection_args"] = detectionArgs.String
+			}
+		} else {
+			path["detection_args"] = nil
 		}
 		if verificationTimeoutHours.Valid {
 			path["verification_timeout_hours"] = verificationTimeoutHours.Int64
@@ -241,10 +256,10 @@ func (s *RESTServer) createScanPath(c *gin.Context) {
 	}
 
 	_, err := s.db.Exec(`INSERT INTO scan_paths
-		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		req.LocalPath, req.ArrPath, req.ArrInstanceID, req.Enabled, req.AutoRemediate,
-		req.DetectionMethod, detectionArgsJSON, req.DetectionMode, req.MaxRetries, req.VerificationTimeoutHours)
+		req.DryRun, req.DetectionMethod, detectionArgsJSON, req.DetectionMode, req.MaxRetries, req.VerificationTimeoutHours)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
@@ -375,11 +390,11 @@ func (s *RESTServer) updateScanPath(c *gin.Context) {
 
 	_, err := s.db.Exec(`UPDATE scan_paths SET
 		local_path = ?, arr_path = ?, arr_instance_id = ?, enabled = ?,
-		auto_remediate = ?, detection_method = ?, detection_args = ?,
+		auto_remediate = ?, dry_run = ?, detection_method = ?, detection_args = ?,
 		detection_mode = ?, max_retries = ?, verification_timeout_hours = ?
 		WHERE id = ?`,
 		req.LocalPath, req.ArrPath, req.ArrInstanceID, req.Enabled,
-		req.AutoRemediate, req.DetectionMethod, detectionArgsJSON,
+		req.AutoRemediate, req.DryRun, req.DetectionMethod, detectionArgsJSON,
 		req.DetectionMode, req.MaxRetries, req.VerificationTimeoutHours, id)
 	if err != nil {
 		respondDatabaseError(c, err)

--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -42,6 +42,7 @@ func setupPathsTestDB(t *testing.T) (*sql.DB, func()) {
 		ALTER TABLE scan_paths ADD COLUMN detection_mode TEXT DEFAULT 'quick';
 		ALTER TABLE scan_paths ADD COLUMN max_retries INTEGER DEFAULT 3;
 		ALTER TABLE scan_paths ADD COLUMN verification_timeout_hours INTEGER;
+		ALTER TABLE scan_paths ADD COLUMN dry_run INTEGER DEFAULT 0;
 	`
 	_, err := db.Exec(schema)
 	require.NoError(t, err)
@@ -194,7 +195,207 @@ func TestGetScanPaths_WithNullDetectionArgs(t *testing.T) {
 	var response []map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Len(t, response, 1)
-	assert.Equal(t, "", response[0]["detection_args"]) // NULL becomes empty string
+	assert.Nil(t, response[0]["detection_args"]) // NULL returns as JSON null
+}
+
+func TestGetScanPaths_DetectionArgsAsArray(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	// Create arr instance
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	// Create scan path with JSON array detection_args
+	_, err := db.Exec(`INSERT INTO scan_paths
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, detection_args)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		"/media/movies", "/movies", arrID, true, false, `["-v","error"]`)
+	require.NoError(t, err)
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	req, _ := http.NewRequest("GET", "/api/config/paths", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Len(t, response, 1)
+
+	// detection_args should be a JSON array, not a string
+	args, ok := response[0]["detection_args"].([]interface{})
+	assert.True(t, ok, "detection_args should be an array")
+	assert.Len(t, args, 2)
+	assert.Equal(t, "-v", args[0])
+	assert.Equal(t, "error", args[1])
+}
+
+func TestGetScanPaths_ArrInstanceIDNull(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	// The base test schema has NOT NULL on arr_instance_id,
+	// so we need to alter it for this specific test
+	_, err := db.Exec("CREATE TABLE scan_paths_backup AS SELECT * FROM scan_paths")
+	require.NoError(t, err)
+	_, err = db.Exec("DROP TABLE scan_paths")
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE scan_paths (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		local_path TEXT NOT NULL,
+		arr_path TEXT NOT NULL,
+		arr_instance_id INTEGER REFERENCES arr_instances(id) ON DELETE SET NULL,
+		enabled INTEGER DEFAULT 1,
+		auto_remediate INTEGER DEFAULT 0,
+		dry_run INTEGER DEFAULT 0,
+		detection_method TEXT DEFAULT 'ffprobe',
+		detection_args TEXT,
+		detection_mode TEXT DEFAULT 'quick',
+		max_retries INTEGER DEFAULT 3,
+		verification_timeout_hours INTEGER,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`)
+	require.NoError(t, err)
+
+	// Create scan path with NULL arr_instance_id
+	_, err = db.Exec(`INSERT INTO scan_paths
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate)
+		VALUES (?, ?, ?, ?, ?)`,
+		"/media/movies", "/movies", nil, true, false)
+	require.NoError(t, err)
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	req, _ := http.NewRequest("GET", "/api/config/paths", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Len(t, response, 1)
+	assert.Nil(t, response[0]["arr_instance_id"], "NULL arr_instance_id should be JSON null, not 0")
+}
+
+func TestGetScanPaths_DryRunField(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	// Create arr instance for foreign key
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	// Create scan path with dry_run
+	_, err := db.Exec(`INSERT INTO scan_paths
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		"/media/movies", "/movies", arrID, true, false, true)
+	require.NoError(t, err)
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	req, _ := http.NewRequest("GET", "/api/config/paths", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+	assert.Len(t, response, 1)
+	assert.Equal(t, true, response[0]["dry_run"])
+}
+
+func TestCreateScanPath_WithDryRun(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	// Create arr instance
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	body := bytes.NewBufferString(fmt.Sprintf(`{
+		"local_path": "/media/test",
+		"arr_instance_id": %d,
+		"enabled": true,
+		"dry_run": true
+	}`, arrID))
+
+	req, _ := http.NewRequest("POST", "/api/config/paths", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Verify dry_run was stored
+	var dryRun bool
+	db.QueryRow("SELECT dry_run FROM scan_paths WHERE local_path = ?", "/media/test").Scan(&dryRun)
+	assert.True(t, dryRun)
+}
+
+func TestUpdateScanPath_WithDryRun(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	// Create arr instance
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	arrResult, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := arrResult.LastInsertId()
+
+	// Create path with dry_run = false
+	result, err := db.Exec(`INSERT INTO scan_paths
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		"/test/path", "/test/arr", arrID, true, false, false)
+	require.NoError(t, err)
+	id, _ := result.LastInsertId()
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	body := bytes.NewBufferString(fmt.Sprintf(`{
+		"local_path": "/test/path",
+		"arr_path": "/test/arr",
+		"arr_instance_id": %d,
+		"enabled": true,
+		"auto_remediate": false,
+		"dry_run": true
+	}`, arrID))
+
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("/api/config/paths/%d", id), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify dry_run was updated
+	var dryRun bool
+	db.QueryRow("SELECT dry_run FROM scan_paths WHERE id = ?", id).Scan(&dryRun)
+	assert.True(t, dryRun)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Fixes 4 related type-mismatch bugs in the scan paths API surface that were causing fields to be silently dropped or misrepresented across the create/update/read/export/import paths:

- **`dry_run` field**: added to create/update/read API (previously silently lost on round-trip)
- **`detection_args`**: now returned as a JSON array in `GET`, not a raw string
- **`arr_instance_id`**: returns `null` for unlinked paths instead of `0` (clearer semantics)
- **Export/import**: `detection_args` exported as array; import accepts both array and legacy string format via `normalizeDetectionArgs` helper (backward compatible)
- **Frontend**: `ScanPath` type and `handleEdit` updated to match the new API contract

## Test plan
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass (incl. new tests in `handlers_config_test.go` and `handlers_paths_test.go`)
- [x] `npm run build` in `frontend/` — clean
- [ ] Round-trip a scan path through create → edit → read in the UI and verify `dry_run` persists
- [ ] Export a scan paths config and re-import it; verify `detection_args` array round-trips
- [ ] Import a config exported by an older Healarr (legacy string format) and verify it still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `dry_run` flag on scan paths.
  * Enhanced configuration import/export to properly handle detection arguments as arrays.

* **Bug Fixes**
  * Improved handling of nullable fields in scan path API responses.
  * Fixed normalization of detection arguments from various input formats.

* **Chores**
  * Updated API type definitions to reflect array-based detection arguments.
  * Added comprehensive test coverage for configuration import/export workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->