### PR TITLE
fix(config): fail export on sub-query errors instead of silent partial backup (Phase 1.4: E1)

### DIFF
--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -80,12 +80,13 @@ func (s *RESTServer) restartServer(c *gin.Context) {
 	})
 }
 
-// exportArrInstances exports arr instances from the database.
-func (s *RESTServer) exportArrInstances() []gin.H {
+// exportArrInstances exports arr instances from the database. Returns the
+// rows and any query/iteration error so the caller can fail the export
+// instead of returning a partial result the user wouldn't know is broken.
+func (s *RESTServer) exportArrInstances() ([]gin.H, error) {
 	rows, err := s.db.Query("SELECT name, type, url, api_key, enabled FROM arr_instances")
 	if err != nil {
-		logger.Debugf("Failed to query arr instances for export: %v", err)
-		return nil
+		return nil, fmt.Errorf("query arr_instances: %w", err)
 	}
 	defer rows.Close()
 
@@ -94,11 +95,13 @@ func (s *RESTServer) exportArrInstances() []gin.H {
 		var name, arrType, url, encryptedKey string
 		var enabled bool
 		if err := rows.Scan(&name, &arrType, &url, &encryptedKey, &enabled); err != nil {
-			logger.Errorf("Failed to scan arr instance for export: %v", err)
-			continue
+			return nil, fmt.Errorf("scan arr_instance: %w", err)
 		}
 		decryptedKey, err := crypto.Decrypt(encryptedKey)
 		if err != nil {
+			// Per-row decrypt failure is recorded as a sentinel; we don't
+			// fail the whole export because the rest of the data is still
+			// valuable, but the sentinel makes the corrupt row obvious.
 			logger.Errorf("Failed to decrypt API key for export: %v", err)
 			decryptedKey = "[DECRYPTION_ERROR]"
 		}
@@ -107,19 +110,18 @@ func (s *RESTServer) exportArrInstances() []gin.H {
 		})
 	}
 	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating arr instances for export: %v", err)
+		return nil, fmt.Errorf("iterate arr_instances: %w", err)
 	}
-	return instances
+	return instances, nil
 }
 
 // exportScanPaths exports scan paths from the database.
-func (s *RESTServer) exportScanPaths() []gin.H {
+func (s *RESTServer) exportScanPaths() ([]gin.H, error) {
 	rows, err := s.db.Query(`SELECT local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run,
 		detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours
 		FROM scan_paths`)
 	if err != nil {
-		logger.Debugf("Failed to query scan paths for export: %v", err)
-		return nil
+		return nil, fmt.Errorf("query scan_paths: %w", err)
 	}
 	defer rows.Close()
 
@@ -133,8 +135,7 @@ func (s *RESTServer) exportScanPaths() []gin.H {
 		var verificationTimeout sql.NullInt64
 		if err := rows.Scan(&localPath, &arrPath, &arrInstanceID, &enabled, &autoRemediate, &dryRun,
 			&detectionMethod, &detectionArgs, &detectionMode, &maxRetries, &verificationTimeout); err != nil {
-			logger.Errorf("Failed to scan path for export: %v", err)
-			continue
+			return nil, fmt.Errorf("scan scan_paths row: %w", err)
 		}
 		path := gin.H{
 			"local_path": localPath, "arr_path": arrPath, "enabled": enabled,
@@ -158,21 +159,20 @@ func (s *RESTServer) exportScanPaths() []gin.H {
 		paths = append(paths, path)
 	}
 	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating scan paths for export: %v", err)
+		return nil, fmt.Errorf("iterate scan_paths: %w", err)
 	}
-	return paths
+	return paths, nil
 }
 
 // exportSchedules exports scan schedules from the database.
-func (s *RESTServer) exportSchedules() []gin.H {
+func (s *RESTServer) exportSchedules() ([]gin.H, error) {
 	rows, err := s.db.Query(`
 		SELECT ss.cron_expression, ss.enabled, sp.local_path
 		FROM scan_schedules ss
 		JOIN scan_paths sp ON ss.scan_path_id = sp.id
 	`)
 	if err != nil {
-		logger.Debugf("Failed to query schedules for export: %v", err)
-		return nil
+		return nil, fmt.Errorf("query scan_schedules: %w", err)
 	}
 	defer rows.Close()
 
@@ -181,27 +181,29 @@ func (s *RESTServer) exportSchedules() []gin.H {
 		var cronExpr, localPath string
 		var enabled bool
 		if err := rows.Scan(&cronExpr, &enabled, &localPath); err != nil {
-			logger.Errorf("Failed to scan schedule for export: %v", err)
-			continue
+			return nil, fmt.Errorf("scan scan_schedule row: %w", err)
 		}
 		schedules = append(schedules, gin.H{
 			"local_path": localPath, "cron_expression": cronExpr, "enabled": enabled,
 		})
 	}
 	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating schedules for export: %v", err)
+		return nil, fmt.Errorf("iterate scan_schedules: %w", err)
 	}
-	return schedules
+	return schedules, nil
 }
 
-// exportNotifications exports notification configs.
-func (s *RESTServer) exportNotifications() []gin.H {
+// exportNotifications exports notification configs. A nil notifier is not
+// an error (legitimate "no notifications configured" state); a failure
+// loading existing configs is, since it would produce a backup the user
+// thinks is complete but secretly omits notifications.
+func (s *RESTServer) exportNotifications() ([]gin.H, error) {
 	if s.notifier == nil {
-		return nil
+		return nil, nil
 	}
 	configs, err := s.notifier.GetAllConfigs()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("get notification configs: %w", err)
 	}
 	var notifConfigs []gin.H
 	for _, cfg := range configs {
@@ -211,26 +213,56 @@ func (s *RESTServer) exportNotifications() []gin.H {
 			"enabled": cfg.Enabled, "throttle_seconds": cfg.ThrottleSeconds,
 		})
 	}
-	return notifConfigs
+	return notifConfigs, nil
 }
 
-// exportConfig exports all configuration as JSON
+// exportConfig exports all configuration as JSON. If any section fails to
+// load (DB error, decrypt failure, notifier failure), the entire export
+// is aborted with a 500 — returning a partial backup that the user thinks
+// is complete is far worse than failing cleanly.
 func (s *RESTServer) exportConfig(c *gin.Context) {
 	export := gin.H{
 		"exported_at": time.Now().Format(time.RFC3339),
 		"version":     config.Version,
 	}
 
-	if instances := s.exportArrInstances(); instances != nil {
+	instances, err := s.exportArrInstances()
+	if err != nil {
+		logger.Errorf("exportConfig: %v", err)
+		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
+		return
+	}
+	if instances != nil {
 		export["arr_instances"] = instances
 	}
-	if paths := s.exportScanPaths(); paths != nil {
+
+	paths, err := s.exportScanPaths()
+	if err != nil {
+		logger.Errorf("exportConfig: %v", err)
+		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
+		return
+	}
+	if paths != nil {
 		export["scan_paths"] = paths
 	}
-	if schedules := s.exportSchedules(); schedules != nil {
+
+	schedules, err := s.exportSchedules()
+	if err != nil {
+		logger.Errorf("exportConfig: %v", err)
+		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
+		return
+	}
+	if schedules != nil {
 		export["schedules"] = schedules
 	}
-	if notifications := s.exportNotifications(); notifications != nil {
+
+	notifications, err := s.exportNotifications()
+	if err != nil {
+		logger.Errorf("exportConfig: %v", err)
+		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
+		return
+	}
+	if notifications != nil {
 		export["notifications"] = notifications
 	}
 

--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -667,11 +667,16 @@ func TestDownloadDatabaseBackup_Success(t *testing.T) {
 // restartServer Tests
 // =============================================================================
 
+// Both ExportConfig DBError tests now assert the fixed fail-closed behavior:
+// when any export sub-query fails, the whole export returns 500. The previous
+// behavior was to return a silent partial backup that the user thought was
+// complete (audit finding E1).
+
 func TestExportConfig_DBError_ArrInstances(t *testing.T) {
 	db, cleanup := setupConfigTestDB(t)
 	defer cleanup()
 
-	// Drop arr_instances table to trigger error
+	// Drop arr_instances table to trigger query error
 	_, err := db.Exec("DROP TABLE arr_instances")
 	require.NoError(t, err)
 
@@ -684,25 +689,27 @@ func TestExportConfig_DBError_ArrInstances(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// Export should still succeed (with empty arr_instances) even if query fails
-	assert.Equal(t, http.StatusOK, w.Code)
+	// Export must fail loudly rather than returning a silently-incomplete backup.
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
-	assert.Contains(t, response, "exported_at")
+	assert.Contains(t, response, "error")
+	// Body must not leak the table-missing detail; just a generic message.
+	assert.Equal(t, "Failed to export configuration", response["error"])
 }
 
 func TestExportConfig_DBError_ScanPaths(t *testing.T) {
 	db, cleanup := setupConfigTestDB(t)
 	defer cleanup()
 
-	// Create an arr instance first
+	// Create an arr instance first so arr_instances export would succeed
 	encryptedKey, _ := crypto.Encrypt("test-key")
 	_, err := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
 		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
 	require.NoError(t, err)
 
-	// Drop scan_paths table to trigger error
+	// Drop scan_paths table to trigger error on the second sub-export
 	_, err = db.Exec("DROP TABLE scan_paths")
 	require.NoError(t, err)
 
@@ -715,13 +722,13 @@ func TestExportConfig_DBError_ScanPaths(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// Export should still succeed (with empty scan_paths) even if query fails
-	assert.Equal(t, http.StatusOK, w.Code)
+	// Same: any sub-query failure aborts the whole export.
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
-	// arr_instances should still be exported
-	assert.Contains(t, response, "arr_instances")
+	assert.Contains(t, response, "error")
+	assert.Equal(t, "Failed to export configuration", response["error"])
 }
 
 func TestExportConfig_WithSchedules(t *testing.T) {


### PR DESCRIPTION
Closes P0 finding E1 — the highest-impact silent-failure scenario in the audit.

## The vulnerability

\`exportConfig\` builds a JSON backup the user downloads. Internally it calls four helpers:

\`\`\`go
if instances := s.exportArrInstances(); instances != nil { export[\"arr_instances\"] = instances }
if paths := s.exportScanPaths(); paths != nil { export[\"scan_paths\"] = paths }
// ...
\`\`\`

Each helper had this pattern:

\`\`\`go
func (s *RESTServer) exportArrInstances() []gin.H {
    rows, err := s.db.Query(\"SELECT ... FROM arr_instances\")
    if err != nil {
        logger.Debugf(\"Failed to query arr instances for export: %v\", err)
        return nil  // ← silent
    }
    // ...
}
\`\`\`

On a DB failure (locked table, schema mismatch, partial migration), the helper returned \`nil\` and the export *succeeded* with a 200 OK but **silently omitted that entire section**. The user downloaded a backup they thought was complete. On restore — typically months later, after a hardware failure or a fresh install — entire configuration sections would silently disappear. The most user-impactful silent failure in the audit.

## The fix

### Helpers now return errors

\`\`\`go
func (s *RESTServer) exportArrInstances() ([]gin.H, error) {
    rows, err := s.db.Query(\"...\")
    if err != nil {
        return nil, fmt.Errorf(\"query arr_instances: %w\", err)
    }
    // ... scan errors and rows.Err() also propagate ...
}
\`\`\`

Same for \`exportScanPaths\`, \`exportSchedules\`, \`exportNotifications\`.

### Per-row decrypt failures keep the existing \`[DECRYPTION_ERROR]\` sentinel

Corrupting one row shouldn't lose the rest of the data — but the sentinel makes the affected row visible in the export so the user knows something is wrong. Audit-confirmed approach.

### \`exportConfig\` bails on any error

Each call site now checks the error; on any failure:

\`\`\`go
respondWithError(c, http.StatusInternalServerError, \"Failed to export configuration\", err)
return
\`\`\`

This logs the underlying error at \`Errorf\` for operator debugging but returns a generic body — consistent with the SSRF leak-prevention hardening from PR #178.

### \`exportNotifications\` preserves \"no notifier\" as non-error

Healarr can legitimately run with no notification configs. A nil \`s.notifier\` returns \`(nil, nil)\` — only a failed \`GetAllConfigs()\` is an error.

## Tests updated

Two existing tests previously documented the *buggy* behavior:

\`\`\`go
// OLD assertion (asserting the bug)
assert.Equal(t, http.StatusOK, w.Code)
// \"Export should still succeed (with empty arr_instances) even if query fails\"
\`\`\`

Both \`TestExportConfig_DBError_ArrInstances\` and \`TestExportConfig_DBError_ScanPaths\` now assert:

\`\`\`go
assert.Equal(t, http.StatusInternalServerError, w.Code)
assert.Equal(t, \"Failed to export configuration\", response[\"error\"])
\`\`\`

i.e. the fix-closed behavior, plus an explicit check that the underlying error text does NOT leak to the caller.

## Backward compatibility

- Successful exports: identical behavior, same JSON shape.
- Failed exports: previously returned 200 + partial body, now return 500 + generic error. Frontends that called \`/api/config/export\` and unconditionally treated 200 as success will see failures surface for the first time. Healarr's UI already handles non-2xx responses generically.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/api/...\` — all tests pass (including the two updated assertions)
- [ ] After merge: verify a real export with a populated DB still works; verify exports with intentionally corrupt schema fail with 500

## Context

Phase 1.4 (E1 portion). Phase 1 remaining: 1.1c webhook secret separation, 1.3 login session tokens, 1.4 harder items (E3, E4, E6, P0-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration export now implements fail-closed behavior: if any required data retrieval fails, the operation returns an HTTP error instead of a silently incomplete backup. This ensures exported configurations are always either complete or properly failed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->