### PR TITLE
fix(verifier): surface history-API failures + publish InstanceUnhealthy (Phase 1.4: E4 — last)

### DIFF
--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -932,11 +932,35 @@ func (v *VerifierService) hasImportEventInHistory(arrPath string, mediaID int64)
 	return findImportEvent(historyItems) != nil, nil
 }
 
-// checkHistoryForImport checks *arr history for import completion
+// checkHistoryForImport checks *arr history for import completion.
+//
+// Important: an API error here previously logged at Debugf and returned false,
+// which downstream is indistinguishable from a real "no import found" signal.
+// A persistently failing *arr API would silently drive the verifier toward
+// false ManuallyRemoved / DownloadTimeout states with no visible cause. Now
+// the API failure is logged at Warnf with explicit "cannot confirm import
+// status" wording, mirroring the symmetric fix already in place at the
+// GetAllFilePaths retry call below.
 func (v *VerifierService) checkHistoryForImport(corruptionID, arrPath string, mediaID int64, referencePath string, metadata map[string]interface{}) bool {
 	historyItems, err := v.getHistoryWithRetry(arrPath, mediaID, 20, 3)
 	if err != nil {
-		logger.Debugf("History check error for %s after retries: %v", corruptionID, err)
+		logger.Warnf("History check failed for %s after retries: %v - cannot confirm import status", corruptionID, err)
+		// Publish InstanceUnhealthy so the UI / notification stack can surface
+		// the degraded *arr API state — the verifier loop will continue, but
+		// at least the operator now has a signal.
+		if pubErr := v.eventBus.Publish(domain.Event{
+			AggregateType: "instance",
+			AggregateID:   fmt.Sprintf("history-check:%s", corruptionID),
+			EventType:     domain.InstanceUnhealthy,
+			EventData: map[string]interface{}{
+				"corruption_id": corruptionID,
+				"operation":     "checkHistoryForImport",
+				"error":         err.Error(),
+				"reason":        "history API failed after retries; cannot confirm import status",
+			},
+		}); pubErr != nil {
+			logger.Debugf("Failed to publish InstanceUnhealthy event for verifier: %v", pubErr)
+		}
 		return false
 	}
 

--- a/internal/services/verifier_test.go
+++ b/internal/services/verifier_test.go
@@ -778,7 +778,7 @@ func TestVerifierService_CheckHistoryForImport(t *testing.T) {
 		}
 	})
 
-	t.Run("history API error returns false", func(t *testing.T) {
+	t.Run("history API error returns false and publishes InstanceUnhealthy", func(t *testing.T) {
 		eb := eventbus.NewEventBus(db)
 		defer eb.Shutdown()
 
@@ -790,9 +790,21 @@ func TestVerifierService_CheckHistoryForImport(t *testing.T) {
 
 		verifier := NewVerifierService(eb, nil, nil, mockArr, db)
 
-		result := verifier.checkHistoryForImport("test-2", "/movies", 123, "/test.mkv", nil)
+		result := verifier.checkHistoryForImport("test-instance-unhealthy", "/movies", 123, "/test.mkv", nil)
 		if result {
 			t.Error("Expected false for history API error")
+		}
+
+		// Verify InstanceUnhealthy event was published — previously the API
+		// failure was silently swallowed (audit P0 E4).
+		var count int
+		err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_type = ? AND aggregate_id = ?`,
+			string(domain.InstanceUnhealthy), "history-check:test-instance-unhealthy").Scan(&count)
+		if err != nil {
+			t.Fatalf("query events: %v", err)
+		}
+		if count == 0 {
+			t.Error("expected an InstanceUnhealthy event to be published when history API fails after retries")
 		}
 	})
 


### PR DESCRIPTION
Closes P0 finding E4 — the last remaining contract-level fix in the Phase 1.4 silent-failure sweep.

## The problem

\`checkHistoryForImport\` (\`internal/services/verifier.go:935\`) on history API failure:

\`\`\`go
historyItems, err := v.getHistoryWithRetry(arrPath, mediaID, 20, 3)
if err != nil {
    logger.Debugf(\"History check error for %s after retries: %v\", corruptionID, err)
    return false  // ← indistinguishable from \"no import found\"
}
\`\`\`

A persistently failing *arr API drove the verifier into:

1. \`checkHistoryForImport\` returns false → no import detected
2. Verifier eventually times out → \`DownloadTimeout\` published
3. Or worse: state machine concludes \"file imported but doesn't exist\" → false \`ManuallyRemoved\` event
4. User sees corrupted-files-getting-deleted alerts with no idea the actual cause is *arr being offline

Three lines below in the same function, the symmetric \`GetAllFilePaths\` retry already had the correct pattern from a prior fix:

\`\`\`go
allPaths, err := v.getFilePathsWithRetry(mediaID, metadata, referencePath, 3)
if err != nil {
    logger.Warnf(\"GetAllFilePaths failed for %s after retries: %v - cannot confirm import status\", corruptionID, err)
    return false
}
\`\`\`

The history check just needed the same treatment, plus an event.

## The fix

1. **Log at Warnf with explicit \"cannot confirm import status\" wording** (mirrors the symmetric fix three lines below).
2. **Publish an \`InstanceUnhealthy\` event** so the UI + notification stack can surface the degraded *arr API immediately, rather than waiting for the false-positive downstream effects to confuse users:

\`\`\`go
v.eventBus.Publish(domain.Event{
    AggregateType: \"instance\",
    AggregateID:   fmt.Sprintf(\"history-check:%s\", corruptionID),
    EventType:     domain.InstanceUnhealthy,
    EventData: map[string]interface{}{
        \"corruption_id\": corruptionID,
        \"operation\":     \"checkHistoryForImport\",
        \"error\":         err.Error(),
        \"reason\":        \"history API failed after retries; cannot confirm import status\",
    },
})
\`\`\`

\`InstanceUnhealthy\` was declared in \`domain/events.go\` but had no producers until now — same situation as \`ScanFailed\` before PR #186.

The function still returns \`false\` so callers don't break. The change is purely visibility.

## Tests

Existing subtest \`\"history API error returns false\"\` renamed to \`\"history API error returns false and publishes InstanceUnhealthy\"\` and extended:

- Still asserts the function returns false (unchanged behavior)
- Now also queries the events table for an \`InstanceUnhealthy\` row with the expected aggregate_id and asserts it's present

Other subtests (\`no_import_events\`, \`import_event_found_but_no_arr_client\`, \`with_existing_files\`) unchanged and continue to pass.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./internal/services/... -run TestVerifierService_CheckHistoryForImport\` — all subtests pass; new \`InstanceUnhealthy\` assertion verified
- [ ] After merge: simulate *arr API outage during a verification cycle; verify the UI surfaces the InstanceUnhealthy event rather than producing eventual false ManuallyRemoved alerts

## Context

Phase 1.4 (E4 portion) — the last contract-level fix in 1.4. The remaining items in the audit's 1.4 list were either pure log-level upgrades (shipped in #183) or had follow-up structural recommendations (E1 #184, E3 #185, E6 #186). Phase 1.4 is **complete** after this PR.

Phase 1 remaining: **1.1c** webhook secret separation (M, requires DB migration), **1.3** login session tokens (M).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for import history verification—the system now explicitly logs and reports when it cannot confirm import status due to API failures, rather than silently proceeding. This enhances system transparency and health monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->