### PR TITLE
fix(webhook): publish ScanFailed event when async scan fails (Phase 1.4: E6)

### DIFF
--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/mescon/Healarr/internal/crypto"
+	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/safego"
 )
@@ -119,10 +120,29 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 		return
 	}
 
-	// Trigger single file scan
+	// Trigger single file scan. On failure, publish a ScanFailed event so
+	// the UI can surface the issue — previously the HTTP 202 "Scan queued"
+	// response promised work that silently died, with the failure only
+	// visible in backend logs.
 	safego.Run("webhook-scan", func() {
 		if err := s.scanner.ScanFile(localPath); err != nil {
 			logger.Warnf("Webhook-triggered scan failed for %s: %v", localPath, err)
+			pubErr := s.eventBus.Publish(domain.Event{
+				AggregateType: "scan",
+				// No scan_id yet — ScanFile failed before one was assigned.
+				// Use the file path as the aggregate ID so duplicate failures
+				// collate in the timeline and clients can index by path.
+				AggregateID: "webhook:" + localPath,
+				EventType:   domain.ScanFailed,
+				EventData: map[string]interface{}{
+					"file_path": localPath,
+					"trigger":   "webhook",
+					"error":     err.Error(),
+				},
+			})
+			if pubErr != nil {
+				logger.Errorf("Failed to publish ScanFailed event for webhook scan: %v", pubErr)
+			}
 		}
 	})
 

--- a/internal/api/handlers_webhook_test.go
+++ b/internal/api/handlers_webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/mattn/go-sqlite3" // Register CGo SQLite driver for database/sql
@@ -18,6 +19,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
+	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/services"
 	"github.com/mescon/Healarr/internal/testutil"
@@ -70,10 +72,13 @@ func setupWebhookTestDB(t *testing.T) (*sql.DB, func()) {
 
 		CREATE TABLE events (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			aggregate_type TEXT NOT NULL,
+			aggregate_id TEXT NOT NULL,
 			event_type TEXT NOT NULL,
-			aggregate_id TEXT,
-			event_data TEXT NOT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+			event_data JSON NOT NULL,
+			event_version INTEGER NOT NULL DEFAULT 1,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			user_id TEXT
 		);
 
 		CREATE TABLE arr_instances (
@@ -553,4 +558,76 @@ func TestWebhook_DecryptError(t *testing.T) {
 
 	hub.Shutdown()
 	eb.Shutdown()
+}
+
+// TestWebhook_ScanFailure_PublishesScanFailedEvent verifies that when the
+// async scan triggered by a webhook fails, a ScanFailed event reaches the
+// event bus so the UI can surface the failure. Previously the HTTP 200
+// "Scan queued" response promised work that silently died (audit P0 E6).
+func TestWebhook_ScanFailure_PublishesScanFailedEvent(t *testing.T) {
+	db, cleanup := setupWebhookTestDB(t)
+	defer cleanup()
+
+	arrID := createTestArrInstance(t, db, true)
+
+	mockPM := &testutil.MockPathMapper{
+		ToLocalPathFunc: func(arrPath string) (string, error) {
+			return "/local" + arrPath, nil
+		},
+	}
+
+	// Scan signals when it has run (and failed) so the test can wait
+	// without sleeping.
+	scanDone := make(chan struct{}, 1)
+	mockScanner := &webhookMockScanner{
+		ScanFileFunc: func(_ string) error {
+			defer func() { scanDone <- struct{}{} }()
+			return assert.AnError
+		},
+	}
+
+	router, apiKey, serverCleanup := setupWebhookTestServer(t, db, mockPM, mockScanner)
+	defer serverCleanup()
+
+	body := bytes.NewBufferString(`{
+		"eventType": "Download",
+		"movieFile": {"path": "/movies/broken.mkv"}
+	}`)
+	req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// The webhook handler still returns 200 (the scan was queued; the
+	// failure is async). The fix is that we now ALSO publish an event.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Wait for the async scan to fire and the event to be persisted.
+	select {
+	case <-scanDone:
+	case <-time.After(time.Second):
+		t.Fatal("scan goroutine did not run within 1s")
+	}
+
+	// Give the eventbus's Publish (DB INSERT) a brief moment to complete.
+	// Events.Publish is synchronous to the DB, but the goroutine call is
+	// fire-and-forget from the webhook handler's perspective.
+	deadline := time.Now().Add(2 * time.Second)
+	var count int
+	var eventData string
+	for time.Now().Before(deadline) {
+		row := db.QueryRow(`SELECT COUNT(*), COALESCE(MAX(event_data), '') FROM events
+			WHERE event_type = ? AND aggregate_id = ?`,
+			string(domain.ScanFailed), "webhook:/local/movies/broken.mkv")
+		_ = row.Scan(&count, &eventData)
+		if count >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	require.GreaterOrEqual(t, count, 1, "ScanFailed event should have been published for the failing webhook scan")
+	assert.Contains(t, eventData, "/local/movies/broken.mkv")
+	assert.Contains(t, eventData, "webhook")
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -2196,19 +2196,19 @@ func TestNotifier_LoadConfigs_InvalidEventsJSON(t *testing.T) {
 
 	n := NewNotifier(tdb.DB, eb)
 
-	// loadConfigs should succeed even with invalid events JSON
-	err = n.loadConfigs()
-	if err != nil {
+	// loadConfigs should succeed (it skips bad rows rather than aborting the
+	// whole load); but the corrupt config must NOT be in the active set.
+	// Previously it loaded with cfg.Events = []string{} which silently
+	// disabled the notification — fixed in Phase 1.4 (E3).
+	if err := n.loadConfigs(); err != nil {
 		t.Fatalf("loadConfigs failed unexpectedly: %v", err)
 	}
 
-	// The config should be loaded with empty events (invalid events JSON falls back to [])
-	if len(n.configs) != 1 {
-		t.Fatalf("Expected 1 config (with empty events fallback), got %d", len(n.configs))
+	if _, ok := n.configs[1]; ok {
+		t.Error("config with corrupt events JSON must be excluded from active set, not loaded with empty events")
 	}
-	cfg := n.configs[1]
-	if len(cfg.Events) != 0 {
-		t.Errorf("Expected empty events for invalid JSON, got %v", cfg.Events)
+	if len(n.configs) != 0 {
+		t.Errorf("Expected 0 active configs, got %d", len(n.configs))
 	}
 }
 
@@ -2230,19 +2230,17 @@ func TestNotifier_GetAllConfigs_InvalidEventsJSON(t *testing.T) {
 
 	n := NewNotifier(tdb.DB, eb)
 
-	// GetAllConfigs should handle invalid JSON gracefully by using empty events
+	// GetAllConfigs skips corrupt rows (Errorf + continue) rather than
+	// returning them with cfg.Events = []string{}. Previously the API would
+	// have returned the bad row to the UI as "configured but no events" —
+	// fixed in Phase 1.4 (E3).
 	configs, err := n.GetAllConfigs()
 	if err != nil {
-		t.Fatalf("GetAllConfigs() error = %v", err)
+		t.Fatalf("GetAllConfigs() unexpected error = %v", err)
 	}
 
-	if len(configs) != 1 {
-		t.Fatalf("Expected 1 config, got %d", len(configs))
-	}
-
-	// Events should be empty array for invalid JSON
-	if len(configs[0].Events) != 0 {
-		t.Errorf("Expected 0 events for invalid JSON, got %d", len(configs[0].Events))
+	if len(configs) != 0 {
+		t.Errorf("Expected corrupt config to be excluded; got %d configs", len(configs))
 	}
 }
 
@@ -2264,15 +2262,15 @@ func TestNotifier_GetConfig_InvalidEventsJSON(t *testing.T) {
 
 	n := NewNotifier(tdb.DB, eb)
 
-	// GetConfig should handle invalid JSON gracefully
+	// GetConfig propagates scan errors directly to the caller (single-row
+	// lookup; nothing to skip). Previously it would have returned a config
+	// with Events=[] — fixed in Phase 1.4 (E3).
 	cfg, err := n.GetConfig(1)
-	if err != nil {
-		t.Fatalf("GetConfig() error = %v", err)
+	if err == nil {
+		t.Fatalf("GetConfig() should return error for corrupt events JSON; got cfg=%+v", cfg)
 	}
-
-	// Events should be empty array for invalid JSON
-	if len(cfg.Events) != 0 {
-		t.Errorf("Expected 0 events for invalid JSON, got %d", len(cfg.Events))
+	if cfg != nil {
+		t.Errorf("GetConfig() should return nil cfg on error; got %+v", cfg)
 	}
 }
 


### PR DESCRIPTION
Closes P0 finding E6 — the webhook returned \`200 \"Scan queued\"\` immediately and triggered the scan in a goroutine; if the scan failed, the failure only existed in backend logs.

## The problem

\`\`\`go
safego.Run(\"webhook-scan\", func() {
    if err := s.scanner.ScanFile(localPath); err != nil {
        logger.Warnf(\"Webhook-triggered scan failed for %s: %v\", localPath, err)
    }
})
\`\`\`

Failure modes that hit this path silently:
- Mount loss between webhook and scan (file no longer accessible)
- ffprobe binary missing or unexecutable
- DB locked / migration in progress
- Path mapping returns nonsensical local path

The user sees the webhook hit (200 OK), the *arr instance thinks Healarr is happy, but no scan record gets created and no notification fires. The failure is invisible to everything except backend log inspection.

## The fix

Publish a \`ScanFailed\` event on error in the same goroutine:

\`\`\`go
safego.Run(\"webhook-scan\", func() {
    if err := s.scanner.ScanFile(localPath); err != nil {
        logger.Warnf(\"...\", localPath, err)
        pubErr := s.eventBus.Publish(domain.Event{
            AggregateType: \"scan\",
            AggregateID:   \"webhook:\" + localPath,
            EventType:     domain.ScanFailed,
            EventData: map[string]interface{}{
                \"file_path\": localPath,
                \"trigger\":   \"webhook\",
                \"error\":     err.Error(),
            },
        })
        if pubErr != nil {
            logger.Errorf(\"Failed to publish ScanFailed event for webhook scan: %v\", pubErr)
        }
    }
})
\`\`\`

### Why this routing works

- \`internal/api/websocket.go:98\` already subscribes the WS hub to \`ScanFailed\` → UI surfaces the failure in real time
- \`internal/notifier/notifier.go:744\` already has a formatter (\`fmtScanFailed\`) → notification configs subscribing to \`ScanFailed\` fire Discord/Slack/etc.
- \`internal/metrics/metrics.go:240\` already counts \`ScanFailed\` → operator dashboards reflect it

The plumbing existed; only the *publisher* was missing.

### Aggregate ID design

The scan never reached the point where a scan_id was generated, so the AggregateID needs a fallback. \`\"webhook:\" + localPath\` keeps:
- Repeated failures on the same file collated in the timeline
- Clear provenance (\"webhook:\" prefix distinguishes from regular scan failures)

This is also the first actual publisher of \`ScanFailed\` — the event type was declared in \`domain/events.go\` but had no producers. The webhook scan is the natural first one because it's the only fire-and-forget scan path.

## Tests

\`TestWebhook_ScanFailure_PublishesScanFailedEvent\`:
- Mock scanner returns an error from \`ScanFile\`
- Webhook handler returns 200 (unchanged)
- Test waits on a channel for the goroutine to run
- Polls the events table until a \`ScanFailed\` row with the expected aggregate_id appears
- Asserts the event_data contains the file path and trigger

**Schema fix in setupWebhookTestDB**: the previous test schema was missing \`aggregate_type\` and \`event_version\` columns on the events table. Updated to match production. This wouldn't affect tests that didn't publish events (i.e., everything before this PR), but tests that DO publish events were guaranteed to fail until corrected.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/api/...\` — all tests pass (including new regression test)
- [ ] After merge: configure a Discord notification subscribing to ScanFailed; trigger a webhook with an unmappable path or kill ffprobe; verify the failure surfaces in UI + Discord

## Context

Phase 1.4 (E6 portion). Phase 1 remaining after this: 1.1c webhook secret separation (M, DB migration), 1.3 login session tokens (M), 1.4 E4 verifier history retry (the last 1.4 silent-failure item).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for webhook-triggered file scans; failed scans are now recorded so failures are tracked reliably.

* **Tests**
  * Added test coverage to verify webhook scan failure reporting.
  * Updated notifier tests to ensure invalid/ corrupt event configurations are excluded and surface errors appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->