### PR TITLE
chore: Phase 0 cleanup from full-codebase review

### DIFF
--- a/cmd/seeder/main.go
+++ b/cmd/seeder/main.go
@@ -88,17 +88,11 @@ func main() {
 			log.Printf("Failed to insert event: %v", err)
 		}
 
-		// 2. Simulate some state changes
+		// Latest event_type defines current_state in the view; SearchCompleted seeds a resolved-looking entry.
 		if e.Data["file_path"] == "/mnt/media/Movies/Inception/Inception.mkv" {
-			// Mark as resolved
 			_, _ = db.Exec(sqlInsertEvent, "corruption", id, "RemediationStarted", "{}")
-			_, _ = db.Exec(sqlInsertEvent, "corruption", id, "FileDeleted", "{}")     // Or whatever resolves it
-			_, _ = db.Exec(sqlInsertEvent, "corruption", id, "SearchCompleted", "{}") // This might mark it resolved in our logic?
-			// Actually the view looks for latest event_type.
-			// If we want 'resolved', we need an event that maps to that state or logic.
-			// The view just takes the latest event_type as current_state.
-			// So let's emit a 'CorruptionResolved' event (if it exists) or just leave it as SearchCompleted.
-			// Let's assume SearchCompleted implies resolution for now or add a specific event.
+			_, _ = db.Exec(sqlInsertEvent, "corruption", id, "FileDeleted", "{}")
+			_, _ = db.Exec(sqlInsertEvent, "corruption", id, "SearchCompleted", "{}")
 		}
 	}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -164,7 +164,7 @@ const ActiveScansTable = () => {
             const msg = lastMessage as { type: string; data: unknown };
             if (msg.type === 'ScanProgress') {
                 const progress = msg.data as ScanProgress;
-                // eslint-disable-next-line react-hooks/set-state-in-effect
+                // eslint-disable-next-line react-hooks/set-state-in-effect -- reacting to WebSocket message state
                 setScans(prev => ({ ...prev, [progress.id]: progress }));
             } else if (msg.type === 'ScanCompleted') {
                 const { scan_id } = msg.data as { scan_id: string };

--- a/internal/api/handlers_schedules.go
+++ b/internal/api/handlers_schedules.go
@@ -93,14 +93,7 @@ func (s *RESTServer) updateSchedule(c *gin.Context) {
 		return
 	}
 
-	// If enabled is missing, default to true (or maybe we should require it?)
-	// Actually, for an update, we might want to keep existing if nil.
-	// But for simplicity, let's assume the frontend sends everything or we fetch-modify-save.
-	// Let's enforce Enabled is present for now, or handle it carefully.
-	// In the service, we require enabled boolean.
-
-	// Default enabled to true; if provided, use the provided value
-	// Note: Service signature requires explicit enabled, so client must send full state
+	// Default enabled to true when omitted; UpdateSchedule requires explicit value.
 	enabled := true
 	if req.Enabled != nil {
 		enabled = *req.Enabled

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -34,7 +34,7 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 
 	var warnings []string
 
-	// Query 1: All corruption stats in a single query (was 5 separate queries)
+	// All corruption stats in a single query
 	var resolved, orphaned, inProgress, manualIntervention, pending, failed, ignored int
 	if err := s.db.QueryRow(`
 		SELECT
@@ -64,7 +64,7 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	// Total excludes ignored - they're not part of active remediation
 	stats.TotalCorruptions = pending + resolved + orphaned + manualIntervention + inProgress + failed
 
-	// Query 2: All scan stats in a single query (was 4 separate queries)
+	// All scan stats in a single query
 	if err := s.db.QueryRow(`
 		SELECT
 			COUNT(CASE WHEN status = 'running' THEN 1 END),

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -477,7 +477,7 @@ func (s *RESTServer) setupRoutes() {
 			protected.POST("/scans/resume-all", s.resumeAllScans)
 			protected.POST("/scans/cancel-all", s.cancelAllScans)
 			protected.POST("/scans", s.triggerScan) // RESTful: POST to collection
-			protected.POST("/scan", s.triggerScan)  // Legacy: keep for compatibility
+			protected.POST("/scan", s.triggerScan)  // Legacy alias kept for older clients
 			// Parameter routes come after specific routes
 			protected.GET("/scans/:scan_id", s.getScanDetails)
 			protected.GET("/scans/:scan_id/files", s.getScanFiles)

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -305,10 +305,8 @@ func (r *Repository) StartPeriodicCheckpoint(interval time.Duration) func() {
 	}
 }
 
-// recreateViews drops and recreates database views to ensure they match the latest schema.
-// This is necessary because SQLite views are not automatically updated when the schema changes.
-// Note: corruption_status VIEW is now a thin wrapper over corruption_summary TABLE for backwards compatibility.
-// createViewsWithSummaryTable creates optimized views using corruption_summary table
+// createViewsWithSummaryTable creates optimized views backed by the corruption_summary table.
+// corruption_status remains as a thin VIEW wrapper for backwards compatibility with older queries.
 func (r *Repository) createViewsWithSummaryTable() error {
 	// corruption_status VIEW is a thin wrapper for backwards compatibility
 	_, err := r.DB.Exec(`
@@ -445,6 +443,8 @@ func (r *Repository) createViewsLegacy() error {
 	return nil
 }
 
+// recreateViews drops and recreates database views to ensure they match the latest schema.
+// SQLite views are not automatically updated when the underlying schema changes.
 func (r *Repository) recreateViews() error {
 	// Drop existing views
 	// Security: view names are hardcoded in this slice, not from user input

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -140,8 +140,8 @@ func NewHealthCheckerWithPaths(ffprobePath, ffmpegPath, mediainfoPath, handbrake
 }
 
 // Check validates a media file using the default ffprobe detection method.
+// Retained for the HealthChecker interface; new code should call CheckWithConfig directly.
 func (hc *CmdHealthChecker) Check(path, mode string) (bool, *HealthCheckError) {
-	// Legacy method - use default ffprobe detection
 	return hc.CheckWithConfig(path, DetectionConfig{
 		Method: DetectionFFprobe,
 		Args:   []string{},

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -591,8 +591,7 @@ func (n *Notifier) extractAggregateID(data map[string]interface{}) string {
 	if id, ok := data["corruption_id"].(string); ok && id != "" {
 		return id
 	}
-	// Note: We no longer fall back to file_path - it's not a valid aggregate ID
-	// Aggregate IDs must be UUIDs to properly correlate events
+	// Aggregate IDs must be UUIDs to correlate events; file_path is not valid here.
 	return ""
 }
 

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -127,15 +127,7 @@ func (r *RemediatorService) checkDeletionCompleted(corruptionID string) (bool, i
 		mediaID = int64(mediaIDFloat.Float64)
 	}
 
-	// Parse metadata if available
-	var metadata map[string]interface{}
-	if metadataJSON.Valid && metadataJSON.String != "" {
-		// The metadata is stored as a JSON object, we need to extract it
-		// For simplicity, we'll just return nil and let the search use mediaID
-		metadata = nil
-	}
-
-	return true, mediaID, metadata
+	return true, mediaID, nil
 }
 
 // retrySearchOnly triggers a new search without attempting deletion

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -56,12 +56,8 @@ func isHiddenOrTempFile(path string) bool {
 	name := filepath.Base(path)
 	nameLower := strings.ToLower(name)
 
-	// Skip hidden files (starting with .)
+	// Skip hidden files (starting with .) — also covers FUSE .fuse_hidden* files
 	if strings.HasPrefix(name, ".") {
-		return true
-	}
-	// Skip FUSE temporary files
-	if strings.HasPrefix(name, ".fuse_hidden") {
 		return true
 	}
 	// Skip common temp file patterns
@@ -1507,14 +1503,15 @@ func (s *ScannerService) ResumeScan(scanID string) error {
 	return nil
 }
 
+const scanPathCacheTTL = 60 * time.Second
+
 // refreshScanPathCache loads all enabled scan paths into memory cache.
-// Cache expires after 60 seconds to pick up config changes.
+// Cache expires after scanPathCacheTTL to pick up config changes.
 func (s *ScannerService) refreshScanPathCache() error {
 	s.scanPathCacheMu.Lock()
 	defer s.scanPathCacheMu.Unlock()
 
-	// Check if cache is still valid (60 second TTL)
-	if time.Since(s.scanPathCacheTime) < 60*time.Second && len(s.scanPathCache) > 0 {
+	if time.Since(s.scanPathCacheTime) < scanPathCacheTTL && len(s.scanPathCache) > 0 {
 		return nil
 	}
 
@@ -1734,8 +1731,7 @@ func (s *ScannerService) LoadActiveCorruptionsForPath(rootPath string) map[strin
 // queueForRescan adds a file to the pending_rescans table for later retry
 // when infrastructure issues are resolved
 func (s *ScannerService) queueForRescan(filePath string, pathID int64, errorType, errorMessage string) {
-	// Calculate next retry time with exponential backoff
-	// First retry: 5 minutes, then 15, 30, 60, 120 minutes
+	// Exponential backoff: 5 minutes initially, doubling each retry, capped at 160 minutes (5 * 2^5)
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 


### PR DESCRIPTION
First batch from the 11-agent code review. All Phase 0 \"quick win\" findings — zero-risk dead code and stale comment cleanup. No behavior changes.

## Changes

### Dead code
- **`internal/services/scanner.go`** (`isHiddenOrTempFile`): removed unreachable \`.fuse_hidden\` branch. The preceding \`strings.HasPrefix(name, \".\")\` check already returns true for every \`.fuse_hidden*\` file.
- **`internal/services/remediator.go`** (\`extractMediaIDFromDeletion\`): removed fake metadata-parse block that declared \`metadata\`, set it to \`nil\` unconditionally, and returned \`nil\`. The comment described work that wasn't actually happening.

### Stale / wrong / noisy comments
- **`internal/db/repository.go`**: \`recreateViews\` doc-comment was attached above \`createViewsWithSummaryTable\` (the wrong function). Moved it to the right place and gave \`createViewsWithSummaryTable\` its own comment.
- **`internal/services/scanner.go`** (\`refreshScanPathCache\`): promoted the 60-second magic number to \`scanPathCacheTTL\` constant; the comment was duplicating the literal so they could drift independently.
- **`internal/services/scanner.go`** (\`queueForRescan\`): the comment claimed exponential backoff of \"5/15/30/60/120 minutes\" but the SQL actually doubles \`5 * (1 << min(retry_count, 5))\` — i.e. 5/10/20/40/80/160. Fixed comment to match the code.
- **`internal/api/handlers_schedules.go`** (\`UpdateSchedule\`): replaced 5 lines of stream-of-consciousness deliberation about default-enabled handling with a single descriptive line.
- **`cmd/seeder/main.go`**: similar — replaced 6 lines of internal monologue about resolution semantics with one accurate sentence about how the view derives \`current_state\`.
- **`internal/api/handlers_stats.go`**: dropped the \"(was N separate queries)\" PR-era artifacts from the Query 1/Query 2 comments.
- **`internal/integration/health_checker.go`** (\`Check\`): removed in-body \"Legacy method\" comment that restated the godoc; clarified the godoc explains why the method exists (HealthChecker interface conformance).
- **`internal/notifier/notifier.go`** (\`extractAggregateID\`): collapsed two lines describing deleted behavior into one factual line about the invariant.
- **`internal/api/rest.go`**: tightened the \"Legacy: keep for compatibility\" comment on the duplicate \`POST /scan\` route.
- **`frontend/src/pages/Dashboard.tsx`**: added \"reacting to WebSocket message state\" rationale to the only \`react-hooks/set-state-in-effect\` disable in the codebase that lacked one (consistent with the 5 disables added in #166).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass
- [x] \`npm run lint\` + \`npm run build\` in \`frontend/\` — clean

## Context
This is **Phase 0 of 9** in the remediation plan derived from the full-codebase review. Phase 1+ will be tracked as a separate task list and shipped as further PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media file enumeration to consistently treat all dot-prefixed entries as hidden files during scans.

* **Documentation**
  * Clarified inline documentation regarding schedule defaults, dashboard statistics retrieval, legacy API compatibility, database views, health checking methods, event correlation, and file scanning behavior.

* **Chores**
  * Minor code cleanup and simplifications in deletion and event processing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->