### PR TITLE
fix(webhook): per-instance webhook secret separate from master API key (Phase 1.1c — Phase 1 complete)

### DIFF
--- a/internal/api/handlers_arr.go
+++ b/internal/api/handlers_arr.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/network"
@@ -61,7 +63,7 @@ func validateArrURL(rawURL string) error {
 }
 
 func (s *RESTServer) getArrInstances(c *gin.Context) {
-	rows, err := s.db.Query("SELECT id, name, type, url, api_key, enabled FROM arr_instances")
+	rows, err := s.db.Query("SELECT id, name, type, url, api_key, enabled, webhook_secret FROM arr_instances")
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
@@ -73,7 +75,8 @@ func (s *RESTServer) getArrInstances(c *gin.Context) {
 		var id int
 		var name, arrType, url, apiKey string
 		var enabled bool
-		if err := rows.Scan(&id, &name, &arrType, &url, &apiKey, &enabled); err != nil {
+		var webhookSecret sql.NullString
+		if err := rows.Scan(&id, &name, &arrType, &url, &apiKey, &enabled, &webhookSecret); err != nil {
 			logger.Warnf("Failed to scan arr_instances row: %v", err)
 			continue
 		}
@@ -83,14 +86,28 @@ func (s *RESTServer) getArrInstances(c *gin.Context) {
 			logger.Errorf("Failed to decrypt API key for instance %d: %v", id, err)
 			decryptedKey = "[DECRYPTION_ERROR]"
 		}
-		instances = append(instances, map[string]interface{}{
+		entry := map[string]interface{}{
 			"id":      id,
 			"name":    name,
 			"type":    arrType,
 			"url":     url,
 			"api_key": decryptedKey,
 			"enabled": enabled,
-		})
+		}
+		// Webhook secret may be NULL for legacy instances; surface a sentinel
+		// so the UI can show a "no webhook secret configured — generate one"
+		// affordance without confusing it for a normal value.
+		if webhookSecret.Valid && webhookSecret.String != "" {
+			decryptedSecret, derr := crypto.Decrypt(webhookSecret.String)
+			if derr != nil {
+				logger.Errorf("Failed to decrypt webhook secret for instance %d: %v", id, derr)
+				decryptedSecret = "[DECRYPTION_ERROR]"
+			}
+			entry["webhook_secret"] = decryptedSecret
+		} else {
+			entry["webhook_secret"] = nil
+		}
+		instances = append(instances, entry)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -178,13 +195,75 @@ func (s *RESTServer) createArrInstance(c *gin.Context) {
 		return
 	}
 
-	_, err = s.db.Exec("INSERT INTO arr_instances (name, type, url, api_key, enabled) VALUES (?, ?, ?, ?, ?)",
-		instanceName, req.Type, req.URL, encryptedKey, req.Enabled)
+	// Generate a per-instance webhook secret so this instance's webhook
+	// credential is decoupled from the master admin API key (Phase 1.1c).
+	// We return the plaintext secret in the response so the user can paste
+	// it into Sonarr/Radarr; the DB stores it encrypted.
+	webhookSecret, err := auth.GenerateAPIKey()
+	if err != nil {
+		logger.Errorf("Failed to generate webhook secret: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate webhook secret"})
+		return
+	}
+	encryptedSecret, err := crypto.Encrypt(webhookSecret)
+	if err != nil {
+		logger.Errorf("Failed to encrypt webhook secret: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encrypt webhook secret"})
+		return
+	}
+
+	result, err := s.db.Exec(
+		"INSERT INTO arr_instances (name, type, url, api_key, enabled, webhook_secret) VALUES (?, ?, ?, ?, ?, ?)",
+		instanceName, req.Type, req.URL, encryptedKey, req.Enabled, encryptedSecret)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	c.Status(http.StatusCreated)
+	id, _ := result.LastInsertId()
+
+	c.JSON(http.StatusCreated, gin.H{
+		"id":             id,
+		"webhook_secret": webhookSecret,
+	})
+}
+
+// regenerateWebhookSecret generates a fresh per-instance webhook secret,
+// invalidating the old one. The new secret is returned plaintext so the user
+// can update their *arr webhook configuration; stored encrypted at rest.
+func (s *RESTServer) regenerateWebhookSecret(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing instance ID"})
+		return
+	}
+
+	secret, err := auth.GenerateAPIKey()
+	if err != nil {
+		logger.Errorf("Failed to generate webhook secret: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate webhook secret"})
+		return
+	}
+	encryptedSecret, err := crypto.Encrypt(secret)
+	if err != nil {
+		logger.Errorf("Failed to encrypt webhook secret: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to encrypt webhook secret"})
+		return
+	}
+
+	result, err := s.db.Exec(
+		"UPDATE arr_instances SET webhook_secret = ? WHERE id = ?",
+		encryptedSecret, id)
+	if err != nil {
+		respondDatabaseError(c, err)
+		return
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Instance not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"webhook_secret": secret})
 }
 
 func (s *RESTServer) deleteArrInstance(c *gin.Context) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -69,6 +69,7 @@ func setupTestDB(t *testing.T) (*sql.DB, func()) {
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
 			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 

--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"crypto/subtle"
+	"database/sql"
 	"net/http"
 	"strconv"
 
@@ -43,30 +44,8 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 		return
 	}
 
-	// Verify API key - need to decrypt stored key for comparison
-	var storedKey string
-	err := s.db.QueryRow("SELECT value FROM settings WHERE key = 'api_key'").Scan(&storedKey)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
-		return
-	}
-
-	// Decrypt stored key if encrypted
-	decryptedKey, err := crypto.Decrypt(storedKey)
-	if err != nil {
-		logger.Errorf("Failed to decrypt API key: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
-		return
-	}
-
-	// Use constant-time comparison to prevent timing attacks
-	if subtle.ConstantTimeCompare([]byte(apiKey), []byte(decryptedKey)) != 1 {
-		logger.Debugf("Webhook rejected: Invalid API key")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid API key"})
-		return
-	}
-
-	// Get instance ID from URL parameter
+	// Get instance ID from URL parameter (needed up-front because the
+	// per-instance webhook secret is the authoritative credential).
 	instanceIDStr := c.Param("instance_id")
 	instanceID, err := strconv.ParseInt(instanceIDStr, 10, 64)
 	if err != nil {
@@ -74,9 +53,14 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 		return
 	}
 
-	// Verify instance exists and is enabled
+	// Load the instance: enabled flag + (encrypted) per-instance webhook secret
+	// if one has been generated. Missing webhook_secret column on legacy
+	// rows scans into a NULL sql.NullString.
 	var enabled bool
-	err = s.db.QueryRow("SELECT enabled FROM arr_instances WHERE id = ?", instanceID).Scan(&enabled)
+	var webhookSecret sql.NullString
+	err = s.db.QueryRow(
+		"SELECT enabled, webhook_secret FROM arr_instances WHERE id = ?",
+		instanceID).Scan(&enabled, &webhookSecret)
 	if err != nil {
 		logger.Errorf("Webhook rejected: Instance %d not found", instanceID)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Instance not found"})
@@ -90,6 +74,49 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 			"message": "Enable this instance in the Config page to process webhooks",
 		})
 		return
+	}
+
+	// Authentication path (Phase 1.1c):
+	//
+	// If the instance has a per-instance webhook_secret, that's the ONLY
+	// credential accepted. The master API key no longer works for instances
+	// that have moved to per-instance secrets — that's the whole point of
+	// the separation.
+	//
+	// If webhook_secret is NULL (legacy instance created before this
+	// migration), fall back to master API key. The UI nudges users to
+	// generate a secret to close the gap.
+	if webhookSecret.Valid && webhookSecret.String != "" {
+		decryptedSecret, decErr := crypto.Decrypt(webhookSecret.String)
+		if decErr != nil {
+			logger.Errorf("Failed to decrypt webhook secret for instance %d: %v", instanceID, decErr)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(apiKey), []byte(decryptedSecret)) != 1 {
+			logger.Debugf("Webhook rejected: Invalid webhook secret for instance %d", instanceID)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid webhook secret"})
+			return
+		}
+	} else {
+		// Legacy fallback: validate against the master API key.
+		var storedKey string
+		if err := s.db.QueryRow("SELECT value FROM settings WHERE key = 'api_key'").Scan(&storedKey); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
+			return
+		}
+		decryptedKey, decErr := crypto.Decrypt(storedKey)
+		if decErr != nil {
+			logger.Errorf("Failed to decrypt API key: %v", decErr)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(apiKey), []byte(decryptedKey)) != 1 {
+			logger.Debugf("Webhook rejected: Invalid API key (legacy instance %d without webhook_secret)", instanceID)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid API key"})
+			return
+		}
+		logger.Warnf("Webhook for instance %d authenticated via master API key — generate a per-instance webhook secret to close this gap", instanceID)
 	}
 
 	var req WebhookRequest

--- a/internal/api/handlers_webhook_test.go
+++ b/internal/api/handlers_webhook_test.go
@@ -88,6 +88,7 @@ func setupWebhookTestDB(t *testing.T) (*sql.DB, func()) {
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
 			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -188,13 +189,17 @@ func TestWebhook_InvalidAPIKey(t *testing.T) {
 	db, cleanup := setupWebhookTestDB(t)
 	defer cleanup()
 
+	// Create a legacy-style instance (no webhook_secret) so the master-key
+	// fallback path runs; the wrong-key check then produces 401 with
+	// "Invalid API key" — the legacy-path message from Phase 1.1c.
+	arrID := createTestArrInstance(t, db, true)
 	mockPM := &testutil.MockPathMapper{}
 	mockScanner := &webhookMockScanner{}
 	router, _, serverCleanup := setupWebhookTestServer(t, db, mockPM, mockScanner)
 	defer serverCleanup()
 
 	body := bytes.NewBufferString(`{"eventType": "Download"}`)
-	req, _ := http.NewRequest("POST", "/api/webhook/1", body)
+	req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", "wrong-api-key")
 	w := httptest.NewRecorder()
@@ -491,18 +496,20 @@ func TestWebhook_DBError(t *testing.T) {
 	db, cleanup := setupWebhookTestDB(t)
 	defer cleanup()
 
-	// Setup everything normally first
 	mockPM := &testutil.MockPathMapper{}
 	mockScanner := &webhookMockScanner{}
 	router, apiKey, serverCleanup := setupWebhookTestServer(t, db, mockPM, mockScanner)
 	defer serverCleanup()
 
-	// Drop settings table to cause DB query error
+	// Create a legacy-style instance so the request reaches the master-key
+	// fallback path, then drop the settings table so that query errors —
+	// produces 500 "Authentication error".
+	arrID := createTestArrInstance(t, db, true)
 	_, err := db.Exec("DROP TABLE settings")
 	require.NoError(t, err)
 
 	body := bytes.NewBufferString(`{"eventType": "Download"}`)
-	req, _ := http.NewRequest("POST", "/api/webhook/1", body)
+	req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
 	w := httptest.NewRecorder()
@@ -519,7 +526,6 @@ func TestWebhook_DecryptError(t *testing.T) {
 	db, cleanup := setupWebhookTestDB(t)
 	defer cleanup()
 
-	// Setup without adding an API key through normal flow
 	mockPM := &testutil.MockPathMapper{}
 	mockScanner := &webhookMockScanner{}
 
@@ -539,12 +545,15 @@ func TestWebhook_DecryptError(t *testing.T) {
 
 	r.POST("/api/webhook/:instance_id", s.handleWebhook)
 
-	// Insert an invalid encrypted key that will fail decryption
+	// Insert a legacy instance (no webhook_secret) so the master-key
+	// fallback path runs, plus an invalid encrypted master key so the
+	// decrypt step inside that fallback fails → 500 "Authentication error".
+	arrID := createTestArrInstance(t, db, true)
 	_, err := db.Exec("INSERT INTO settings (key, value) VALUES ('api_key', 'enc:v1:invalid-encrypted-data')")
 	require.NoError(t, err)
 
 	body := bytes.NewBufferString(`{"eventType": "Download"}`)
-	req, _ := http.NewRequest("POST", "/api/webhook/1", body)
+	req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", "any-key-value")
 	w := httptest.NewRecorder()
@@ -558,6 +567,54 @@ func TestWebhook_DecryptError(t *testing.T) {
 
 	hub.Shutdown()
 	eb.Shutdown()
+}
+
+// TestWebhook_PerInstanceSecret_Accepted verifies that an instance with a
+// generated webhook_secret accepts that secret as authentication AND that
+// the master API key is no longer accepted for that instance — the whole
+// point of Phase 1.1c separation.
+func TestWebhook_PerInstanceSecret_Accepted(t *testing.T) {
+	db, cleanup := setupWebhookTestDB(t)
+	defer cleanup()
+
+	// Create an instance and generate a webhook secret for it.
+	arrID := createTestArrInstance(t, db, true)
+	perInstanceSecret := "per-instance-secret-value"
+	encryptedSecret, err := crypto.Encrypt(perInstanceSecret)
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE arr_instances SET webhook_secret = ? WHERE id = ?", encryptedSecret, arrID)
+	require.NoError(t, err)
+
+	mockPM := &testutil.MockPathMapper{
+		ToLocalPathFunc: func(arrPath string) (string, error) { return "/local" + arrPath, nil },
+	}
+	mockScanner := &webhookMockScanner{}
+	router, masterKey, serverCleanup := setupWebhookTestServer(t, db, mockPM, mockScanner)
+	defer serverCleanup()
+
+	t.Run("accepts per-instance secret", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"eventType": "Download", "movieFile": {"path": "/x.mkv"}}`)
+		req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", perInstanceSecret)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "per-instance secret should authenticate")
+	})
+
+	t.Run("master API key NO LONGER accepted once secret is set", func(t *testing.T) {
+		body := bytes.NewBufferString(`{"eventType": "Download", "movieFile": {"path": "/x.mkv"}}`)
+		req, _ := http.NewRequest("POST", "/api/webhook/"+string(rune('0'+arrID)), body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-API-Key", masterKey)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "once per-instance secret exists, master key is no longer valid for that instance (the whole point of separation)")
+
+		var response map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Equal(t, "Invalid webhook secret", response["error"])
+	})
 }
 
 // TestWebhook_ScanFailure_PublishesScanFailedEvent verifies that when the

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -424,6 +424,7 @@ func (s *RESTServer) setupRoutes() {
 			protected.GET("/config/arr", s.getArrInstances)
 			protected.POST("/config/arr", s.createArrInstance)
 			protected.POST("/config/arr/test", s.testArrConnection)
+			protected.POST("/config/arr/:id/webhook-secret", s.regenerateWebhookSecret)
 			protected.PUT("/config/arr/:id", s.updateArrInstance)
 			protected.DELETE("/config/arr/:id", s.deleteArrInstance)
 			protected.GET("/config/arr/:id/rootfolders", s.getArrRootFolders)

--- a/internal/db/migrations/006_webhook_secret.sql
+++ b/internal/db/migrations/006_webhook_secret.sql
@@ -1,0 +1,15 @@
+-- 006_webhook_secret.sql
+--
+-- Per-instance webhook secret. Previously the /api/webhook/:instance_id
+-- endpoint accepted the master API key (the same secret used by the admin
+-- UI) — anyone who could read a Sonarr/Radarr webhook config in a
+-- compromised *arr instance got full Healarr admin access. This migration
+-- adds a webhook_secret column so each *arr instance can have its own
+-- webhook credential, distinct from the admin key.
+--
+-- Existing rows get NULL; the webhook handler falls back to the master key
+-- for backward compatibility until the user generates a per-instance secret
+-- via the UI. New instances created after this migration get a secret
+-- generated at INSERT time.
+
+ALTER TABLE arr_instances ADD COLUMN webhook_secret TEXT;


### PR DESCRIPTION
Closes P0 finding S2 — the last Phase 1 item. With this merged, Phase 1 of the remediation plan is complete.

The webhook handler accepted the master API key as the credential for incoming Sonarr/Radarr webhook calls — one secret, two roles, no separation. Per the audit: anyone who could read the webhook config in a compromised *arr instance gained full Healarr admin access.

Changes:

- Migration 006 adds a nullable webhook_secret column to arr_instances.
- createArrInstance generates a per-instance secret (32-byte cryptographic token, same primitive as auth.GenerateAPIKey), stores encrypted, returns plaintext in response so the user can paste it into Sonarr/Radarr.
- getArrInstances surfaces webhook_secret (decrypted for display); NULL on legacy rows so the UI can prompt to generate one.
- New endpoint POST /api/config/arr/:id/webhook-secret rotates the secret for incident response.
- handleWebhook auth: if the instance has a webhook_secret, ONLY that secret authenticates (master key rejected); if NULL (legacy), master key works with a Warnf nudge to generate a per-instance secret.

Tests: 3 existing webhook tests updated to create instances first (the reorder made instance lookup the first step). New TestWebhook_PerInstanceSecret_Accepted verifies the per-instance secret authenticates AND that the master key is rejected once the instance has one.

Backward-compat: pre-migration instances continue to work via the master-key fallback; new instances get a webhook_secret automatically and require it for webhook auth. Admin UI / CLI auth via master key is unaffected (this PR only changes webhook handler auth).

Phase 1 of the remediation plan is COMPLETE after this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced per-instance webhook secrets for enhanced security and isolation between instances
  * Added the ability to generate and regenerate webhook secrets for individual arr instances
  * New API endpoint to manage webhook secret regeneration
  * Maintained backward compatibility for instances without configured secrets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->