### PR TITLE
fix(events): event-data Parse functions return error, not bool

### DIFF
--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -189,10 +190,15 @@ type CorruptionEventData struct {
 }
 
 // ParseCorruptionEventData extracts typed corruption data from an event.
-func (e *Event) ParseCorruptionEventData() (CorruptionEventData, bool) {
+//
+// Returns an error rather than a bool (was: (data, ok)) so callers that
+// ignore the second return value get a compile warning from errcheck /
+// staticcheck rather than silently accepting a zero-value event with an
+// empty file_path. Closes audit T3.
+func (e *Event) ParseCorruptionEventData() (CorruptionEventData, error) {
 	filePath, ok := e.GetString("file_path")
 	if !ok {
-		return CorruptionEventData{}, false
+		return CorruptionEventData{}, fmt.Errorf("corruption event %s missing required field file_path", e.AggregateID)
 	}
 	return CorruptionEventData{
 		FilePath:       filePath,
@@ -204,7 +210,7 @@ func (e *Event) ParseCorruptionEventData() (CorruptionEventData, bool) {
 		AutoRemediate:  e.GetBoolOr("auto_remediate", false),
 		DryRun:         e.GetBoolOr("dry_run", false),
 		BatchThrottled: e.GetBoolOr("batch_throttled", false),
-	}, true
+	}, nil
 }
 
 // SearchCompletedEventData contains data for SearchCompleted events.
@@ -217,10 +223,11 @@ type SearchCompletedEventData struct {
 }
 
 // ParseSearchCompletedEventData extracts typed search completed data from an event.
-func (e *Event) ParseSearchCompletedEventData() (SearchCompletedEventData, bool) {
+// Returns error (was bool) so silent zero-value events can't slip past callers.
+func (e *Event) ParseSearchCompletedEventData() (SearchCompletedEventData, error) {
 	filePath, ok := e.GetString("file_path")
 	if !ok {
-		return SearchCompletedEventData{}, false
+		return SearchCompletedEventData{}, fmt.Errorf("search-completed event %s missing required field file_path", e.AggregateID)
 	}
 	metadata, _ := e.GetMap("metadata")
 	return SearchCompletedEventData{
@@ -229,7 +236,7 @@ func (e *Event) ParseSearchCompletedEventData() (SearchCompletedEventData, bool)
 		PathID:   e.GetInt64Or("path_id", 0),
 		Metadata: metadata,
 		IsRetry:  e.GetBoolOr("is_retry", false),
-	}, true
+	}, nil
 }
 
 // RetryEventData contains data for RetryScheduled events.
@@ -239,13 +246,14 @@ type RetryEventData struct {
 }
 
 // ParseRetryEventData extracts typed retry data from an event.
-func (e *Event) ParseRetryEventData() (RetryEventData, bool) {
+// Returns error (was bool) so silent zero-value events can't slip past callers.
+func (e *Event) ParseRetryEventData() (RetryEventData, error) {
 	filePath, ok := e.GetString("file_path")
 	if !ok {
-		return RetryEventData{}, false
+		return RetryEventData{}, fmt.Errorf("retry event %s missing required field file_path", e.AggregateID)
 	}
 	return RetryEventData{
 		FilePath: filePath,
 		PathID:   e.GetInt64Or("path_id", 0),
-	}, true
+	}, nil
 }

--- a/internal/domain/events_test.go
+++ b/internal/domain/events_test.go
@@ -355,9 +355,9 @@ func TestEvent_ParseCorruptionEventData(t *testing.T) {
 			},
 		}
 
-		data, ok := e.ParseCorruptionEventData()
-		if !ok {
-			t.Fatal("ParseCorruptionEventData() returned false for valid event")
+		data, err := e.ParseCorruptionEventData()
+		if err != nil {
+			t.Fatalf("ParseCorruptionEventData() returned error for valid event: %v", err)
 		}
 		if data.FilePath != "/media/movies/test.mkv" {
 			t.Errorf("FilePath = %q, want %q", data.FilePath, "/media/movies/test.mkv")
@@ -381,9 +381,9 @@ func TestEvent_ParseCorruptionEventData(t *testing.T) {
 			},
 		}
 
-		_, ok := e.ParseCorruptionEventData()
-		if ok {
-			t.Error("ParseCorruptionEventData() should return false when file_path is missing")
+		_, err := e.ParseCorruptionEventData()
+		if err == nil {
+			t.Error("ParseCorruptionEventData() should return an error when file_path is missing")
 		}
 	})
 }
@@ -402,9 +402,9 @@ func TestEvent_ParseSearchCompletedEventData(t *testing.T) {
 			},
 		}
 
-		data, ok := e.ParseSearchCompletedEventData()
-		if !ok {
-			t.Fatal("ParseSearchCompletedEventData() returned false for valid event")
+		data, err := e.ParseSearchCompletedEventData()
+		if err != nil {
+			t.Fatalf("ParseSearchCompletedEventData() returned error for valid event: %v", err)
 		}
 		if data.FilePath != "/media/movies/test.mkv" {
 			t.Errorf("FilePath = %q, want %q", data.FilePath, "/media/movies/test.mkv")
@@ -428,9 +428,9 @@ func TestEvent_ParseSearchCompletedEventData(t *testing.T) {
 			},
 		}
 
-		_, ok := e.ParseSearchCompletedEventData()
-		if ok {
-			t.Error("ParseSearchCompletedEventData() should return false when file_path is missing")
+		_, err := e.ParseSearchCompletedEventData()
+		if err == nil {
+			t.Error("ParseSearchCompletedEventData() should return an error when file_path is missing")
 		}
 	})
 }
@@ -446,9 +446,9 @@ func TestEvent_ParseRetryEventData(t *testing.T) {
 			},
 		}
 
-		data, ok := e.ParseRetryEventData()
-		if !ok {
-			t.Fatal("ParseRetryEventData() returned false for valid event")
+		data, err := e.ParseRetryEventData()
+		if err != nil {
+			t.Fatalf("ParseRetryEventData() returned error for valid event: %v", err)
 		}
 		if data.FilePath != "/media/movies/test.mkv" {
 			t.Errorf("FilePath = %q, want %q", data.FilePath, "/media/movies/test.mkv")
@@ -666,8 +666,8 @@ func TestEvent_ParseRetryEventData_MissingFilePath(t *testing.T) {
 		},
 	}
 
-	_, ok := e.ParseRetryEventData()
-	if ok {
-		t.Error("ParseRetryEventData() should return false when file_path is missing")
+	_, err := e.ParseRetryEventData()
+	if err == nil {
+		t.Error("ParseRetryEventData() should return an error when file_path is missing")
 	}
 }

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -136,9 +136,9 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 	corruptionID := event.AggregateID
 
 	// Use type-safe event data parsing
-	data, ok := event.ParseRetryEventData()
-	if !ok || data.FilePath == "" {
-		logger.Warnf("Invalid retry event data for %s: missing or empty file path", corruptionID)
+	data, err := event.ParseRetryEventData()
+	if err != nil || data.FilePath == "" {
+		logger.Warnf("Invalid retry event data for %s: %v", corruptionID, err)
 		r.publishError(corruptionID, domain.SearchFailed, "missing or empty file_path in retry event")
 		return
 	}
@@ -233,9 +233,9 @@ func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {
 	corruptionID := event.AggregateID
 
 	// Use type-safe event data parsing
-	data, ok := event.ParseCorruptionEventData()
-	if !ok {
-		logger.Errorf("Missing file_path in event data for corruption %s", corruptionID)
+	data, err := event.ParseCorruptionEventData()
+	if err != nil {
+		logger.Errorf("Invalid corruption event %s: %v", corruptionID, err)
 		r.publishError(corruptionID, domain.DeletionFailed, "missing file_path in event data")
 		return
 	}

--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -503,9 +503,9 @@ func (v *VerifierService) handleSearchCompleted(event domain.Event) {
 	v.cancelExistingVerification(corruptionID)
 
 	// Use type-safe event data parsing
-	data, ok := event.ParseSearchCompletedEventData()
-	if !ok {
-		logger.Errorf("Missing file_path in SearchCompleted event for %s", corruptionID)
+	data, err := event.ParseSearchCompletedEventData()
+	if err != nil {
+		logger.Errorf("Invalid SearchCompleted event for %s: %v", corruptionID, err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Closes audit finding **T3** (event envelope). Three event-data Parse helpers (\`ParseCorruptionEventData\`, \`ParseSearchCompletedEventData\`, \`ParseRetryEventData\`) returned \`(data, bool)\`. A caller that ignored the second return — accidentally or otherwise — silently accepted a zero-value event with an empty \`file_path\`, which is precisely the silent-failure class the audit flagged.

Switching the signatures to \`(data, error)\` makes that mistake a compile error: \`errcheck\` / \`staticcheck\` flag any unhandled error, and the message now carries the aggregate ID so log lines become forensically useful.

## Changes

- \`internal/domain/events.go\`: Parse functions now return \`error\` with \`fmt.Errorf(\"... event %s missing required field file_path\", e.AggregateID)\` messages.
- \`internal/services/remediator.go\` (two callers): \`data, ok :=\` → \`data, err :=\`; log the actual error via \`%v\`.
- \`internal/services/verifier.go\` (one caller): same pattern.
- \`internal/domain/events_test.go\` (6 assertions): assert on \`err != nil\` / \`err == nil\` instead of \`!ok\` / \`ok\`.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/domain/... ./internal/services/...\` — pass
- [x] \`/usr/bin/golangci-lint run ./internal/domain/... ./internal/services/...\` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced event processing error handling with more detailed error messages when parsing fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->