### PR TITLE
refactor(api): drop exposeError parameter from respondBadRequest (Phase 1.1e)

### DIFF
--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -39,13 +39,12 @@ func respondAuthError(c *gin.Context, err error) {
 	respondWithError(c, http.StatusInternalServerError, ErrMsgAuthenticationError, err)
 }
 
-// respondBadRequest handles bad request errors, optionally exposing the error message
-// Use exposeError=true only for validation errors safe to show users
-func respondBadRequest(c *gin.Context, err error, exposeError bool) {
-	if exposeError && err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+// respondBadRequest replies with a 400 and a generic "Invalid request" body,
+// logging the underlying error at debug level. Never echoes the error text
+// to the caller — that prevents bind/validation errors from leaking type
+// information (e.g. "json: cannot unmarshal string into Go struct field X
+// of type int") that helps an attacker fingerprint internal types.
+func respondBadRequest(c *gin.Context, err error) {
 	respondWithError(c, http.StatusBadRequest, ErrMsgInvalidRequest, err)
 }
 

--- a/internal/api/handlers_arr.go
+++ b/internal/api/handlers_arr.go
@@ -153,7 +153,7 @@ func (s *RESTServer) createArrInstance(c *gin.Context) {
 		Enabled bool   `json:"enabled"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -207,7 +207,7 @@ func (s *RESTServer) updateArrInstance(c *gin.Context) {
 		Enabled bool   `json:"enabled"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -240,7 +240,7 @@ func (s *RESTServer) testArrConnection(c *gin.Context) {
 		APIKey string `json:"api_key"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -30,7 +30,7 @@ func (s *RESTServer) handleAuthSetup(c *gin.Context) {
 		Password string `json:"password"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -81,7 +81,7 @@ func (s *RESTServer) handleLogin(c *gin.Context) {
 		Password string `json:"password"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -193,7 +193,7 @@ func (s *RESTServer) changePassword(c *gin.Context) {
 		NewPassword     string `json:"new_password"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_auth_test.go
+++ b/internal/api/handlers_auth_test.go
@@ -511,44 +511,36 @@ func TestRespondAuthError(t *testing.T) {
 // respondBadRequest full coverage
 // =============================================================================
 
-func TestRespondBadRequest_ExposeError(t *testing.T) {
+func TestRespondBadRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("exposes_error_when_requested", func(t *testing.T) {
+	t.Run("hides_underlying_error", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 
-		testErr := assert.AnError
-		respondBadRequest(c, testErr, true)
+		respondBadRequest(c, assert.AnError)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response map[string]interface{}
 		json.Unmarshal(w.Body.Bytes(), &response)
-		assert.Contains(t, response["error"], testErr.Error())
+		// Always the generic message — the underlying error must never leak.
+		assert.Equal(t, "Invalid request", response["error"])
+		// And specifically must not contain the underlying error text.
+		assert.NotContains(t, response["error"], assert.AnError.Error())
 	})
 
-	t.Run("hides_error_when_not_requested", func(t *testing.T) {
+	t.Run("handles_nil_error", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 
-		respondBadRequest(c, assert.AnError, false)
+		respondBadRequest(c, nil)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 
 		var response map[string]interface{}
 		json.Unmarshal(w.Body.Bytes(), &response)
 		assert.Equal(t, "Invalid request", response["error"])
-	})
-
-	t.Run("handles_nil_error_with_expose", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		c, _ := gin.CreateTestContext(w)
-
-		respondBadRequest(c, nil, true)
-
-		// With nil error and expose=true, falls through to default message
-		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
 

--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -30,7 +30,7 @@ func (s *RESTServer) updateSettings(c *gin.Context) {
 		BasePath string `json:"base_path"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -481,7 +481,7 @@ func (s *RESTServer) importNotifications(notifications []importNotification) int
 func (s *RESTServer) importConfig(c *gin.Context) {
 	var req importConfigRequest
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_corruptions.go
+++ b/internal/api/handlers_corruptions.go
@@ -433,7 +433,7 @@ func (s *RESTServer) retryCorruptions(c *gin.Context) {
 		IDs []string `json:"ids"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -488,7 +488,7 @@ func (s *RESTServer) ignoreCorruptions(c *gin.Context) {
 		IDs []string `json:"ids"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -527,7 +527,7 @@ func (s *RESTServer) deleteCorruptions(c *gin.Context) {
 		IDs []string `json:"ids"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -40,7 +40,7 @@ func (s *RESTServer) createNotification(c *gin.Context) {
 
 	var req notifier.NotificationConfig
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -72,7 +72,7 @@ func (s *RESTServer) updateNotification(c *gin.Context) {
 
 	var req notifier.NotificationConfig
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 	req.ID = id
@@ -112,7 +112,7 @@ func (s *RESTServer) testNotification(c *gin.Context) {
 
 	var req notifier.NotificationConfig
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_paths.go
+++ b/internal/api/handlers_paths.go
@@ -246,7 +246,7 @@ func (s *RESTServer) getDetectionPreview(c *gin.Context) {
 func (s *RESTServer) createScanPath(c *gin.Context) {
 	var req scanPathRequest
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -379,7 +379,7 @@ func (s *RESTServer) updateScanPath(c *gin.Context) {
 	id := c.Param("id")
 	var req scanPathRequest
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -16,7 +16,7 @@ func (s *RESTServer) triggerScan(c *gin.Context) {
 		PathID int64 `json:"path_id"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_schedules.go
+++ b/internal/api/handlers_schedules.go
@@ -48,7 +48,7 @@ func (s *RESTServer) addSchedule(c *gin.Context) {
 		CronExpression string `json:"cron_expression"`
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (s *RESTServer) updateSchedule(c *gin.Context) {
 		Enabled        *bool  `json:"enabled"` // Pointer to distinguish between false and missing
 	}
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 

--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -93,7 +93,7 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 
 	var req WebhookRequest
 	if err := c.BindJSON(&req); err != nil {
-		respondBadRequest(c, err, false)
+		respondBadRequest(c, err)
 		return
 	}
 


### PR DESCRIPTION
Closes a P1 finding from the review — \`respondBadRequest\` accepted an \`exposeError bool\` that, when \`true\`, echoed the underlying error text back to the caller.

## The footgun

\`\`\`go
// Before
func respondBadRequest(c *gin.Context, err error, exposeError bool) {
    if exposeError && err != nil {
        c.JSON(http.StatusBadRequest, gin.H{\"error\": err.Error()})  // leaks
        return
    }
    respondWithError(c, http.StatusBadRequest, ErrMsgInvalidRequest, err)
}
\`\`\`

A grep of all 20 production call sites confirmed every one passed \`false\` (we verified this back during the original W4 review in February). But the dead branch existed — a future caller copying an example or trying to be \"helpful\" could pass \`true\` and leak bind/validation errors like \`json: cannot unmarshal string into Go struct field X of type int\` which fingerprint internal type structure.

## The fix

\`\`\`go
// After
func respondBadRequest(c *gin.Context, err error) {
    respondWithError(c, http.StatusBadRequest, ErrMsgInvalidRequest, err)
}
\`\`\`

One safe behavior: 400 + generic \"Invalid request\" body, underlying error logged at debug for operator diagnostics. The footgun is gone.

## Changes

- Removed the \`exposeError\` parameter (errors.go)
- Updated 20 production call sites via sed (pattern was uniform: \`respondBadRequest(c, err, false)\` → \`respondBadRequest(c, err)\`)
- Replaced the test block that exercised the now-removed \`true\` branch (\`TestRespondBadRequest_ExposeError\` → \`TestRespondBadRequest\`); new tests explicitly assert the underlying error text does NOT appear in the response

## Note on 1.6 (webhook shutdown safety, also in original Phase 1 plan)

The audit also recommended adding context-cancellation to the webhook-triggered scan goroutine. Doing that requires \`ScannerService.ScanFile\` to accept a \`ctx\`, which is a larger refactor scheduled for Phase 3 (Repository) or Phase 6 (Scanner). The \`safego.Run\` from #176 already provides crash safety for that goroutine. Deferring 1.6 until ScanFile's signature changes.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/api/...\` — all tests pass
- [x] sed sweep verified: 0 production call sites remain with the 3-arg form

## Context

Phase 1.1e of the remediation plan. After this, the remaining Phase 1 work is: 1.1c (webhook secret separation — needs DB migration), 1.1d (detection_args allowlist), 1.3 (login session tokens), 1.4 (silent-error sweep), 1.6 (deferred, see above), 1.7 (scanner shutdown timeout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API error responses now return standardized messages instead of exposing underlying technical details in responses. Internal error information continues to be logged for diagnostic purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->