### PR TITLE
fix: surface notifier events-JSON + monitor file_path lookup errors (Phase 1.4: E3 + P0-5)

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -423,8 +423,13 @@ func (n *Notifier) scanNotificationRow(scanner interface {
 	if err := json.Unmarshal([]byte(decrypted), &cfg.Config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config for notification %d: %w", cfg.ID, err)
 	}
-	if json.Unmarshal([]byte(eventsJSON), &cfg.Events) != nil {
-		cfg.Events = []string{}
+	// Previously this silently set cfg.Events to []string{} on unmarshal
+	// failure, which loaded the notification config with zero subscribed
+	// events — it would silently never fire. Returning an error lets the
+	// caller skip the config and log loudly so the operator can fix the
+	// corrupt row rather than wonder why notifications stopped working.
+	if err := json.Unmarshal([]byte(eventsJSON), &cfg.Events); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal events for notification %d: %w", cfg.ID, err)
 	}
 	return &cfg, nil
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -458,6 +458,40 @@ func TestNotifier_LoadConfigs_WithData(t *testing.T) {
 	}
 }
 
+// TestNotifier_LoadConfigs_CorruptEventsJSON_Skipped verifies that a row with
+// malformed events JSON is excluded from the loaded configs instead of being
+// loaded with cfg.Events = []string{} (which would silently disable that
+// notification for all events).
+func TestNotifier_LoadConfigs_CorruptEventsJSON_Skipped(t *testing.T) {
+	tdb := newTestDB(t)
+	defer tdb.Close()
+
+	// A good config (will be loaded) plus a bad-events-JSON one (must be skipped).
+	_, err := tdb.DB.Exec(`
+		INSERT INTO notifications (id, name, provider_type, config, events, enabled, throttle_seconds)
+		VALUES (1, 'Good', 'discord', '{"webhook_url":"https://test.com"}', '["ScanCompleted"]', 1, 60),
+		       (2, 'Corrupt', 'discord', '{"webhook_url":"https://test.com"}', 'not valid json', 1, 60)
+	`)
+	if err != nil {
+		t.Fatalf("Failed to insert test data: %v", err)
+	}
+
+	eb := eventbus.NewEventBus(tdb.DB)
+	defer eb.Shutdown()
+
+	n := NewNotifier(tdb.DB, eb)
+	if err := n.loadConfigs(); err != nil {
+		t.Fatalf("loadConfigs failed: %v", err)
+	}
+
+	if _, ok := n.configs[1]; !ok {
+		t.Error("good config (ID 1) should have been loaded")
+	}
+	if _, ok := n.configs[2]; ok {
+		t.Error("corrupt-events config (ID 2) must NOT be loaded as an empty-events config; it should be skipped so the operator sees the failure")
+	}
+}
+
 func TestNotifier_LoadConfigs_DisabledNotLoaded(t *testing.T) {
 	tdb := newTestDB(t)
 	defer tdb.Close()

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -338,11 +338,17 @@ func (m *MonitorService) getRetryCount(corruptionID string) (int, int, error) {
 func (m *MonitorService) handleNeedsAttention(event domain.Event) {
 	corruptionID := event.AggregateID
 
-	// Extract relevant info for logging
+	// Extract relevant info for logging. If we can't find a filePath the
+	// downstream Warnf logs "(file: )" which is exactly the case where the
+	// operator most needs the identifier — so capture the corruption-context
+	// error rather than discarding it.
 	filePath, _ := event.GetString("file_path")
 	if filePath == "" {
-		// Try to get from corruption context
-		filePath, _, _ = m.getCorruptionContext(corruptionID)
+		var ctxErr error
+		filePath, _, ctxErr = m.getCorruptionContext(corruptionID)
+		if ctxErr != nil {
+			logger.Errorf("handleNeedsAttention: cannot resolve file_path for %s: %v", corruptionID, ctxErr)
+		}
 	}
 
 	switch event.EventType {


### PR DESCRIPTION
Two small focused P0 silent-failure fixes from the audit, bundled because they're the same shape (\"captured error was discarded\") in different services.

## E3 — Notifier events-JSON unmarshal silently dropped

\`internal/notifier/notifier.go\` (\`scanNotificationRow\`):

\`\`\`go
// Before
if json.Unmarshal([]byte(eventsJSON), &cfg.Events) != nil {
    cfg.Events = []string{}
}
\`\`\`

If the \`events\` JSON column was malformed (DB corruption, migration glitch, manual SQL edit), \`cfg.Events\` was silently emptied and the config loaded into the active set. With zero subscribed events, the notification config would never fire for anything — the user thinks Discord is wired up, gets no alerts, never sees a clue why.

\`\`\`go
// After
if err := json.Unmarshal([]byte(eventsJSON), &cfg.Events); err != nil {
    return nil, fmt.Errorf(\"failed to unmarshal events for notification %d: %w\", cfg.ID, err)
}
\`\`\`

\`loadConfigs\` already handles \`scanNotificationRow\` errors by logging at \`Errorf\` and skipping the row. After the fix, a corrupt config is excluded from the active set instead of silently disabled — the operator sees the failure in logs and can fix the DB row.

## P0-5 — Monitor file_path lookup error discarded

\`internal/services/monitor.go\` (\`handleNeedsAttention\`):

\`\`\`go
// Before
filePath, _ := event.GetString(\"file_path\")
if filePath == \"\" {
    filePath, _, _ = m.getCorruptionContext(corruptionID)
}
// later: logger.Warnf(\"Manual intervention required for %s: ... (file: %s)\", corruptionID, errMsg, filePath)
\`\`\`

When \`getCorruptionContext\` failed (DB error, missing context row), the \`_, _, _\` swallowed the error and \`filePath\` stayed empty. The downstream Warnf then logged \`(file: )\` — exactly the case where the operator most needs the identifier to take manual action.

\`\`\`go
// After
filePath, _ := event.GetString(\"file_path\")
if filePath == \"\" {
    var ctxErr error
    filePath, _, ctxErr = m.getCorruptionContext(corruptionID)
    if ctxErr != nil {
        logger.Errorf(\"handleNeedsAttention: cannot resolve file_path for %s: %v\", corruptionID, ctxErr)
    }
}
\`\`\`

The lookup failure is now visible. The downstream Warnf still runs (with empty filePath if the lookup failed) so the operator gets the \`(file: )\` AND a preceding error explaining why.

## Tests

- **\`TestNotifier_LoadConfigs_CorruptEventsJSON_Skipped\`**: inserts one good notification config and one with garbage events JSON, calls \`loadConfigs\`, verifies the good one is in the active set and the corrupt one is **not** (was previously loaded as a silently-disabled config).

P0-5's fix is mechanical (capture and log an error variable that was being discarded) — verifying via log capture would require new test infrastructure for a one-line change, so the change ships without a dedicated test.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/notifier/... -run CorruptEvents\` — passes
- [x] \`go test ./...\` — all packages pass
- [ ] After merge: in a test env, corrupt a notification config's events JSON manually and verify Healarr logs the error and excludes the config from active set
- [ ] After merge: verify the \"file: \" log path in monitor produces the new error log when getCorruptionContext returns missing-row

## Context

Phase 1.4 (E3 + P0-5 portion). Phase 1 remaining: 1.1c webhook secret separation (M, DB migration), 1.3 login session tokens (M), 1.4 (E4 verifier history, E6 webhook scan failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading notification configurations with invalid data.
  * Enhanced logging visibility for file path resolution failures in event processing.

* **Tests**
  * Added regression test to ensure malformed notification configurations are properly skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->