### PR TITLE
fix(integration): convert ArrType to a typed enum with boundary validation (Phase 2.1.a: T2)

### DIFF
--- a/internal/api/handlers_arr.go
+++ b/internal/api/handlers_arr.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
+	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/network"
 )
@@ -177,6 +178,13 @@ func (s *RESTServer) createArrInstance(c *gin.Context) {
 	// Security: Validate URL to prevent SSRF attacks
 	if err := validateArrURL(req.URL); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": formatInvalidURLError(err)})
+		return
+	}
+
+	// Boundary validation: reject unknown ArrType strings here so the
+	// typed enum is the only thing ever persisted (closes T2 from audit).
+	if _, err := integration.ParseArrType(req.Type); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,13 +22,71 @@ import (
 	"github.com/mescon/Healarr/internal/logger"
 )
 
-// Arr instance type constants
+// ArrType is the typed enum of supported *arr application kinds. Using a
+// distinct string type (rather than bare string) lets the compiler catch
+// at-boundary mistakes — `ParseArrType(s)` is the only way to convert a
+// raw string to ArrType, so unknown values can't silently reach the DB.
+// Also implements sql.Scanner so DB reads validate at row-scan time.
+type ArrType string
+
+// Arr instance type constants.
 const (
-	ArrTypeSonarr     = "sonarr"
-	ArrTypeRadarr     = "radarr"
-	ArrTypeWhisparrV2 = "whisparr-v2"
-	ArrTypeWhisparrV3 = "whisparr-v3"
+	ArrTypeSonarr     ArrType = "sonarr"
+	ArrTypeRadarr     ArrType = "radarr"
+	ArrTypeWhisparrV2 ArrType = "whisparr-v2"
+	ArrTypeWhisparrV3 ArrType = "whisparr-v3"
 )
+
+// validArrTypes is the authoritative set used for boundary validation
+// (ParseArrType) and DB scan validation (ArrType.Scan).
+var validArrTypes = map[ArrType]bool{
+	ArrTypeSonarr:     true,
+	ArrTypeRadarr:     true,
+	ArrTypeWhisparrV2: true,
+	ArrTypeWhisparrV3: true,
+}
+
+// ParseArrType validates and converts a raw string to ArrType. Use at API
+// write boundaries (handlers that accept user input) and any other place
+// that crosses from untyped strings into the type system.
+func ParseArrType(s string) (ArrType, error) {
+	a := ArrType(s)
+	if !validArrTypes[a] {
+		return "", fmt.Errorf("unknown ArrType %q (must be sonarr, radarr, whisparr-v2, or whisparr-v3)", s)
+	}
+	return a, nil
+}
+
+// Scan implements sql.Scanner so ArrInstanceInfo.Type can be passed
+// directly to rows.Scan. An unknown DB value produces an error at scan
+// time rather than silently producing an invalid ArrType that later
+// switch statements fall through.
+func (a *ArrType) Scan(value any) error {
+	if value == nil {
+		return fmt.Errorf("ArrType: cannot scan NULL")
+	}
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("ArrType: expected string DB value, got %T", value)
+	}
+	parsed, err := ParseArrType(s)
+	if err != nil {
+		return fmt.Errorf("ArrType.Scan: %w", err)
+	}
+	*a = parsed
+	return nil
+}
+
+// Value implements driver.Valuer so ArrType can be passed directly as
+// a query parameter.
+func (a ArrType) Value() (driver.Value, error) {
+	return string(a), nil
+}
 
 // RateLimiter implements a token bucket rate limiter for API calls
 type RateLimiter struct {
@@ -121,7 +180,7 @@ func (c *HTTPArrClient) ResetAllCircuitBreakers() {
 type ArrInstance struct {
 	ID     int64
 	Name   string
-	Type   string
+	Type   ArrType
 	URL    string
 	APIKey string
 }
@@ -250,7 +309,12 @@ func (c *HTTPArrClient) getInstanceForPath(arrPath string) (*ArrInstance, error)
 		var i ArrInstance
 		var rootPath string
 		var encryptedKey string
-		if rows.Scan(&i.ID, &i.Name, &i.Type, &i.URL, &encryptedKey, &rootPath) != nil {
+		if err := rows.Scan(&i.ID, &i.Name, &i.Type, &i.URL, &encryptedKey, &rootPath); err != nil {
+			// ArrType.Scan rejects unknown DB values here. Logging at Errorf
+			// surfaces the bad row (typically a manual SQL insert with a
+			// typo'd type) rather than silently producing "no instance
+			// found" downstream.
+			logger.Errorf("getInstanceForPath: skipping unscannable row: %v", err)
 			continue
 		}
 
@@ -1588,7 +1652,7 @@ func (c *HTTPArrClient) getMovieDetails(instance *ArrInstance, movieID int64) (*
 		Title:        movie.Title,
 		Year:         movie.Year,
 		MediaType:    "movie",
-		ArrType:      instance.Type,
+		ArrType:      string(instance.Type),
 		InstanceName: instance.Name,
 	}, nil
 }
@@ -1622,7 +1686,7 @@ func (c *HTTPArrClient) getSeriesDetails(instance *ArrInstance, seriesID int64) 
 		Title:        series.Title,
 		Year:         series.Year,
 		MediaType:    "series",
-		ArrType:      instance.Type,
+		ArrType:      string(instance.Type),
 		InstanceName: instance.Name,
 	}, nil
 }
@@ -1673,7 +1737,7 @@ func (c *HTTPArrClient) GetEpisodeDetails(episodeID int64, arrPath string) (*Med
 		SeasonNumber:  episode.SeasonNumber,
 		EpisodeNumber: episode.EpisodeNumber,
 		EpisodeTitle:  episode.Title,
-		ArrType:       instance.Type,
+		ArrType:       string(instance.Type),
 		InstanceName:  instance.Name,
 	}, nil
 }

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -4799,8 +4799,21 @@ func TestHTTPArrClient_GetFilePath_UnsupportedType(t *testing.T) {
 	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/other', '/other', 1, 0, 0)`)
 
 	_, err := client.GetFilePath(0, nil, "/other/file.mkv")
-	if err == nil || !strings.Contains(err.Error(), "unsupported") {
-		t.Error("Expected error about unsupported type")
+	// With ArrType being a validated typed enum, the DB row with type='unknown'
+	// is now rejected at row-scan time by ArrType.Scan (visible in the Errorf
+	// log line we added). The row is skipped, so the caller sees "no instance
+	// found" rather than reaching the unsupported-type switch downstream.
+	// This is a stronger guarantee: invalid types never reach business logic.
+	if err == nil {
+		t.Error("Expected error for unknown arr type")
+	} else {
+		msg := err.Error()
+		// Accept either the new "no instance found" (post-scan-rejection) or
+		// the historical "unsupported" message if the path is ever refactored
+		// to validate type later instead of at scan.
+		if !strings.Contains(msg, "unsupported") && !strings.Contains(msg, "no instance found") {
+			t.Errorf("expected error indicating unknown ArrType (either pre-scan reject or post-switch), got: %v", err)
+		}
 	}
 }
 

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -8,10 +8,14 @@ import (
 )
 
 // ArrInstanceInfo represents a configured *arr instance.
+//
+// Type is the typed ArrType enum (defined in arr_client.go) rather than a
+// bare string — the compiler now rejects misspelled or unknown values at
+// every comparison and DB scan site.
 type ArrInstanceInfo struct {
 	ID     int64
 	Name   string
-	Type   string // sonarr, radarr, whisparr
+	Type   ArrType // sonarr, radarr, whisparr-v2, whisparr-v3
 	URL    string
 	APIKey string
 }

--- a/internal/services/health_monitor.go
+++ b/internal/services/health_monitor.go
@@ -346,7 +346,7 @@ func (h *HealthMonitorService) handleInstanceUnhealthy(instance *integration.Arr
 		EventType:     domain.InstanceUnhealthy,
 		EventData: map[string]interface{}{
 			"instance_name": instance.Name,
-			"instance_type": instance.Type,
+			"instance_type": string(instance.Type),
 			"instance_url":  instance.URL,
 			"error":         err.Error(),
 		},
@@ -375,7 +375,7 @@ func (h *HealthMonitorService) handleInstanceRecovered(instance *integration.Arr
 			EventType:     domain.InstanceHealthy,
 			EventData: map[string]interface{}{
 				"instance_name": instance.Name,
-				"instance_type": instance.Type,
+				"instance_type": string(instance.Type),
 				"instance_url":  instance.URL,
 			},
 		}); pubErr != nil {


### PR DESCRIPTION
First enum in the Phase 2.1 sweep. Closes audit finding T2 (ArrType drift between Go and TS) on the Go side. The remaining 6 enums (ProviderType, ScanStatus, DownloadState, DownloadStatus, Protocol, DetectionMode) follow the same template in subsequent PRs.

## The bug

`ArrInstanceInfo.Type string // sonarr, radarr, whisparr` — bare string field. Misspelled SQL inserts, malformed API requests, or refactor mistakes would silently produce instances with Type values the downstream switch statements didn't recognize, falling through to either errors-much-later or wrong behavior.

## The template

```go
type ArrType string

const (
    ArrTypeSonarr     ArrType = "sonarr"
    ArrTypeRadarr     ArrType = "radarr"
    ArrTypeWhisparrV2 ArrType = "whisparr-v2"
    ArrTypeWhisparrV3 ArrType = "whisparr-v3"
)

func ParseArrType(s string) (ArrType, error) { /* validation */ }
func (a *ArrType) Scan(value any) error      { /* DB read validation */ }
func (a ArrType) Value() (driver.Value, error) { /* DB write */ }
```

Three boundary controls — the compiler enforces all internal use, `ParseArrType` validates API input, `Scan` validates DB reads, `Value` keeps DB writes symmetric.

## What this catches

| Vector | Before | After |
|---|---|---|
| Misspelled `"sonar"` literal in Go | Compiles fine, silent failures downstream | Type error at compile time |
| Manual SQL `INSERT … type='unknown'` | Silently produces `Type="unknown"` struct | `rows.Scan` returns `ArrType.Scan: unknown ArrType`; row skipped with Errorf log |
| POST /api/config/arr with `type="sonarrsharp"` | Silently stored, breaks on first scan | 400 with "unknown ArrType" + valid options list |

## Sites updated

- `ArrInstanceInfo.Type` and internal `ArrInstance.Type` fields now `ArrType`
- ~10 comparison and switch sites (e.g. `instance.Type == ArrTypeSonarr`) — type-correct without changes
- `handlers_arr.createArrInstance` calls `ParseArrType(req.Type)` after URL validation
- `MediaDetails.ArrType` stays `string` (JSON DTO to frontend) with explicit `string(instance.Type)` cast at 3 assignment sites
- `health_monitor.go` event payloads cast `string(instance.Type)` at publish — events are JSON-marshaled, typed enum is internal-only
- `getInstanceForPath` row-scan now logs Errorf on failure (was silent continue) — surfaces `ArrType.Scan: unknown ArrType <foo>` so typo'd manual INSERTs don't produce silent "no instance found" downstream

## Test fixups

- **TestHTTPArrClient_GetFilePath_UnsupportedType**: was asserting "unsupported instance type" from the downstream switch. Now Scan rejects the row up-front (a better location for the error) and the caller sees "no instance found". Test accepts either pattern for refactor resilience.
- **TestHealthMonitorService_checkInstanceHealth_PublishesInstanceHealthyOnRecovery**: was asserting `event.EventData["instance_type"] != "sonarr"` and failing because the payload contained a typed `ArrType` value. Fixed by the boundary cast in health_monitor.go — the event payload is now plain string, the typed enum stays internal.

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — full suite passes (including the two updated tests)
- [ ] After merge: POST a malformed type to /api/config/arr, verify 400 with the helpful error
- [ ] After merge: manually insert a malformed row, verify Errorf in logs and that the row doesn't break downstream scans

## Context

Phase 2 (Foundational types) progress:
- ✅ 2.3 HealthErrorType category map (#190)
- ✅ 2.4 ScanProgressView snapshot (#191)
- 🟡 **2.1.a ArrType typed enum** *(this PR)*
- 2.1.b-g remaining enums (ProviderType, ScanStatus, DownloadState, DownloadStatus, Protocol, DetectionMode)
- 2.2 typed event envelope (M)

Frontend coordination (matching TS literal unions in `frontend/src/lib/enums.ts`) deferred to the end of the enum sweep so it can be done in one coordinated pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for instance type creation; invalid types now return a clear error message instead of proceeding with creation.
  * Enhanced reliability of instance type data handling and error reporting during system operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->