### PR TITLE
fix(notifier): convert ProviderType to typed enum with boundary validation (Phase 2.1.b)

### DIFF
--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -491,9 +491,17 @@ func (s *RESTServer) importNotifications(notifications []importNotification) int
 			continue
 		}
 
+		// Boundary validation: reject unknown provider_type at the import
+		// edge so the typed enum is the only thing reaching the DB.
+		providerType, perr := notifier.ParseProviderType(notif.ProviderType)
+		if perr != nil {
+			logger.Errorf("Skipping notification %q on import: %v", notif.Name, perr)
+			continue
+		}
+
 		cfg := &notifierConfig{
 			Name:            notif.Name,
-			ProviderType:    notif.ProviderType,
+			ProviderType:    providerType,
 			Config:          configBytes,
 			Events:          notif.Events,
 			Enabled:         notif.Enabled,

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -44,6 +44,14 @@ func (s *RESTServer) createNotification(c *gin.Context) {
 		return
 	}
 
+	// Boundary validation: JSON unmarshaling accepts any string into the
+	// typed ProviderType field; this is where we reject unknown values
+	// before they reach the DB (Phase 2.1.b).
+	if _, err := notifier.ParseProviderType(string(req.ProviderType)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	// Validate and set defaults for ThrottleSeconds (1-3600 seconds)
 	if req.ThrottleSeconds <= 0 || req.ThrottleSeconds > 3600 {
 		req.ThrottleSeconds = 5
@@ -76,6 +84,11 @@ func (s *RESTServer) updateNotification(c *gin.Context) {
 		return
 	}
 	req.ID = id
+
+	if _, err := notifier.ParseProviderType(string(req.ProviderType)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	if err := s.notifier.UpdateConfig(&req); err != nil {
 		respondDatabaseError(c, err)

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,36 +38,96 @@ const (
 // notificationColumns is the SQL column list for notification queries.
 const notificationColumns = `id, name, provider_type, config, events, enabled, throttle_seconds, created_at, updated_at`
 
-// Provider types
+// ProviderType is the typed enum of supported notification provider kinds.
+// Same template as integration.ArrType (Phase 2.1.a): typed string + Scan
+// + Value + ParseProviderType for boundary validation. Closes T2 (Provider
+// drift) on the notifier side.
+type ProviderType string
+
+// Provider types — all known notification providers.
 const (
-	ProviderDiscord    = "discord"
-	ProviderPushover   = "pushover"
-	ProviderTelegram   = "telegram"
-	ProviderSlack      = "slack"
-	ProviderEmail      = "email"
-	ProviderGotify     = "gotify"
-	ProviderNtfy       = "ntfy"
-	ProviderWhatsApp   = "whatsapp"
-	ProviderSignal     = "signal"
-	ProviderBark       = "bark"
-	ProviderGoogleChat = "googlechat"
-	ProviderIFTTT      = "ifttt"
-	ProviderJoin       = "join"
-	ProviderMattermost = "mattermost"
-	ProviderMatrix     = "matrix"
-	ProviderPushbullet = "pushbullet"
-	ProviderRocketchat = "rocketchat"
-	ProviderTeams      = "teams"
-	ProviderZulip      = "zulip"
-	ProviderGeneric    = "generic"
-	ProviderCustom     = "custom"
+	ProviderDiscord    ProviderType = "discord"
+	ProviderPushover   ProviderType = "pushover"
+	ProviderTelegram   ProviderType = "telegram"
+	ProviderSlack      ProviderType = "slack"
+	ProviderEmail      ProviderType = "email"
+	ProviderGotify     ProviderType = "gotify"
+	ProviderNtfy       ProviderType = "ntfy"
+	ProviderWhatsApp   ProviderType = "whatsapp"
+	ProviderSignal     ProviderType = "signal"
+	ProviderBark       ProviderType = "bark"
+	ProviderGoogleChat ProviderType = "googlechat"
+	ProviderIFTTT      ProviderType = "ifttt"
+	ProviderJoin       ProviderType = "join"
+	ProviderMattermost ProviderType = "mattermost"
+	ProviderMatrix     ProviderType = "matrix"
+	ProviderPushbullet ProviderType = "pushbullet"
+	ProviderRocketchat ProviderType = "rocketchat"
+	ProviderTeams      ProviderType = "teams"
+	ProviderZulip      ProviderType = "zulip"
+	ProviderGeneric    ProviderType = "generic"
+	ProviderCustom     ProviderType = "custom"
 )
 
-// NotificationConfig represents a notification provider configuration
+// validProviderTypes is the authoritative set for boundary validation.
+var validProviderTypes = map[ProviderType]bool{
+	ProviderDiscord: true, ProviderPushover: true, ProviderTelegram: true,
+	ProviderSlack: true, ProviderEmail: true, ProviderGotify: true,
+	ProviderNtfy: true, ProviderWhatsApp: true, ProviderSignal: true,
+	ProviderBark: true, ProviderGoogleChat: true, ProviderIFTTT: true,
+	ProviderJoin: true, ProviderMattermost: true, ProviderMatrix: true,
+	ProviderPushbullet: true, ProviderRocketchat: true, ProviderTeams: true,
+	ProviderZulip: true, ProviderGeneric: true, ProviderCustom: true,
+}
+
+// ParseProviderType validates and converts a raw string to ProviderType.
+// Use at API write boundaries (create/update notification handlers).
+func ParseProviderType(s string) (ProviderType, error) {
+	p := ProviderType(s)
+	if !validProviderTypes[p] {
+		return "", fmt.Errorf("unknown provider_type %q", s)
+	}
+	return p, nil
+}
+
+// Scan implements sql.Scanner so NotificationConfig.ProviderType can be
+// passed directly to rows.Scan. Unknown DB values produce errors at scan
+// time rather than silently propagating to downstream switches.
+func (p *ProviderType) Scan(value any) error {
+	if value == nil {
+		return fmt.Errorf("ProviderType: cannot scan NULL")
+	}
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("ProviderType: expected string DB value, got %T", value)
+	}
+	parsed, err := ParseProviderType(s)
+	if err != nil {
+		return fmt.Errorf("ProviderType.Scan: %w", err)
+	}
+	*p = parsed
+	return nil
+}
+
+// Value implements driver.Valuer for symmetric DB writes.
+func (p ProviderType) Value() (driver.Value, error) {
+	return string(p), nil
+}
+
+// NotificationConfig represents a notification provider configuration.
+//
+// ProviderType is the typed ProviderType enum — the compiler rejects
+// misspelled or unknown values at every comparison site, and the DB
+// row scan validates at read time via ProviderType.Scan.
 type NotificationConfig struct {
 	ID              int64           `json:"id"`
 	Name            string          `json:"name"`
-	ProviderType    string          `json:"provider_type"`
+	ProviderType    ProviderType    `json:"provider_type"`
 	Config          json.RawMessage `json:"config"`
 	Events          []string        `json:"events"`
 	Enabled         bool            `json:"enabled"`
@@ -609,7 +670,7 @@ func (n *Notifier) extractAggregateID(data map[string]interface{}) string {
 }
 
 // providerLabels maps provider types to human-readable labels
-var providerLabels = map[string]string{
+var providerLabels = map[ProviderType]string{
 	ProviderDiscord:    "Discord",
 	ProviderPushover:   "Pushover",
 	ProviderTelegram:   "Telegram",
@@ -633,12 +694,15 @@ var providerLabels = map[string]string{
 	ProviderCustom:     "Custom (Shoutrrr URL)",
 }
 
-// getProviderLabel returns a human-readable label for the provider type
-func (n *Notifier) getProviderLabel(providerType string) string {
+// getProviderLabel returns a human-readable label for the provider type.
+// Falls back to the raw provider string if not found in the labels map
+// (defensive — should not happen since ParseProviderType validates input,
+// but Scan-rejected types or future additions could conceivably land here).
+func (n *Notifier) getProviderLabel(providerType ProviderType) string {
 	if label, ok := providerLabels[providerType]; ok {
 		return label
 	}
-	return providerType
+	return string(providerType)
 }
 
 func (n *Notifier) buildShoutrrrURL(cfg *NotificationConfig) (string, error) {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -90,7 +90,7 @@ func TestProviderConstants(t *testing.T) {
 	// Verify provider constants exist and have expected values
 	tests := []struct {
 		name     string
-		constant string
+		constant ProviderType
 		expected string
 	}{
 		{"Discord", ProviderDiscord, "discord"},
@@ -118,7 +118,7 @@ func TestProviderConstants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.constant != tt.expected {
+			if string(tt.constant) != tt.expected {
 				t.Errorf("Provider%s = %q, want %q", tt.name, tt.constant, tt.expected)
 			}
 		})
@@ -1263,7 +1263,7 @@ func TestNotifier_GetProviderLabel(t *testing.T) {
 	n := NewNotifier(tdb.DB, eb)
 
 	tests := []struct {
-		provider string
+		provider ProviderType
 		expected string
 	}{
 		{ProviderDiscord, "Discord"},
@@ -1291,7 +1291,7 @@ func TestNotifier_GetProviderLabel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.provider, func(t *testing.T) {
+		t.Run(string(tt.provider), func(t *testing.T) {
 			label := n.getProviderLabel(tt.provider)
 			if label != tt.expected {
 				t.Errorf("getProviderLabel(%q) = %q, want %q", tt.provider, label, tt.expected)

--- a/internal/notifier/url_builders.go
+++ b/internal/notifier/url_builders.go
@@ -27,7 +27,7 @@ func normalizeAPIURL(rawURL string) string {
 }
 
 // urlBuilders maps provider types to their URL builders
-var urlBuilders = map[string]URLBuilder{
+var urlBuilders = map[ProviderType]URLBuilder{
 	ProviderDiscord:    &discordBuilder{},
 	ProviderPushover:   &pushoverBuilder{},
 	ProviderTelegram:   &telegramBuilder{},

--- a/internal/notifier/url_builders_test.go
+++ b/internal/notifier/url_builders_test.go
@@ -212,7 +212,7 @@ func TestNtfyBuilder_BuildURL(t *testing.T) {
 
 func TestUrlBuilders_MapCompleteness(t *testing.T) {
 	// Verify all providers have builders
-	expectedProviders := []string{
+	expectedProviders := []ProviderType{
 		ProviderDiscord,
 		ProviderPushover,
 		ProviderSlack,
@@ -237,7 +237,7 @@ func TestUrlBuilders_MapCompleteness(t *testing.T) {
 	}
 
 	for _, provider := range expectedProviders {
-		t.Run(provider, func(t *testing.T) {
+		t.Run(string(provider), func(t *testing.T) {
 			if _, ok := urlBuilders[provider]; !ok {
 				t.Errorf("Missing URL builder for provider: %s", provider)
 			}
@@ -310,7 +310,7 @@ func BenchmarkNtfyBuilder_BuildURL(b *testing.B) {
 }
 
 func BenchmarkUrlBuilderLookup(b *testing.B) {
-	providers := []string{
+	providers := []ProviderType{
 		ProviderDiscord,
 		ProviderSlack,
 		ProviderTelegram,


### PR DESCRIPTION
Second enum in the Phase 2.1 sweep. Same template as #192 (ArrType): typed string + ParseProviderType + Scan + Value + boundary validation at API write sites + the import boundary.

ProviderType has 21 constants (Discord, Slack, Telegram, … through Generic and Custom). The bare-string field was accepting arbitrary values that failed later at urlBuilders lookup with the generic "unknown provider type" — now they're caught at the BindJSON / Scan / import boundaries.

## Sites updated

- `type ProviderType string` + all 21 typed constants + `validProviderTypes` map
- `ParseProviderType`, `(*ProviderType).Scan`, `ProviderType.Value`
- `NotificationConfig.ProviderType` field typed
- `providerLabels` and `urlBuilders` maps keyed by `ProviderType`
- `getProviderLabel(providerType ProviderType)` signature
- Boundary validation:
  - `createNotification` after BindJSON
  - `updateNotification` after BindJSON
  - `importNotifications` per row (skip with Errorf log, consistent with the per-row resilience pattern from the import flow)

## Test fixups

- `TestProviderConstants`: tt.constant typed; compare via `string(tt.constant)`
- `TestUrlBuilders_MapCompleteness`: expectedProviders slice typed
- `TestGetProviderLabel`: provider field typed
- `t.Run` calls cast `string(provider)` (t.Run takes a name string)
- `BenchmarkUrlBuilderLookup`: typed slice

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — full suite passes

## Context

Phase 2 progress:
- ✅ 2.3 HealthErrorType category map (#190)
- ✅ 2.4 ScanProgressView snapshot (#191)
- ✅ 2.1.a ArrType (#192)
- 🟡 **2.1.b ProviderType** *(this PR)*
- 2.1.c-g remaining (ScanStatus, DownloadState, DownloadStatus, Protocol, DetectionMode)
- 2.2 typed event envelope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for notification provider types during creation and updates—invalid values are now rejected with a 400 Bad Request error.
  * Database reads now validate provider types to prevent invalid values from being stored.
  * Improved error handling and robustness for notification configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->