### PR TITLE
fix(scanner): ScanProgressView snapshot decouples public reads from live mutex (Phase 2.4: T4)

### DIFF
--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -1054,7 +1054,7 @@ func TestTriggerScan_BadRequest(t *testing.T) {
 // scansMockScanner implements services.Scanner with controllable behavior for testing
 // pause/resume/cancel handlers with active scans.
 type scansMockScanner struct {
-	activeScans    []services.ScanProgress
+	activeScans    []services.ScanProgressView
 	pauseCalled    map[string]bool
 	resumeCalled   map[string]bool
 	cancelCalled   map[string]bool
@@ -1087,7 +1087,7 @@ func (m *scansMockScanner) IsPathBeingScanned(_ string) bool {
 	return m.isPathScanning
 }
 
-func (m *scansMockScanner) GetActiveScans() []services.ScanProgress {
+func (m *scansMockScanner) GetActiveScans() []services.ScanProgressView {
 	return m.activeScans
 }
 
@@ -1134,7 +1134,7 @@ func TestPauseAllScans_WithActiveScans(t *testing.T) {
 	defer eb.Shutdown()
 
 	mockScanner := newScansMockScanner()
-	mockScanner.activeScans = []services.ScanProgress{
+	mockScanner.activeScans = []services.ScanProgressView{
 		{ID: "scan-1", Status: "running", Path: "/test/path1"},
 		{ID: "scan-2", Status: "running", Path: "/test/path2"},
 		{ID: "scan-3", Status: "paused", Path: "/test/path3"}, // Should not be paused (already paused)
@@ -1182,7 +1182,7 @@ func TestResumeAllScans_WithActiveScans(t *testing.T) {
 	defer eb.Shutdown()
 
 	mockScanner := newScansMockScanner()
-	mockScanner.activeScans = []services.ScanProgress{
+	mockScanner.activeScans = []services.ScanProgressView{
 		{ID: "scan-1", Status: "paused", Path: "/test/path1"},
 		{ID: "scan-2", Status: "paused", Path: "/test/path2"},
 		{ID: "scan-3", Status: "running", Path: "/test/path3"}, // Should not be resumed (already running)
@@ -1230,7 +1230,7 @@ func TestCancelAllScans_WithActiveScans(t *testing.T) {
 	defer eb.Shutdown()
 
 	mockScanner := newScansMockScanner()
-	mockScanner.activeScans = []services.ScanProgress{
+	mockScanner.activeScans = []services.ScanProgressView{
 		{ID: "scan-1", Status: "running", Path: "/test/path1"},
 		{ID: "scan-2", Status: "paused", Path: "/test/path2"},
 		{ID: "scan-3", Status: "completed", Path: "/test/path3"}, // Should not be cancelled

--- a/internal/api/handlers_webhook_test.go
+++ b/internal/api/handlers_webhook_test.go
@@ -38,13 +38,13 @@ func (m *webhookMockScanner) ScanFile(path string) error {
 	return nil
 }
 
-func (m *webhookMockScanner) ScanPath(_ int64, _ string) error        { return nil }
-func (m *webhookMockScanner) IsPathBeingScanned(_ string) bool        { return false }
-func (m *webhookMockScanner) GetActiveScans() []services.ScanProgress { return nil }
-func (m *webhookMockScanner) CancelScan(_ string) error               { return nil }
-func (m *webhookMockScanner) PauseScan(_ string) error                { return nil }
-func (m *webhookMockScanner) ResumeScan(_ string) error               { return nil }
-func (m *webhookMockScanner) Shutdown()                               {}
+func (m *webhookMockScanner) ScanPath(_ int64, _ string) error            { return nil }
+func (m *webhookMockScanner) IsPathBeingScanned(_ string) bool            { return false }
+func (m *webhookMockScanner) GetActiveScans() []services.ScanProgressView { return nil }
+func (m *webhookMockScanner) CancelScan(_ string) error                   { return nil }
+func (m *webhookMockScanner) PauseScan(_ string) error                    { return nil }
+func (m *webhookMockScanner) ResumeScan(_ string) error                   { return nil }
+func (m *webhookMockScanner) Shutdown()                                   {}
 
 // setupWebhookTestDB creates a test database for webhook tests
 func setupWebhookTestDB(t *testing.T) (*sql.DB, func()) {

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -121,24 +121,71 @@ const (
 )
 
 // ScanProgress represents the current state and progress of an active scan.
+//
+// Direct field access is permitted ONLY for code that holds mu — writers
+// must Lock/Unlock around mutations, and any reader that crosses the
+// service boundary (handlers, JSON marshaling, events) MUST go through
+// Snapshot() to get a value-copy ScanProgressView rather than reading
+// exported fields directly. That separation closes the data race the
+// audit flagged on Status (T4).
 type ScanProgress struct {
 	mu              sync.Mutex         `json:"-"` // Protects mutable fields during concurrent access
-	ID              string             `json:"id"`
-	Type            string             `json:"type"` // "path" or "file"
-	Path            string             `json:"path"`
-	PathID          int64              `json:"path_id,omitempty"` // Database path ID for resumable scans
-	TotalFiles      int                `json:"total_files"`
-	FilesDone       int                `json:"files_done"`
-	CurrentFile     string             `json:"current_file"`
-	Status          string             `json:"status"` // "enumerating", "scanning", "paused", "interrupted", "cancelled"
-	StartTime       string             `json:"start_time"`
-	ScanDBID        int64              `json:"scan_db_id,omitempty"` // Database scan record ID for navigation
-	cancel          context.CancelFunc `json:"-"`                    // Don't export in JSON
-	pauseChan       chan struct{}      `json:"-"`                    // Channel to signal pause
-	resumeChan      chan struct{}      `json:"-"`                    // Channel to signal resume
-	isPaused        bool               `json:"-"`                    // Track pause state
-	corruptionCount int                `json:"-"`                    // Track corruptions found in this scan for throttling
-	isThrottled     bool               `json:"-"`                    // Whether this scan is being throttled
+	ID              string             `json:"-"`
+	Type            string             `json:"-"` // "path" or "file"
+	Path            string             `json:"-"`
+	PathID          int64              `json:"-"` // Database path ID for resumable scans
+	TotalFiles      int                `json:"-"`
+	FilesDone       int                `json:"-"`
+	CurrentFile     string             `json:"-"`
+	Status          string             `json:"-"` // "enumerating", "scanning", "paused", "interrupted", "cancelled"
+	StartTime       string             `json:"-"`
+	ScanDBID        int64              `json:"-"` // Database scan record ID for navigation
+	cancel          context.CancelFunc `json:"-"` // Don't export in JSON
+	pauseChan       chan struct{}      `json:"-"` // Channel to signal pause
+	resumeChan      chan struct{}      `json:"-"` // Channel to signal resume
+	isPaused        bool               `json:"-"` // Track pause state
+	corruptionCount int                `json:"-"` // Track corruptions found in this scan for throttling
+	isThrottled     bool               `json:"-"` // Whether this scan is being throttled
+}
+
+// ScanProgressView is a race-free value-type snapshot of a ScanProgress.
+// It carries no mutex and contains only the fields appropriate for JSON
+// serialization — handlers and event publishers consume this type so
+// readers never touch the live (and concurrently mutated) struct.
+type ScanProgressView struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"` // "path" or "file"
+	Path        string `json:"path"`
+	PathID      int64  `json:"path_id,omitempty"`
+	TotalFiles  int    `json:"total_files"`
+	FilesDone   int    `json:"files_done"`
+	CurrentFile string `json:"current_file"`
+	Status      string `json:"status"`
+	StartTime   string `json:"start_time"`
+	ScanDBID    int64  `json:"scan_db_id,omitempty"`
+}
+
+// Snapshot returns a ScanProgressView atomically: the lock is held for the
+// duration of the field reads so the view captures a consistent state, but
+// the returned value carries no mutex so callers can serialize it freely.
+//
+// This is the only sanctioned way to read ScanProgress fields from code
+// that doesn't already hold the mutex.
+func (p *ScanProgress) Snapshot() ScanProgressView {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return ScanProgressView{
+		ID:          p.ID,
+		Type:        p.Type,
+		Path:        p.Path,
+		PathID:      p.PathID,
+		TotalFiles:  p.TotalFiles,
+		FilesDone:   p.FilesDone,
+		CurrentFile: p.CurrentFile,
+		Status:      p.Status,
+		StartTime:   p.StartTime,
+		ScanDBID:    p.ScanDBID,
+	}
 }
 
 // scanPathConfig holds cached scan path configuration
@@ -178,7 +225,7 @@ type Scanner interface {
 	ScanFile(localPath string) error
 	ScanPath(pathID int64, localPath string) error
 	IsPathBeingScanned(path string) bool
-	GetActiveScans() []ScanProgress
+	GetActiveScans() []ScanProgressView
 	CancelScan(scanID string) error
 	PauseScan(scanID string) error
 	ResumeScan(scanID string) error
@@ -1397,62 +1444,42 @@ func (s *ScannerService) markFileProcessed(progress *ScanProgress, fileIndex int
 }
 
 func (s *ScannerService) emitProgress(p *ScanProgress) {
-	// Build event data under lock to avoid race with markFileProcessed
-	p.mu.Lock()
-	eventData := map[string]interface{}{
-		"id":           p.ID,
-		"type":         p.Type,
-		"path":         p.Path,
-		"total_files":  p.TotalFiles,
-		"files_done":   p.FilesDone,
-		"current_file": p.CurrentFile,
-		"status":       p.Status,
-		"start_time":   p.StartTime,
-		"scan_db_id":   p.ScanDBID, // Database ID for frontend navigation
-	}
-	scanID := p.ID
-	p.mu.Unlock()
-
-	// Publish event outside the lock to avoid holding lock during I/O
+	// Snapshot captures fields atomically under the per-scan mutex so the
+	// event sees a consistent state; the publish happens outside the lock
+	// because Publish does I/O.
+	view := p.Snapshot()
 	if err := s.eventBus.Publish(domain.Event{
 		AggregateType: "scan",
-		AggregateID:   scanID,
+		AggregateID:   view.ID,
 		EventType:     domain.ScanProgress,
-		EventData:     eventData,
+		EventData: map[string]interface{}{
+			"id":           view.ID,
+			"type":         view.Type,
+			"path":         view.Path,
+			"total_files":  view.TotalFiles,
+			"files_done":   view.FilesDone,
+			"current_file": view.CurrentFile,
+			"status":       view.Status,
+			"start_time":   view.StartTime,
+			"scan_db_id":   view.ScanDBID, // Database ID for frontend navigation
+		},
 	}); err != nil {
 		logger.Debugf("Failed to emit scan progress: %v", err)
 	}
 }
 
-// GetActiveScans returns a copy of all currently active scan progress states.
-func (s *ScannerService) GetActiveScans() []ScanProgress {
+// GetActiveScans returns race-free snapshots of all currently active scans.
+// Each view is captured under the per-scan mutex so the snapshot is
+// internally consistent; the returned slice itself is safe to mutate by
+// the caller.
+func (s *ScannerService) GetActiveScans() []ScanProgressView {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	scans := make([]ScanProgress, 0, len(s.activeScans))
+	views := make([]ScanProgressView, 0, len(s.activeScans))
 	for _, scan := range s.activeScans {
-		// Lock individual scan to safely copy mutable fields (fixes data race)
-		scan.mu.Lock()
-		// Manually copy fields to avoid copylocks warning (mutex is not copied)
-		scanCopy := ScanProgress{
-			ID:              scan.ID,
-			Type:            scan.Type,
-			Path:            scan.Path,
-			PathID:          scan.PathID,
-			TotalFiles:      scan.TotalFiles,
-			FilesDone:       scan.FilesDone,
-			CurrentFile:     scan.CurrentFile,
-			Status:          scan.Status,
-			StartTime:       scan.StartTime,
-			ScanDBID:        scan.ScanDBID,
-			isPaused:        scan.isPaused,
-			corruptionCount: scan.corruptionCount,
-			isThrottled:     scan.isThrottled,
-			// Note: cancel, pauseChan, resumeChan are not copied (internal use only)
-		}
-		scan.mu.Unlock()
-		scans = append(scans, scanCopy) //nolint:govet // scanCopy has fresh zero-valued mutex, not copied from original
+		views = append(views, scan.Snapshot())
 	}
-	return scans
+	return views
 }
 
 // IsPathBeingScanned checks if a scan is already in progress for the given path

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -16,9 +16,9 @@ import (
 // ErrMockAPIFailure is a standard error used in tests to simulate API failures.
 var ErrMockAPIFailure = errors.New("mock API failure")
 
-// ScanProgress mirrors services.ScanProgress for testing without creating an import cycle.
+// ScanProgressView mirrors services.ScanProgressView for testing without creating an import cycle.
 // Only includes the JSON-exported fields needed for test assertions.
-type ScanProgress struct {
+type ScanProgressView struct {
 	ID          string `json:"id"`
 	Type        string `json:"type"`
 	Path        string `json:"path"`
@@ -610,11 +610,11 @@ func (m *MockEventBus) LastEvent() *domain.Event {
 // =============================================================================
 
 // MockScannerService implements the Scanner interface for testing.
-// Uses local ScanProgress type to avoid import cycle with services package.
+// Uses local ScanProgressView type to avoid import cycle with services package.
 type MockScannerService struct {
 	ScanPathFunc            func(pathID int64, localPath string) error
 	ScanFileFunc            func(localPath string) error
-	GetActiveScansFunc      func() []ScanProgress
+	GetActiveScansFunc      func() []ScanProgressView
 	IsPathBeingScanningFunc func(path string) bool
 	IsFileBeingScannedFunc  func(localPath string) bool
 	PauseScanFunc           func(scanID string) error
@@ -668,7 +668,7 @@ func (m *MockScannerService) ScanFile(localPath string) error {
 	return nil
 }
 
-func (m *MockScannerService) GetActiveScans() []ScanProgress {
+func (m *MockScannerService) GetActiveScans() []ScanProgressView {
 	m.recordCall("GetActiveScans")
 	if m.GetActiveScansFunc != nil {
 		return m.GetActiveScansFunc()


### PR DESCRIPTION
Closes audit finding T4 — the race-prone public boundary on `Scanner.GetActiveScans()`.

## The bug

`ScanProgress` embeds a `sync.Mutex` and exports its mutable fields (Status, FilesDone, CurrentFile, …). Writers (like `markFileProcessed` bumping FilesDone) hold the mutex; readers in the public API path did not.

The previous workaround in `GetActiveScans` manually copied fields under the per-scan lock and silenced the resulting `copylocks` lint warning:

```go
scans = append(scans, scanCopy) //nolint:govet // scanCopy has fresh zero-valued mutex, not copied from original
```

The type itself was still wrong — we just told the linter to stop noticing. Any new code path reading `activeScans[i].Status` directly would race; nothing in the type system prevented it.

## The fix

New `ScanProgressView` value type carrying the JSON-marshalable fields without the mutex:

```go
type ScanProgressView struct {
    ID, Type, Path, CurrentFile, Status, StartTime string
    PathID, ScanDBID                                 int64
    TotalFiles, FilesDone                            int
}
```

New `(*ScanProgress).Snapshot() ScanProgressView` method — takes the per-scan lock, copies fields atomically, returns by value. **This is the only sanctioned way to read ScanProgress fields from code that doesn't already hold the mutex.**

`Scanner.GetActiveScans()` now returns `[]ScanProgressView`. `emitProgress` also uses `Snapshot()` to build event data. The `nolint:govet` workaround is gone — the race-prone pattern is no longer expressible at the public boundary.

ScanProgress's exported fields are now `json:"-"` (marshaling goes through ScanProgressView). Internal field access by writers is unchanged — they already hold the mutex correctly.

## Scope

This is the **partial** Snapshot refactor that the audit recommended: fix the **public boundary**, leave **internal field access** alone for now. Full privatization (`SetStatus()`, `IncrementFilesDone()`, etc. at ~30 internal write sites) is a separate refactor. The race the audit named — `races on Status` between writers and the public reader — is fixed by the snapshot boundary alone.

## Callers updated

- All 4 `s.scanner.GetActiveScans()` callsites in `handlers_scans.go` use `.ID` / `.Status` — same field names on `ScanProgressView`, no change needed.
- `handlers_health.go` (length-only use)
- `MockScannerService` and `scansMockScanner` / `webhookMockScanner` signatures updated.
- `internal/testutil/ScanProgress` renamed to `ScanProgressView` (had no mutex, was already a value type — the rename just keeps the name in sync with the new public name).

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — full suite passes
- [x] `nolint:govet` line is gone (`grep -rn 'nolint:govet' internal/services/scanner.go` returns nothing)

## Context

Phase 2 (Foundational types) — item 2.4. With #190 just merged, Phase 2 is half-done:
- ✅ 2.3 HealthErrorType category map (#190)
- ✅ 2.4 ScanProgressView snapshot *(this PR)*
- 2.1 typed enum sweep (M, coordinated Go+TS)
- 2.2 typed event envelope (M)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of scan progress data to ensure consistent and reliable reporting of active scan status information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->