### PR TITLE
fix(security): SSRF guards + sanitize testArrConnection responses (Phase 1.1: S3)

### DIFF
--- a/internal/api/handlers_arr.go
+++ b/internal/api/handlers_arr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/network"
 )
 
 // errInvalidURLScheme is returned when a URL has an invalid scheme.
@@ -47,6 +48,13 @@ func validateArrURL(rawURL string) error {
 	// Ensure host is present
 	if parsed.Host == "" {
 		return errors.New("URL must include a host")
+	}
+
+	// SSRF guard: when HEALARR_BLOCK_PRIVATE_TARGETS=true, refuse RFC1918 /
+	// loopback / link-local / multicast destinations. No-op by default to
+	// preserve the homelab use case where *arr lives on the same LAN.
+	if err := network.ValidateDestination(rawURL); err != nil {
+		return err
 	}
 
 	return nil
@@ -262,9 +270,10 @@ func (s *RESTServer) testArrConnection(c *gin.Context) {
 
 	httpReq, err := http.NewRequest("GET", targetURL, nil) // #nosec G107 -- URL is validated above
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
+		logger.Debugf("testArrConnection create request error: %v", err)
+		c.JSON(http.StatusBadGateway, gin.H{
 			"success": false,
-			"error":   fmt.Sprintf("Failed to create request: %v", err),
+			"error":   "Failed to create connection request",
 		})
 		return
 	}
@@ -272,20 +281,24 @@ func (s *RESTServer) testArrConnection(c *gin.Context) {
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
+		// Don't echo the underlying error; that lets an attacker probe internal
+		// hosts via the failure message ("connection refused on 10.0.0.5:22").
 		logger.Debugf("Connection test failed: %v", err)
-		c.JSON(http.StatusOK, gin.H{
+		c.JSON(http.StatusBadGateway, gin.H{
 			"success": false,
-			"error":   fmt.Sprintf("Connection failed: %v", err),
+			"error":   "Connection failed",
 		})
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// Don't echo the upstream status; it lets an attacker fingerprint
+		// what kind of service is at the destination.
 		logger.Debugf("Connection test returned status: %d", resp.StatusCode)
-		c.JSON(http.StatusOK, gin.H{
+		c.JSON(http.StatusBadGateway, gin.H{
 			"success": false,
-			"error":   fmt.Sprintf("Server returned status %d", resp.StatusCode),
+			"error":   "Server did not respond with a successful status",
 		})
 		return
 	}

--- a/internal/api/handlers_arr_test.go
+++ b/internal/api/handlers_arr_test.go
@@ -627,13 +627,15 @@ func TestTestArrConnection_Failure_ConnectionError(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	// Connection failure returns 502 Bad Gateway with a generic error message;
+	// the underlying error is NOT echoed (SSRF leak prevention).
+	assert.Equal(t, http.StatusBadGateway, w.Code)
 
 	var response map[string]interface{}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, false, response["success"])
-	assert.Contains(t, response["error"], "Connection failed")
+	assert.Equal(t, "Connection failed", response["error"])
 }
 
 func TestTestArrConnection_Failure_BadStatus(t *testing.T) {
@@ -660,12 +662,14 @@ func TestTestArrConnection_Failure_BadStatus(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	// Non-2xx upstream response yields 502 with a generic error; we never
+	// echo the upstream status code to the caller (SSRF leak prevention).
+	assert.Equal(t, http.StatusBadGateway, w.Code)
 
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, false, response["success"])
-	assert.Contains(t, response["error"], "Server returned status 401")
+	assert.Equal(t, "Server did not respond with a successful status", response["error"])
 }
 
 func TestTestArrConnection_InvalidJSON(t *testing.T) {

--- a/internal/network/ssrf.go
+++ b/internal/network/ssrf.go
@@ -1,0 +1,77 @@
+// Package network provides outbound-request safety helpers, primarily
+// SSRF (Server-Side Request Forgery) protection for user-supplied URLs.
+package network
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+)
+
+// ErrPrivateDestination is returned when ValidateDestination is configured
+// to block private/internal addresses and the resolved host is one.
+var ErrPrivateDestination = errors.New("destination resolves to a private or internal address")
+
+// ErrCannotResolveHost is returned when DNS resolution fails for the host.
+var ErrCannotResolveHost = errors.New("cannot resolve destination host")
+
+// envBlockPrivate enables strict SSRF protection: any RFC1918, loopback,
+// link-local, multicast, or unspecified destination is refused.
+//
+// Default (unset): only enforce that the URL parses and has a host. This
+// preserves the typical Healarr deployment where *arr services live on the
+// same private LAN as Healarr (e.g., Sonarr at 192.168.1.10).
+const envBlockPrivate = "HEALARR_BLOCK_PRIVATE_TARGETS"
+
+// ValidateDestination checks that rawURL's host is safe to send authenticated
+// requests to. When HEALARR_BLOCK_PRIVATE_TARGETS=true, all resolved IPs are
+// checked against private/loopback/link-local/multicast ranges and the call
+// fails if any match.
+//
+// When the env var is unset, only basic URL well-formedness is enforced and
+// any host (private or public) is accepted. This is the homelab-friendly
+// default; operators in stricter environments should set the flag.
+func ValidateDestination(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse URL: %w", err)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return errors.New("URL has no host")
+	}
+
+	if os.Getenv(envBlockPrivate) != "true" {
+		return nil
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return fmt.Errorf("%w: %s", ErrCannotResolveHost, host)
+	}
+
+	for _, ip := range ips {
+		if isPrivateOrInternal(ip) {
+			return fmt.Errorf("%w: %s resolves to %s", ErrPrivateDestination, host, ip)
+		}
+	}
+
+	return nil
+}
+
+// isPrivateOrInternal returns true for any IP that an attacker should not be
+// able to direct authenticated outbound requests to: RFC1918 ranges,
+// loopback, link-local (including the cloud metadata address 169.254.169.254),
+// multicast, and the unspecified address.
+func isPrivateOrInternal(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}

--- a/internal/network/ssrf_test.go
+++ b/internal/network/ssrf_test.go
@@ -1,0 +1,130 @@
+package network
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestValidateDestination_NoBlockFlag_AllowsPrivate(t *testing.T) {
+	// Default: HEALARR_BLOCK_PRIVATE_TARGETS unset → private hosts pass.
+	t.Setenv("HEALARR_BLOCK_PRIVATE_TARGETS", "")
+
+	cases := []string{
+		"http://192.168.1.10:8989",
+		"http://10.0.0.5",
+		"http://127.0.0.1:3000",
+		"https://example.com",
+	}
+	for _, u := range cases {
+		if err := ValidateDestination(u); err != nil {
+			t.Errorf("ValidateDestination(%q) = %v, want nil with block flag unset", u, err)
+		}
+	}
+}
+
+func TestValidateDestination_BadURL(t *testing.T) {
+	// Malformed URLs are always rejected regardless of flag.
+	cases := []string{
+		"not a url",
+		"",
+		"http://",
+	}
+	for _, u := range cases {
+		if err := ValidateDestination(u); err == nil {
+			t.Errorf("ValidateDestination(%q) = nil, want error", u)
+		}
+	}
+}
+
+func TestValidateDestination_BlockFlag_RejectsPrivate(t *testing.T) {
+	t.Setenv("HEALARR_BLOCK_PRIVATE_TARGETS", "true")
+
+	// IP literals: deterministic, no DNS dependency.
+	cases := []string{
+		"http://192.168.1.1",     // RFC1918
+		"http://10.0.0.1",        // RFC1918
+		"http://172.16.0.1",      // RFC1918
+		"http://127.0.0.1",       // loopback
+		"http://169.254.169.254", // cloud metadata
+		"http://0.0.0.0",         // unspecified
+		"http://[::1]",           // IPv6 loopback
+		"http://[fe80::1]",       // IPv6 link-local
+	}
+	for _, u := range cases {
+		err := ValidateDestination(u)
+		if err == nil {
+			t.Errorf("ValidateDestination(%q) = nil, want ErrPrivateDestination", u)
+			continue
+		}
+		if !errors.Is(err, ErrPrivateDestination) {
+			t.Errorf("ValidateDestination(%q) error = %v, want ErrPrivateDestination", u, err)
+		}
+	}
+}
+
+func TestValidateDestination_BlockFlag_AllowsPublic(t *testing.T) {
+	t.Setenv("HEALARR_BLOCK_PRIVATE_TARGETS", "true")
+
+	// Public IPs (Cloudflare, Google DNS) — known to be public.
+	cases := []string{
+		"http://1.1.1.1",
+		"http://8.8.8.8:80",
+	}
+	for _, u := range cases {
+		if err := ValidateDestination(u); err != nil {
+			t.Errorf("ValidateDestination(%q) = %v, want nil for public IP", u, err)
+		}
+	}
+}
+
+func TestValidateDestination_BlockFlag_UnresolvableHost(t *testing.T) {
+	t.Setenv("HEALARR_BLOCK_PRIVATE_TARGETS", "true")
+
+	err := ValidateDestination("http://this-host-does-not-exist-for-sure.invalid")
+	if err == nil {
+		t.Fatal("ValidateDestination on unresolvable host = nil, want error")
+	}
+	if !errors.Is(err, ErrCannotResolveHost) {
+		t.Errorf("error = %v, want ErrCannotResolveHost wrapped", err)
+	}
+}
+
+func TestIsPrivateOrInternal(t *testing.T) {
+	cases := []struct {
+		ip      string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"169.254.169.254", true}, // cloud metadata
+		{"0.0.0.0", true},
+		{"::1", true},
+		{"fe80::1", true},
+		{"1.1.1.1", false},
+		{"8.8.8.8", false},
+		{"93.184.215.14", false}, // example.com
+	}
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("ParseIP(%q) returned nil", tc.ip)
+		}
+		got := isPrivateOrInternal(ip)
+		if got != tc.private {
+			t.Errorf("isPrivateOrInternal(%s) = %v, want %v", tc.ip, got, tc.private)
+		}
+	}
+}
+
+func TestValidateDestination_BlockFlag_NoHost(t *testing.T) {
+	t.Setenv("HEALARR_BLOCK_PRIVATE_TARGETS", "true")
+	if err := ValidateDestination("file:///etc/passwd"); err == nil {
+		t.Error("ValidateDestination(file:///...) should error on missing host")
+	} else if !strings.Contains(err.Error(), "host") {
+		t.Errorf("error should mention host, got: %v", err)
+	}
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/network"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -1005,6 +1006,9 @@ func (n *Notifier) sendGenericWebhook(cfg *NotificationConfig, eventType string,
 	}
 
 	targetURL := ensureHTTPScheme(c.WebhookURL)
+	if err := network.ValidateDestination(targetURL); err != nil {
+		return fmt.Errorf("webhook destination refused: %w", err)
+	}
 	structuredData := extractWebhookData(data)
 
 	// Add extra data from config


### PR DESCRIPTION
Closes P0 finding S3 from the audit. The vulnerability was twofold:

1. \`testArrConnection\` echoed the underlying error and upstream status verbatim — an authenticated attacker could probe internal services (\`http://192.168.1.5:22/\`, \`http://169.254.169.254/latest/meta-data/\`) and read the failure message to enumerate the internal network.
2. No SSRF guard on outbound destinations — *arr URLs and generic webhook URLs were accepted without any check against private/loopback/link-local ranges.

## Design choice: opt-in block, not opt-out

The audit recommended \"block RFC1918 by default, opt-in to allow\". For Healarr that default would break ~every install — the typical homelab has Sonarr at \`192.168.1.10:8989\` next to Healarr on the same LAN.

This PR flips the polarity: blocking is **opt-in** via \`HEALARR_BLOCK_PRIVATE_TARGETS=true\` for operators in stricter environments. The information-leak half of the fix (sanitized error responses) is **always on**, since it has no cost for any deployment.

## Changes

### New \`internal/network\` package

\`ValidateDestination(rawURL string) error\`:
- Always validates URL parses + has a host.
- When \`HEALARR_BLOCK_PRIVATE_TARGETS=true\`: resolves the host and refuses any IP in RFC1918 / loopback / link-local / multicast / unspecified. IPv4 + IPv6.

### Wired into:

- **\`validateArrURL\`** (\`internal/api/handlers_arr.go\`): added call to \`ValidateDestination\` after the existing scheme/host checks. Covers both adding *arr instances and the connection-test path.
- **\`sendGenericWebhook\`** (\`internal/notifier/notifier.go\`): validates the webhook destination before sending the request.

### \`testArrConnection\` response sanitization (always on)

| Before | After |
|---|---|
| \`200 OK\` + body \`{\"error\": \"Connection failed: dial tcp 192.168.1.5:22: connection refused\"}\` | \`502 Bad Gateway\` + body \`{\"error\": \"Connection failed\"}\` |
| \`200 OK\` + body \`{\"error\": \"Server returned status 401\"}\` | \`502 Bad Gateway\` + body \`{\"error\": \"Server did not respond with a successful status\"}\` |
| \`200 OK\` + body \`{\"error\": \"Failed to create request: %v\"}\` | \`502 Bad Gateway\` + body \`{\"error\": \"Failed to create connection request\"}\` |

The underlying error is still logged at debug level for operator diagnostics — it just doesn't ride out via the API. The status-code change (200 → 502 on failure) also makes failures externally observable to monitoring instead of falsely reporting success.

### Tests

- \`internal/network/ssrf_test.go\`: 7 new unit tests covering default-allow + strict-block modes against IP literals (both IPv4 and IPv6), plus malformed URLs, no-host URLs, and unresolvable hosts.
- Updated 2 existing tests in \`handlers_arr_test.go\` that asserted the old leaky error responses to assert the new sanitized 502 responses.

## Backward compatibility

- Default deployments: only behavioral change is testArrConnection now returns 502 instead of 200 on upstream failures. Frontend likely already handles both (or only checks the \`success: false\` JSON field).
- \`HEALARR_BLOCK_PRIVATE_TARGETS=true\` enables strict mode. Operators who set this can no longer point Healarr at RFC1918 *arr instances — intended behavior for that mode.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass (incl. new \`internal/network\` and updated \`handlers_arr_test.go\`)
- [ ] After merge: set \`HEALARR_BLOCK_PRIVATE_TARGETS=true\` in a test env, confirm adding an *arr instance at \`http://192.168.1.10\` is refused with a clear error
- [ ] After merge: confirm testArrConnection returns \`502\` for unreachable host and the body no longer contains the underlying error text

## Context

Phase 1.1 (S3 portion). Phase 1.1 already shipped S1 (mandatory encryption key) via #177. Remaining 1.1 items: webhook secret separation (S2 — needs DB migration), detection_args allowlist, respondBadRequest cleanup. Those will follow as separate PRs.