### PR TITLE
fix(scanner): make shutdown timeout configurable, default 30s (Phase 1.7)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -25,6 +25,26 @@ import (
 // scannerQueryTimeout is the maximum time for database queries in scanner service.
 const scannerQueryTimeout = 10 * time.Second
 
+// defaultShutdownTimeout is how long Shutdown waits for in-flight scan
+// goroutines (mostly ffprobe/ffmpeg calls) to finish before declaring
+// shutdown complete. Scan progress is persisted incrementally so a hard
+// cutoff is safe, but a longer default reduces the chance that an
+// in-flight thorough-mode ffmpeg decode is interrupted mid-file.
+const defaultShutdownTimeout = 30 * time.Second
+
+// scannerShutdownTimeout returns the operator-configured shutdown timeout
+// from HEALARR_SCANNER_SHUTDOWN_TIMEOUT (parsed via time.ParseDuration),
+// or defaultShutdownTimeout if unset/invalid.
+func scannerShutdownTimeout() time.Duration {
+	if v := os.Getenv("HEALARR_SCANNER_SHUTDOWN_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+		logger.Warnf("Invalid HEALARR_SCANNER_SHUTDOWN_TIMEOUT %q; using default %s", v, defaultShutdownTimeout)
+	}
+	return defaultShutdownTimeout
+}
+
 // Default media file extensions to scan
 var defaultMediaExtensions = map[string]bool{
 	".mkv":  true,
@@ -247,18 +267,21 @@ func (s *ScannerService) Shutdown() {
 	}
 	s.mu.Unlock()
 
-	// Brief wait for goroutines to acknowledge cancellation (non-blocking)
+	// Wait for in-flight scan goroutines to finish. Scan-record state is
+	// already persisted in the for-loop above, so an interrupted goroutine
+	// only loses progress within its current per-file ffprobe call.
 	done := make(chan struct{})
 	safego.Run("scanner-shutdown-wait", func() {
 		s.wg.Wait()
 		close(done)
 	})
 
+	timeout := scannerShutdownTimeout()
 	select {
 	case <-done:
 		logger.Infof("Scanner: all scans stopped")
-	case <-time.After(2 * time.Second):
-		logger.Infof("Scanner: timeout waiting for scans, state saved for resumption")
+	case <-time.After(timeout):
+		logger.Warnf("Scanner: %s shutdown timeout reached; in-flight per-file work may have been interrupted (scan records already marked interrupted at file boundaries; resumption will pick up there)", timeout)
 	}
 
 	logger.Infof("Scanner: shutdown complete")

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4260,3 +4260,35 @@ func TestScannerService_ContentAnalysis_QuickMode_Skipped(t *testing.T) {
 		t.Error("AnalyzeContent should not be called in quick mode")
 	}
 }
+
+func TestScannerShutdownTimeout_Default(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_SHUTDOWN_TIMEOUT", "")
+	got := scannerShutdownTimeout()
+	if got != defaultShutdownTimeout {
+		t.Errorf("scannerShutdownTimeout() = %v, want %v", got, defaultShutdownTimeout)
+	}
+}
+
+func TestScannerShutdownTimeout_FromEnvVar(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_SHUTDOWN_TIMEOUT", "2m")
+	got := scannerShutdownTimeout()
+	if got != 2*time.Minute {
+		t.Errorf("scannerShutdownTimeout() = %v, want 2m", got)
+	}
+}
+
+func TestScannerShutdownTimeout_InvalidFallsBackToDefault(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_SHUTDOWN_TIMEOUT", "not a duration")
+	got := scannerShutdownTimeout()
+	if got != defaultShutdownTimeout {
+		t.Errorf("scannerShutdownTimeout() with invalid env = %v, want default %v", got, defaultShutdownTimeout)
+	}
+}
+
+func TestScannerShutdownTimeout_NegativeFallsBackToDefault(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_SHUTDOWN_TIMEOUT", "-1s")
+	got := scannerShutdownTimeout()
+	if got != defaultShutdownTimeout {
+		t.Errorf("scannerShutdownTimeout() with negative env = %v, want default %v", got, defaultShutdownTimeout)
+	}
+}


### PR DESCRIPTION
Closes the P2 \"Two-second shutdown timeout drops scan state\" finding from the review.

## The problem

\`ScannerService.Shutdown\` waited 2 seconds for in-flight goroutines to finish, then logged:

\`\`\`
Scanner: timeout waiting for scans, state saved for resumption
\`\`\`

— at INFO level, regardless of what actually happened. For thorough-mode scans (\`ffmpeg\` decode of a full file, often 5-10+ minutes per file), the 2-second cutoff was guaranteed to fire and the log message was misleading: \"state saved\" implied a clean save, but in reality whatever ffprobe/ffmpeg call was running got interrupted mid-stream.

The scan-record state itself (\`current_file_index\`) IS saved synchronously before the wait, so resumption still works correctly. The issue is honesty about what the 2s timeout actually meant.

## The fix

- New const \`defaultShutdownTimeout = 30 * time.Second\` (was \`2 * time.Second\`)
- New helper \`scannerShutdownTimeout()\` reads \`HEALARR_SCANNER_SHUTDOWN_TIMEOUT\` via \`time.ParseDuration\`; invalid or non-positive values log a warning and fall back to the default. Operators running thorough mode against large files can set \`\"5m\"\` or \`\"10m\"\` if they want shutdown to wait out long decodes
- \`Shutdown()\` uses the configured timeout
- The timeout-branch log is now \`Warnf\` (not \`Infof\`) and states accurately:

\`\`\`
Scanner: 30s shutdown timeout reached; in-flight per-file work may have been
interrupted (scan records already marked interrupted at file boundaries;
resumption will pick up there)
\`\`\`

## Tests

Four new tests in \`scanner_test.go\`:

| Test | Setup | Asserts |
|---|---|---|
| \`TestScannerShutdownTimeout_Default\` | Env var unset | Returns \`defaultShutdownTimeout\` |
| \`TestScannerShutdownTimeout_FromEnvVar\` | \`HEALARR_SCANNER_SHUTDOWN_TIMEOUT=2m\` | Returns 2 minutes |
| \`TestScannerShutdownTimeout_InvalidFallsBackToDefault\` | env=\"not a duration\" | Logs warning, returns default |
| \`TestScannerShutdownTimeout_NegativeFallsBackToDefault\` | env=\"-1s\" | Logs warning, returns default |

## Backward compatibility

Existing deployments will see shutdown take up to 30s instead of 2s if scans were in flight. For most deployments this matches what users intuitively expect — \"give the running scan a chance to finish.\" Operators who specifically want the old short-cutoff behavior can set \`HEALARR_SCANNER_SHUTDOWN_TIMEOUT=2s\`.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/services/...\` — all tests pass (incl. 4 new shutdown-timeout tests)
- [x] gofmt clean
- [ ] After merge: trigger a thorough-mode scan, send SIGTERM mid-decode, verify the warning log + that scan resumes from the last file boundary on restart

## Context

Phase 1.7 of the remediation plan. After this, Phase 1 remaining is the bigger items: 1.1c (webhook secret separation — needs DB migration, M), 1.3 (login session tokens — M), 1.4 (silent-error sweep — M). 1.6 (webhook shutdown safety) is deferred until ScanFile accepts a ctx (Phase 3/6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable scanner shutdown timeout via environment variable, with a default of 30 seconds (previously hardcoded at 2 seconds).

* **Tests**
  * Added unit tests for timeout configuration behavior, including edge cases for invalid or missing environment variable values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->