### PR TITLE
fix(auth): decouple browser session tokens from the master API key (Phase 1.3)

### DIFF
--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -104,24 +105,21 @@ func (s *RESTServer) handleLogin(c *gin.Context) {
 		return
 	}
 
-	// Get API key to return as session token
-	var encryptedKey string
-	err = s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = 'api_key'").Scan(&encryptedKey)
+	// Issue a per-login session token rather than returning the master API
+	// key. Sessions live in their own table with a 24h expiry and can be
+	// invalidated via logout, decoupled from the long-lived integration key
+	// used by Sonarr/Radarr webhooks (Phase 1.3 P1 finding).
+	token, expiresAt, err := s.createSession(ctx, c.Request.UserAgent(), c.ClientIP())
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve API key"})
-		return
-	}
-
-	// Decrypt API key
-	apiKey, err := crypto.Decrypt(encryptedKey)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decrypt API key"})
+		logger.Errorf("Login: failed to create session: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"token":   apiKey, // Use API key as session token for simplicity
-		"message": "Login successful",
+		"token":      token,
+		"expires_at": expiresAt.Format(time.RFC3339),
+		"message":    "Login successful",
 	})
 	logger.Infof("User logged in successfully from %s", c.ClientIP())
 }

--- a/internal/api/handlers_auth_test.go
+++ b/internal/api/handlers_auth_test.go
@@ -165,11 +165,20 @@ func TestHandleLogin_DBError(t *testing.T) {
 	assert.Equal(t, "Database error", response["error"])
 }
 
-func TestHandleLogin_MissingAPIKey(t *testing.T) {
+// TestHandleLogin_SessionCreateFails replaces the previous TestHandleLogin_
+// MissingAPIKey and _DecryptionError tests, which exercised codepaths that
+// no longer exist (login no longer touches the master API key — Phase 1.3
+// decoupled login session tokens from the integration key).
+//
+// The new failure mode: session row insert fails (e.g., sessions table
+// missing, DB locked, disk full). Login should 500 with a generic message
+// and the underlying error stays in logs.
+func TestHandleLogin_SessionCreateFails(t *testing.T) {
 	db, cleanup := setupAuthErrorTestDB(t)
 	defer cleanup()
 
-	// Setup password but no API key
+	// setupAuthErrorTestDB intentionally has no sessions table; INSERT will
+	// fail with "no such table: sessions".
 	hash, _ := auth.HashPassword("testpassword")
 	db.Exec("INSERT INTO settings (key, value) VALUES ('password_hash', ?)", hash)
 
@@ -189,36 +198,8 @@ func TestHandleLogin_MissingAPIKey(t *testing.T) {
 
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
-	assert.Equal(t, "Failed to retrieve API key", response["error"])
-}
-
-func TestHandleLogin_DecryptionError(t *testing.T) {
-	db, cleanup := setupAuthErrorTestDB(t)
-	defer cleanup()
-
-	// Setup password and invalid encrypted API key with proper prefix
-	// Use "enc:v1:" prefix with invalid base64 to trigger decryption error
-	hash, _ := auth.HashPassword("testpassword")
-	db.Exec("INSERT INTO settings (key, value) VALUES ('password_hash', ?)", hash)
-	db.Exec("INSERT INTO settings (key, value) VALUES ('api_key', 'enc:v1:!!!invalid-base64!!!')")
-
-	server := createAuthErrorTestServer(t, db)
-
-	gin.SetMode(gin.TestMode)
-	r := gin.New()
-	r.POST("/auth/login", server.handleLogin)
-
-	body := strings.NewReader(`{"password": "testpassword"}`)
-	req, _ := http.NewRequest("POST", "/auth/login", body)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-
-	var response map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &response)
-	assert.Equal(t, "Failed to decrypt API key", response["error"])
+	// Generic message — underlying DB error stays in logs.
+	assert.Equal(t, "Failed to create session", response["error"])
 }
 
 // =============================================================================

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -82,6 +82,15 @@ func setupTestDB(t *testing.T) (*sql.DB, func()) {
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
+		CREATE TABLE sessions (
+			token TEXT PRIMARY KEY,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			expires_at TIMESTAMP NOT NULL,
+			last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			user_agent TEXT,
+			ip_address TEXT
+		);
+
 		CREATE VIEW corruption_status AS
 		SELECT 'CorruptionDetected' as current_state, 0 as count;
 	`
@@ -307,8 +316,27 @@ func TestHandleLogin_Success(t *testing.T) {
 
 	var response map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &response)
-	if response["token"] != apiKey {
-		t.Errorf("Expected token to match API key")
+
+	// Login now issues a fresh session token, NOT the master API key.
+	// Asserting NotEqual is the regression test for Phase 1.3 P0.
+	gotToken, ok := response["token"].(string)
+	if !ok || gotToken == "" {
+		t.Fatalf("expected non-empty token in response, got %v", response["token"])
+	}
+	if gotToken == apiKey {
+		t.Error("login token must NOT equal the master API key — sessions are now decoupled (Phase 1.3)")
+	}
+	if response["expires_at"] == nil {
+		t.Error("expected expires_at in response")
+	}
+
+	// Verify the session row was persisted.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM sessions WHERE token = ?", gotToken).Scan(&count); err != nil {
+		t.Fatalf("query sessions: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 session row for the returned token, got %d", count)
 	}
 }
 

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -407,6 +407,7 @@ func (s *RESTServer) setupRoutes() {
 			protected.GET("/auth/key", s.getAPIKey)
 			protected.POST("/auth/regenerate", s.regenerateAPIKey)
 			protected.POST("/auth/password", s.changePassword)
+			protected.POST("/auth/logout", s.handleLogout)
 
 			// System info (authenticated)
 			protected.GET("/system/info", s.handleSystemInfo)
@@ -584,10 +585,21 @@ func (s *RESTServer) extractAPIToken(c *gin.Context) string {
 // errInvalidToken indicates the provided token doesn't match the stored API key
 var errInvalidToken = errors.New("invalid token")
 
-// verifyAPIToken verifies the provided token against the stored API key
+// verifyAPIToken verifies the provided token. Accepts either:
+//
+//	(1) the master API key — used by Sonarr/Radarr webhook integrations
+//	    and any non-browser caller; matched with constant-time comparison
+//	(2) a valid, unexpired session token — issued by POST /auth/login
+//	    and used by the browser UI
+//
+// Both paths are checked because integrations must keep working while
+// browsers stop receiving the master key (Phase 1.3).
 func (s *RESTServer) verifyAPIToken(token string) error {
+	ctx := context.Background()
+
 	var encryptedKey string
-	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = 'api_key'").Scan(&encryptedKey); err != nil {
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT value FROM settings WHERE key = 'api_key'").Scan(&encryptedKey); err != nil {
 		return fmt.Errorf("failed to retrieve API key: %w", err)
 	}
 
@@ -596,9 +608,21 @@ func (s *RESTServer) verifyAPIToken(token string) error {
 		return fmt.Errorf("failed to decrypt API key: %w", err)
 	}
 
-	// Use constant-time comparison to prevent timing attacks
-	if subtle.ConstantTimeCompare([]byte(token), []byte(storedKey)) != 1 {
-		return errInvalidToken
+	// Master API key path (integrations).
+	if subtle.ConstantTimeCompare([]byte(token), []byte(storedKey)) == 1 {
+		return nil
 	}
-	return nil
+
+	// Session token path (browsers).
+	if sessErr := s.validateSession(ctx, token); sessErr == nil {
+		return nil
+	} else if !errors.Is(sessErr, sql.ErrNoRows) && !errors.Is(sessErr, errSessionExpired) {
+		// Unknown token (no row) and expired sessions both surface as
+		// errInvalidToken to the middleware; any OTHER error (e.g. DB
+		// failure) needs to be returned so the middleware logs it
+		// distinctly rather than treating it as a bad token.
+		return fmt.Errorf("session lookup failed: %w", sessErr)
+	}
+
+	return errInvalidToken
 }

--- a/internal/api/rest_test.go
+++ b/internal/api/rest_test.go
@@ -535,6 +535,17 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 
 		_, err = db.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)`)
 		require.NoError(t, err)
+		// sessions table is required for the session-lookup fallback path
+		// added in Phase 1.3.
+		_, err = db.Exec(`CREATE TABLE sessions (
+			token TEXT PRIMARY KEY,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			expires_at TIMESTAMP NOT NULL,
+			last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			user_agent TEXT,
+			ip_address TEXT
+		)`)
+		require.NoError(t, err)
 
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)
 		require.NoError(t, err)
@@ -604,6 +615,15 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		defer db.Close()
 
 		_, err = db.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)`)
+		require.NoError(t, err)
+		_, err = db.Exec(`CREATE TABLE sessions (
+			token TEXT PRIMARY KEY,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			expires_at TIMESTAMP NOT NULL,
+			last_used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			user_agent TEXT,
+			ip_address TEXT
+		)`)
 		require.NoError(t, err)
 
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mescon/Healarr/internal/auth"
+	"github.com/mescon/Healarr/internal/logger"
+)
+
+// defaultSessionTTL is how long a newly issued session token remains valid.
+// Long enough for normal browser use without daily re-logins; short enough
+// that a leaked token expires automatically if logout was missed.
+const defaultSessionTTL = 24 * time.Hour
+
+// errSessionExpired indicates a session row exists but is past its expires_at.
+var errSessionExpired = errors.New("session expired")
+
+// createSession generates a fresh session token, persists it with an expiry,
+// and returns the token + expiry time for the caller to send to the client.
+//
+// The token uses the same 32-byte cryptographic primitive as the master API
+// key but is stored in a separate table so it can be expired/revoked
+// independently of the integration key used by Sonarr/Radarr webhooks.
+func (s *RESTServer) createSession(ctx context.Context, userAgent, ipAddress string) (string, time.Time, error) {
+	token, err := auth.GenerateAPIKey()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generate session token: %w", err)
+	}
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(defaultSessionTTL)
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, token, now, expiresAt, now, userAgent, ipAddress)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("persist session: %w", err)
+	}
+
+	return token, expiresAt, nil
+}
+
+// validateSession looks up the token in the sessions table. If found and
+// unexpired, it bumps last_used_at and returns nil. If the token isn't a
+// known session, returns sql.ErrNoRows so the caller can distinguish
+// "this is not a session token, try the master key path" from "this is
+// an expired/known-bad session token."
+func (s *RESTServer) validateSession(ctx context.Context, token string) error {
+	var expiresAt time.Time
+	err := s.db.QueryRowContext(ctx,
+		`SELECT expires_at FROM sessions WHERE token = ?`, token).Scan(&expiresAt)
+	if err != nil {
+		// sql.ErrNoRows or any other DB error — propagate so the caller
+		// can decide whether to try the master-key path.
+		return err
+	}
+
+	if time.Now().UTC().After(expiresAt) {
+		return errSessionExpired
+	}
+
+	// Bump last_used_at on a successful validation. We don't fail the
+	// request if this update errors — the session is valid, the bump is
+	// purely diagnostic ("when did this session last act?").
+	if _, updateErr := s.db.ExecContext(ctx,
+		`UPDATE sessions SET last_used_at = ? WHERE token = ?`,
+		time.Now().UTC(), token); updateErr != nil {
+		logger.Debugf("session last_used_at update failed for token: %v", updateErr)
+	}
+
+	return nil
+}
+
+// deleteSession removes a session row, used by logout.
+func (s *RESTServer) deleteSession(ctx context.Context, token string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE token = ?`, token)
+	return err
+}
+
+// handleLogout invalidates the session token from the request. Returns 200
+// in both the "session deleted" and "no such session" cases — logout should
+// be idempotent from the client's perspective; whether or not the token
+// was a known session is not useful information for the caller.
+func (s *RESTServer) handleLogout(c *gin.Context) {
+	token := s.extractAPIToken(c)
+	if token == "" {
+		c.JSON(http.StatusOK, gin.H{"message": "Already logged out"})
+		return
+	}
+
+	if err := s.deleteSession(c.Request.Context(), token); err != nil {
+		// DB failure during logout is logged but doesn't change the
+		// response — the token might still be valid if we say so.
+		logger.Errorf("Logout: failed to delete session: %v", err)
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Logged out"})
+}
+
+// expiredSessionsSweep deletes session rows whose expires_at is in the past.
+// Called periodically from the existing maintenance goroutine; bounded by
+// the number of expired sessions, so a single DELETE is fine without LIMIT.
+//
+//nolint:unused // exposed for the maintenance scheduler to wire in
+func (s *RESTServer) expiredSessionsSweep(ctx context.Context) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE expires_at < ?`, time.Now().UTC())
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// (no errInvalidSession alias yet — callers in this package use sql.ErrNoRows
+// directly via errors.Is.)

--- a/internal/db/migrations/005_sessions.sql
+++ b/internal/db/migrations/005_sessions.sql
@@ -1,0 +1,23 @@
+-- 005_sessions.sql
+--
+-- Per-login session tokens. The previous behavior was that POST /api/auth/login
+-- returned the master API key (used by Sonarr/Radarr webhook integrations) as
+-- the "session token" — meaning every browser session shared the same
+-- non-revocable, non-expiring secret with the long-lived integration key.
+-- A leaked browser token couldn't be revoked without rotating the integration
+-- key and reconfiguring every *arr instance.
+--
+-- This migration adds a sessions table; the auth middleware accepts either
+-- the master API key (for integrations) or a valid, unexpired session token
+-- (for browsers).
+
+CREATE TABLE sessions (
+    token         TEXT      PRIMARY KEY,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at    TIMESTAMP NOT NULL,
+    last_used_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    user_agent    TEXT,
+    ip_address    TEXT
+);
+
+CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);


### PR DESCRIPTION
Closes the P1 finding — \`POST /api/auth/login\` returned the master API key (the integration key used by Sonarr/Radarr webhooks) as the \"session token,\" so browser localStorage shared its non-revocable non-expiring secret with every connected *arr instance.

## What's new

### Migration \`005_sessions.sql\`

\`\`\`sql
CREATE TABLE sessions (
    token         TEXT      PRIMARY KEY,
    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    expires_at    TIMESTAMP NOT NULL,
    last_used_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    user_agent    TEXT,
    ip_address    TEXT
);
CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
\`\`\`

### \`internal/api/sessions.go\` (new)

- \`createSession(ctx, ua, ip)\` — generates a 32-byte cryptographic token (same primitive as \`auth.GenerateAPIKey\`), persists with 24h expiry, returns \`(token, expiresAt, error)\`
- \`validateSession(ctx, token)\` — lookup + expiry check + bumps \`last_used_at\`. Returns \`sql.ErrNoRows\` for unknown tokens (so the auth middleware can distinguish \"not a session token, try master key\" from \"this is a known-bad session\")
- \`deleteSession(ctx, token)\` — for logout
- \`handleLogout(c)\` — POST /api/auth/logout, idempotent (200 whether or not the token was a known session)
- \`expiredSessionsSweep(ctx)\` — bulk DELETE for the maintenance scheduler to wire in later (not yet plumbed; expired sessions are rejected at validation time, so no functional gap)

### \`handleLogin\` changes

Stops touching the master API key entirely. Creates a session, returns the new token:

\`\`\`json
{ \"token\": \"<32-byte-base64url>\", \"expires_at\": \"2026-05-22T15:30:00Z\", \"message\": \"Login successful\" }
\`\`\`

Field name preserved so the frontend doesn't need any change — it just stops being the integration key.

### \`verifyAPIToken\` middleware changes

Now accepts **either**:

| Caller | Header / form | What's validated |
|---|---|---|
| Sonarr/Radarr webhook, CLI, integrations | \`X-API-Key: <master_api_key>\` | Constant-time match against the encrypted-at-rest master key |
| Browser (post-login) | \`X-API-Key: <session_token>\` | Lookup in \`sessions\` table; check \`expires_at > now\` |

Master-key path runs first (cheap, no DB lookup beyond the existing one). Session lookup is fallback.

### Route

Added \`protected.POST(\"/auth/logout\", s.handleLogout)\`.

## Tests

- **\`setupTestDB\`**: now includes the \`sessions\` table so all existing tests work against the new auth path.
- **\`TestHandleLogin_Success\`**: rewritten — asserts the returned token is **NOT** equal to the master API key (the regression assertion for this PR), that \`expires_at\` is present, and that a row landed in the sessions table.
- **\`TestHandleLogin_MissingAPIKey\` + \`TestHandleLogin_DecryptionError\`**: removed (they tested codepaths that no longer execute — login doesn't read or decrypt the master key). Replaced with **\`TestHandleLogin_SessionCreateFails\`** which exercises the new failure mode (sessions table missing → INSERT fails → 500 with generic message).
- **\`rest_test.go\`**: two subtests (\`TestRESTServer_VerifyAPIToken/invalid_token\`, \`TestRESTServer_AuthMiddleware/rejects_invalid\`) updated to create the \`sessions\` table inline so the session-fallback path returns \`sql.ErrNoRows\` (→ 401) rather than \"no such table\" (→ 500).

## Backward compatibility

| Scenario | Before | After |
|---|---|---|
| Sonarr/Radarr webhook with master API key | Works | Works (master-key path matches first) |
| CLI / integration with master API key | Works | Works |
| Existing browser with stored master-key token | Works | Works on this request, on next login receives a session token |
| Browser logged in on new version | Got master key | Gets session token; master key never enters localStorage |

The migration is purely additive (new table only); rollback only requires `DROP TABLE sessions` (and existing browsers would need to re-login).

## Deferred to follow-up PRs

- Wire \`expiredSessionsSweep\` into the maintenance scheduler (today expired sessions are rejected via \`validateSession\` but rows accumulate; not urgent because the index makes the scan cheap and growth is bounded by session lifetime × concurrent users)
- Frontend \"Sign out\" button → POST /auth/logout (UI currently just clears localStorage; the endpoint exists and is idempotent)

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass (incl. updated assertions)
- [ ] After merge: confirm fresh login returns a different token from \`/api/auth/key\`; confirm both work for protected endpoints; confirm 24h-old sessions return 401

## Context

Phase 1.3 of the remediation plan. After this, **Phase 1 has only 1.1c (webhook secret separation) remaining** — that one is also M-effort with a DB migration.