### PR TITLE
fix(notifier): only arm throttle window on successful send (Phase 1.5: E2)

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -535,24 +535,30 @@ func (n *Notifier) sendNotification(cfg *NotificationConfig, eventType string, d
 		err = shoutrrr.Send(shoutrrrURL, message)
 	}
 
-	// Update last sent time
-	n.mu.Lock()
-	n.lastSent[cfg.ID] = time.Now()
-	n.mu.Unlock()
-
 	// Log result and publish to EventBus for timeline
 	aggregateID := n.extractAggregateID(data)
 	providerLabel := n.getProviderLabel(cfg.ProviderType)
 
 	if err != nil {
+		// Do NOT update lastSent on failure. Otherwise, in a burst (e.g. many
+		// CorruptionDetected events firing at once) the first failed send would
+		// throttle every subsequent send in the window and the user would
+		// receive zero alerts despite events occurring. Failed sends leave the
+		// throttle window open so the next event can try again.
 		logger.Errorf("Failed to send notification %d: %v", cfg.ID, err)
 		n.logNotification(cfg.ID, eventType, message, "failed", err.Error())
 		n.publishNotificationEvent(aggregateID, domain.NotificationFailed, providerLabel, eventType, err.Error())
-	} else {
-		logger.Debugf("Sent notification %d for event %s", cfg.ID, eventType)
-		n.logNotification(cfg.ID, eventType, message, "sent", "")
-		n.publishNotificationEvent(aggregateID, domain.NotificationSent, providerLabel, eventType, "")
+		return
 	}
+
+	// Send succeeded — arm the throttle window.
+	n.mu.Lock()
+	n.lastSent[cfg.ID] = time.Now()
+	n.mu.Unlock()
+
+	logger.Debugf("Sent notification %d for event %s", cfg.ID, eventType)
+	n.logNotification(cfg.ID, eventType, message, "sent", "")
+	n.publishNotificationEvent(aggregateID, domain.NotificationSent, providerLabel, eventType, "")
 }
 
 // publishNotificationEvent publishes notification success/failure events to the event bus

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -2908,3 +2908,85 @@ func TestEventTitles_IncludesNewEvents(t *testing.T) {
 		}
 	}
 }
+
+// =============================================================================
+// Throttle behavior — fix for P0-2 (E2 in the review)
+// Regression test: a failed send must NOT arm the throttle window, otherwise
+// a burst of events after a transient webhook outage silently drops every
+// subsequent alert until the window expires.
+// =============================================================================
+
+func newGenericNotifierWithURL(t *testing.T, webhookURL string) (*Notifier, *NotificationConfig) {
+	t.Helper()
+	tdb := newTestDB(t)
+	t.Cleanup(tdb.Close)
+
+	eb := eventbus.NewEventBus(tdb.DB)
+	t.Cleanup(eb.Shutdown)
+
+	n := NewNotifier(tdb.DB, eb)
+
+	cfg := &NotificationConfig{
+		ID:              42,
+		Name:            "throttle-test",
+		ProviderType:    ProviderGeneric,
+		Config:          json.RawMessage(fmt.Sprintf(`{"webhook_url":%q}`, webhookURL)),
+		Events:          []string{string(domain.CorruptionDetected)},
+		Enabled:         true,
+		ThrottleSeconds: 60,
+	}
+	return n, cfg
+}
+
+func TestNotifier_Throttle_NotArmedOnSendFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n, cfg := newGenericNotifierWithURL(t, srv.URL)
+
+	n.sendNotification(cfg, string(domain.CorruptionDetected), map[string]interface{}{
+		"file_path": "/x.mkv",
+	})
+
+	n.mu.RLock()
+	_, throttled := n.lastSent[cfg.ID]
+	n.mu.RUnlock()
+
+	if throttled {
+		t.Fatal("lastSent must not be set after a failed send — a burst of events would silently drop every alert in the throttle window")
+	}
+
+	if n.canSend(cfg.ID, cfg.ThrottleSeconds) != true {
+		t.Fatal("canSend should still return true after a failed send")
+	}
+}
+
+func TestNotifier_Throttle_ArmedOnSendSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, cfg := newGenericNotifierWithURL(t, srv.URL)
+
+	before := time.Now()
+	n.sendNotification(cfg, string(domain.CorruptionDetected), map[string]interface{}{
+		"file_path": "/x.mkv",
+	})
+
+	n.mu.RLock()
+	ts, armed := n.lastSent[cfg.ID]
+	n.mu.RUnlock()
+
+	if !armed {
+		t.Fatal("lastSent must be set after a successful send (otherwise throttle never kicks in)")
+	}
+	if ts.Before(before) {
+		t.Errorf("lastSent timestamp %v is before the call started at %v", ts, before)
+	}
+	if n.canSend(cfg.ID, cfg.ThrottleSeconds) {
+		t.Error("canSend should return false immediately after a successful send within the throttle window")
+	}
+}


### PR DESCRIPTION
Closes P0 finding E2 from the review — a silent missed-alert bug in the notifier throttle path.

## The bug

\`sendNotification\` updated \`n.lastSent[cfg.ID]\` **before** checking whether the underlying webhook/shoutrrr call actually succeeded:

\`\`\`go
err = shoutrrr.Send(shoutrrrURL, message)
// ...
n.mu.Lock()
n.lastSent[cfg.ID] = time.Now()  // ← always set, even when err != nil
n.mu.Unlock()

if err != nil {
    logger.Errorf(...)  // failure logged, but throttle is already armed
}
\`\`\`

In a burst of events (e.g. a scan finding 50 corrupt files in quick succession, each emitting \`CorruptionDetected\`):

1. Event 1: webhook is down → send fails → \`lastSent\` gets set anyway
2. Events 2-50 within the throttle window (default 60s, often configured higher): \`canSend\` returns false → silently dropped

Net result: the user receives **zero alerts** despite 50 events occurring, even though only the first send actually failed. The very condition notifications exist to alert on is the one most likely to silently die.

## The fix

Move the \`lastSent\` update into the success branch only:

\`\`\`go
if err != nil {
    // Do NOT update lastSent on failure...
    logger.Errorf(...)
    n.logNotification(... \"failed\" ...)
    n.publishNotificationEvent(... NotificationFailed ...)
    return
}

// Send succeeded — arm the throttle window.
n.mu.Lock()
n.lastSent[cfg.ID] = time.Now()
n.mu.Unlock()
// ... success path
\`\`\`

Symmetric behavior: success arms the throttle, failure leaves it open so the next event can retry.

## Regression tests

Two new tests in \`notifier_test.go\`:

| Test | Server | Expected |
|---|---|---|
| \`TestNotifier_Throttle_NotArmedOnSendFailure\` | \`httptest\` returning 500 | \`lastSent[cfg.ID]\` is NOT set; \`canSend\` still returns true |
| \`TestNotifier_Throttle_ArmedOnSendSuccess\` | \`httptest\` returning 200 | \`lastSent[cfg.ID]\` IS set; \`canSend\` returns false within the throttle window |

Both use \`httptest.NewServer\` so they exercise the real \`sendGenericWebhook\` code path (including the SSRF guard, JSON marshaling, and HTTP plumbing).

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] New tests pass
- [x] All existing notifier tests still pass
- [ ] After merge: in a test env, configure a Discord webhook with a bad URL and trigger a burst of CorruptionDetected events. Confirm each one logs a failure (instead of \"throttled\" after the first).

## Context

Phase 1.5 of the remediation plan. The second half of 1.5 (\`ScanCorruptionSummary\` event for bulk notifications) will follow as a separate PR — it's an additive feature rather than a bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification throttling behavior: failed notifications no longer block subsequent retry attempts, allowing faster recovery from transient delivery errors.

* **Tests**
  * Added regression tests verifying throttling correctly handles both successful and failed notification delivery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->