### PR TITLE
fix(security): allowlist detection_args at API write time (Phase 1.1d)

### DIFF
--- a/internal/api/detection_args.go
+++ b/internal/api/detection_args.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// allowedDetectionFlags lists ffmpeg / ffprobe / mediainfo flags that an
+// operator may supply via the per-scan-path detection_args setting.
+//
+// The set is intentionally small: only performance/probing tuning flags
+// that take primitive values. Anything that lets ffmpeg open additional
+// inputs (-i), choose output formats (-f), bypass protocol restrictions
+// (-protocol_whitelist), or reference URLs/files is excluded — those
+// would turn a configurable scan into an exfiltration primitive for any
+// caller who can edit a scan path.
+var allowedDetectionFlags = map[string]bool{
+	"-threads":         true, // CPU thread count for decoding
+	"-probesize":       true, // bytes to read for format detection
+	"-analyzeduration": true, // microseconds to analyze streams
+	"-fpsprobesize":    true, // frames to inspect for FPS detection
+	"-loglevel":        true, // log verbosity (overrides default -v error)
+	"-v":               true, // alias for -loglevel
+	"-hide_banner":     true, // suppress ffmpeg startup banner
+	"-nostats":         true, // suppress periodic encoding statistics
+}
+
+// validateDetectionArgs enforces an allowlist on the per-scan-path
+// detection_args values before they are persisted. Called at API write
+// time so misconfiguration is caught at edit, not at scan execution
+// where it could attempt to exfiltrate data.
+//
+// Each element in args is one ffmpeg argv slot. Flag elements (those
+// starting with "-") must be members of allowedDetectionFlags. Value
+// elements (no leading dash) are accepted but must not contain protocol
+// markers that turn into URLs or pipes inside ffmpeg.
+func validateDetectionArgs(args []string) error {
+	for i, arg := range args {
+		if arg == "" {
+			return fmt.Errorf("detection_args[%d] is empty", i)
+		}
+		if err := checkForProtocolMarker(arg); err != nil {
+			return fmt.Errorf("detection_args[%d]: %w", i, err)
+		}
+		if strings.HasPrefix(arg, "-") {
+			if !allowedDetectionFlags[arg] {
+				return fmt.Errorf("detection_args[%d]: flag %q is not permitted (allowed: %s)",
+					i, arg, allowedFlagsList())
+			}
+		}
+	}
+	return nil
+}
+
+// checkForProtocolMarker rejects strings that ffmpeg would interpret as
+// non-file inputs: URLs, file: URIs, and ffmpeg's pipe: protocol.
+func checkForProtocolMarker(arg string) error {
+	lower := strings.ToLower(arg)
+	switch {
+	case strings.Contains(lower, "://"):
+		return errors.New("URLs are not permitted in detection_args")
+	case strings.HasPrefix(lower, "file:"):
+		return errors.New("file: URIs are not permitted in detection_args")
+	case strings.HasPrefix(lower, "pipe:"):
+		return errors.New("pipe: redirection is not permitted in detection_args")
+	}
+	return nil
+}
+
+// allowedFlagsList returns the allowlist as a sorted comma-separated
+// string, for error messages.
+func allowedFlagsList() string {
+	flags := make([]string, 0, len(allowedDetectionFlags))
+	for f := range allowedDetectionFlags {
+		flags = append(flags, f)
+	}
+	// Insertion sort — N ≤ 10 so the simple algorithm is fine.
+	for i := 1; i < len(flags); i++ {
+		for j := i; j > 0 && flags[j-1] > flags[j]; j-- {
+			flags[j-1], flags[j] = flags[j], flags[j-1]
+		}
+	}
+	return strings.Join(flags, ", ")
+}

--- a/internal/api/detection_args_test.go
+++ b/internal/api/detection_args_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateDetectionArgs_Empty(t *testing.T) {
+	if err := validateDetectionArgs(nil); err != nil {
+		t.Errorf("nil args should be valid, got %v", err)
+	}
+	if err := validateDetectionArgs([]string{}); err != nil {
+		t.Errorf("empty args should be valid, got %v", err)
+	}
+}
+
+func TestValidateDetectionArgs_AllowedFlags(t *testing.T) {
+	cases := [][]string{
+		{"-threads", "4"},
+		{"-probesize", "1000000"},
+		{"-analyzeduration", "10000000"},
+		{"-fpsprobesize", "50"},
+		{"-loglevel", "warning"},
+		{"-v", "error"},
+		{"-hide_banner"},
+		{"-nostats"},
+		{"-threads", "2", "-probesize", "5000000", "-hide_banner"}, // combined
+	}
+	for _, args := range cases {
+		if err := validateDetectionArgs(args); err != nil {
+			t.Errorf("validateDetectionArgs(%v) = %v, want nil", args, err)
+		}
+	}
+}
+
+func TestValidateDetectionArgs_RejectsDisallowedFlags(t *testing.T) {
+	cases := [][]string{
+		{"-i", "/etc/passwd"},          // additional input
+		{"-f", "data"},                 // output format change
+		{"-protocol_whitelist", "all"}, // bypass protocol restriction
+		{"-y"},                         // overwrite flag
+		{"-c:v", "libx264"},            // codec flag
+		{"--something"},                // long form
+		{"-unknown_flag"},              // anything not in allowlist
+	}
+	for _, args := range cases {
+		err := validateDetectionArgs(args)
+		if err == nil {
+			t.Errorf("validateDetectionArgs(%v) = nil, want rejection", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "not permitted") {
+			t.Errorf("validateDetectionArgs(%v) error = %v, expected 'not permitted'", args, err)
+		}
+	}
+}
+
+func TestValidateDetectionArgs_RejectsURLs(t *testing.T) {
+	cases := [][]string{
+		{"-threads", "http://attacker.example/x"},
+		{"-threads", "https://evil.local/y"},
+		{"http://payload-as-flag-value"},
+		{"-i", "https://x"}, // both -i and URL — should fail on -i first
+	}
+	for _, args := range cases {
+		err := validateDetectionArgs(args)
+		if err == nil {
+			t.Errorf("validateDetectionArgs(%v) = nil, want rejection", args)
+			continue
+		}
+		// Either "not permitted" (flag rejected first) or "URL" / "URI" (URL rejected first)
+		msg := err.Error()
+		if !strings.Contains(msg, "URLs are not permitted") &&
+			!strings.Contains(msg, "not permitted") {
+			t.Errorf("validateDetectionArgs(%v) error = %v, expected URL or flag rejection", args, err)
+		}
+	}
+}
+
+func TestValidateDetectionArgs_RejectsFileURI(t *testing.T) {
+	cases := [][]string{
+		{"-threads", "file:/etc/passwd"},
+		{"-threads", "FILE:/etc/passwd"}, // case insensitive
+		{"file:/etc/shadow"},
+	}
+	for _, args := range cases {
+		err := validateDetectionArgs(args)
+		if err == nil {
+			t.Errorf("validateDetectionArgs(%v) = nil, want rejection", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "file:") && !strings.Contains(err.Error(), "URLs") {
+			t.Errorf("validateDetectionArgs(%v) error = %v, expected file: rejection", args, err)
+		}
+	}
+}
+
+func TestValidateDetectionArgs_RejectsPipe(t *testing.T) {
+	cases := [][]string{
+		{"-threads", "pipe:0"},
+		{"pipe:1"},
+	}
+	for _, args := range cases {
+		err := validateDetectionArgs(args)
+		if err == nil {
+			t.Errorf("validateDetectionArgs(%v) = nil, want rejection", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "pipe:") {
+			t.Errorf("validateDetectionArgs(%v) error = %v, expected pipe: rejection", args, err)
+		}
+	}
+}
+
+func TestValidateDetectionArgs_RejectsEmptyString(t *testing.T) {
+	err := validateDetectionArgs([]string{"-threads", ""})
+	if err == nil {
+		t.Fatal("empty string in args should be rejected")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error = %v, expected 'empty' in message", err)
+	}
+}
+
+func TestAllowedFlagsList_StableAndComplete(t *testing.T) {
+	got := allowedFlagsList()
+	// Should be sorted alphabetically and include every entry in the map
+	for flag := range allowedDetectionFlags {
+		if !strings.Contains(got, flag) {
+			t.Errorf("allowedFlagsList() missing %q; got %q", flag, got)
+		}
+	}
+	// Sorted check: split and verify increasing order
+	parts := strings.Split(got, ", ")
+	for i := 1; i < len(parts); i++ {
+		if parts[i-1] > parts[i] {
+			t.Errorf("allowedFlagsList() not sorted: %q comes before %q", parts[i-1], parts[i])
+		}
+	}
+}

--- a/internal/api/handlers_paths.go
+++ b/internal/api/handlers_paths.go
@@ -93,6 +93,14 @@ func prepareScanPathRequest(req *scanPathRequest, c *gin.Context) ([]byte, bool)
 		}
 	}
 
+	// Allowlist detection_args so a malicious or compromised admin session
+	// cannot persist -i http://... / -f data / etc. and have them spliced
+	// into ffmpeg at scan time.
+	if err := validateDetectionArgs(req.DetectionArgs); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return nil, false
+	}
+
 	// Marshal detection args to JSON
 	var detectionArgsJSON []byte
 	if len(req.DetectionArgs) > 0 {

--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -494,7 +494,7 @@ func TestCreateScanPath_WithDetectionArgs(t *testing.T) {
 		"local_path": "/media/custom",
 		"arr_instance_id": ` + string(rune(arrID+'0')) + `,
 		"enabled": true,
-		"detection_args": ["-v", "error", "-show_streams"]
+		"detection_args": ["-v", "error", "-hide_banner"]
 	}`)
 
 	req, _ := http.NewRequest("POST", "/api/config/paths", body)
@@ -510,6 +510,55 @@ func TestCreateScanPath_WithDetectionArgs(t *testing.T) {
 	db.QueryRow("SELECT detection_args FROM scan_paths WHERE local_path = ?", "/media/custom").Scan(&argsJSON)
 	assert.Contains(t, argsJSON, "-v")
 	assert.Contains(t, argsJSON, "error")
+}
+
+// TestCreateScanPath_DetectionArgsAllowlist verifies the validator rejects
+// the dangerous flag patterns that motivated the allowlist.
+func TestCreateScanPath_DetectionArgsAllowlist(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	router, apiKey, serverCleanup := setupPathsTestServer(t, db)
+	defer serverCleanup()
+
+	cases := []struct {
+		name string
+		args string
+	}{
+		{"additional_input", `["-i", "/etc/passwd"]`},
+		{"output_format", `["-f", "data"]`},
+		{"protocol_whitelist", `["-protocol_whitelist", "all"]`},
+		{"url_in_value", `["-threads", "http://evil/x"]`},
+		{"file_uri", `["-threads", "file:/etc/shadow"]`},
+		{"unknown_flag", `["-y"]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewBufferString(`{
+				"local_path": "/media/` + tc.name + `",
+				"arr_instance_id": ` + string(rune(arrID+'0')) + `,
+				"enabled": true,
+				"detection_args": ` + tc.args + `
+			}`)
+			req, _ := http.NewRequest("POST", "/api/config/paths", body)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-API-Key", apiKey)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for %s", tc.args)
+
+			// And the row must not have been persisted.
+			var count int
+			db.QueryRow("SELECT COUNT(*) FROM scan_paths WHERE local_path = ?", "/media/"+tc.name).Scan(&count)
+			assert.Equal(t, 0, count, "%s should not have been persisted", tc.args)
+		})
+	}
 }
 
 func TestCreateScanPath_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
Closes the P1 command-injection-via-ffmpeg-args finding from the audit.

## The vulnerability

\`scanPathRequest.DetectionArgs\` was \`[]string\` with **no validation**. The values are persisted to the DB and spliced into the ffmpeg/ffprobe argv at scan time (\`internal/integration/health_checker.go:413-420\`):

\`\`\`go
args = []string{\"-v\", \"error\", argXError, \"-i\", path, \"-f\", \"null\", \"-\"}
if len(customArgs) > 0 {
    newArgs := []string{\"-v\", \"error\", argXError}
    newArgs = append(newArgs, customArgs...)  // ← attacker-controlled
    newArgs = append(newArgs, \"-i\", path, \"-f\", \"null\", \"-\")
    args = newArgs
}
\`\`\`

A compromised admin session (or one acquired via the credential-leak scenario from S1/S2) could persist:
- \`[\"-i\", \"http://attacker.example/x\"]\` — adds an external input ffmpeg will fetch on every scan
- \`[\"-i\", \"file:/etc/shadow\"]\` — adds a file input that gets decoded as media
- \`[\"-protocol_whitelist\", \"all\"]\` — bypasses ffmpeg's default protocol restriction
- \`[\"-f\", \"data\"]\` — change output format (with creative argument ordering, can affect what gets read)

Shell metacharacters aren't the threat here (\`exec.Command\` doesn't go through a shell), but ffmpeg's own protocol handlers are.

## The fix: minimal allowlist at API write time

New \`internal/api/detection_args.go\`:

\`\`\`go
var allowedDetectionFlags = map[string]bool{
    \"-threads\":         true,
    \"-probesize\":       true,
    \"-analyzeduration\": true,
    \"-fpsprobesize\":    true,
    \"-loglevel\":        true,
    \"-v\":               true, // alias
    \"-hide_banner\":     true,
    \"-nostats\":         true,
}
\`\`\`

\`validateDetectionArgs(args []string) error\` rejects:

| Pattern | Why |
|---|---|
| Empty string | Trying to slip something past the start-of-string check |
| Contains \`://\` | URL — ffmpeg will fetch it |
| Starts with \`file:\` | ffmpeg's file URI protocol |
| Starts with \`pipe:\` | ffmpeg's pipe protocol — could redirect |
| Starts with \`-\` and not in allowlist | Any flag we didn't explicitly bless |

Value elements (no leading \`-\`) pass through modulo the protocol-marker check, since they're the values of already-validated flags.

\`prepareScanPathRequest\` calls the validator before persisting. A reject returns 400 with the specific reason (e.g. \`detection_args[2]: flag \"-i\" is not permitted (allowed: -analyzeduration, -fpsprobesize, -hide_banner, -loglevel, -nostats, -probesize, -threads, -v)\`) so a misconfigured operator can see what went wrong.

## Tests

**\`internal/api/detection_args_test.go\`** — 7 unit tests:
- empty / nil args pass
- each allowlisted flag passes (alone and combined)
- disallowed flags reject (\`-i\`, \`-f\`, \`-protocol_whitelist\`, \`-y\`, \`-c:v\`, \`--something\`, \`-unknown_flag\`)
- URL-in-value rejected
- \`file:\` URI rejected
- \`pipe:\` redirect rejected
- empty-string element rejected
- \`allowedFlagsList()\` is sorted and complete

**\`handlers_paths_test.go\` TestCreateScanPath_DetectionArgsAllowlist** — 6 integration sub-tests posting to the actual handler with each dangerous arg pattern, verifying:
- HTTP 400 returned
- Row is NOT persisted (count check)

Also updated the existing \`TestCreateScanPath_WithDetectionArgs\` to use an allowlisted arg combination (was using \`-show_streams\` which is benign but not in the allowlist).

## Back-compat

Existing scan_paths rows in the DB are NOT re-validated — they continue to work at scan time. Only new writes (POST /paths, PUT /paths/:id) trigger the validator. If a user previously configured a now-disallowed flag, their next edit will be rejected; deploy notes should mention this.

In practice, ad-hoc detection_args is an advanced feature; the audit's threat model assumed it was configured maliciously, not legitimately, so the breakage of legitimate exotic configurations is unlikely.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/api/...\` — all tests pass (including 7 new unit + 6 new sub-tests)
- [ ] After merge: confirm UI \"detection args\" advanced field shows a meaningful error if user pastes \`-i ...\`

## Context

Phase 1.1d of the remediation plan. Phase 1 remaining: 1.1c (webhook secret separation — needs DB migration, M), 1.3 (login session tokens, M), 1.4 (silent-error sweep, M), 1.6 (deferred), 1.7 (scanner shutdown timeout, S).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media detection arguments are now validated to prevent dangerous configurations. Invalid inputs (URLs, file URIs, pipe directives, and unpermitted flags) are rejected with HTTP 400 responses and clear error messages.

* **Tests**
  * Added comprehensive validation tests for media detection argument handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->