### PR TITLE
feat(repository): extract sessions into typed repository (Phase 3.1)

### DIFF
--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -12,6 +12,11 @@ import (
 	"github.com/mescon/Healarr/internal/logger"
 )
 
+// defaultSessionTTL is how long a newly issued session token remains valid.
+// Long enough for normal browser use without daily re-logins; short enough
+// that a leaked token expires automatically if logout was missed.
+const defaultSessionTTL = 24 * time.Hour
+
 func (s *RESTServer) handleAuthSetup(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -109,16 +114,22 @@ func (s *RESTServer) handleLogin(c *gin.Context) {
 	// key. Sessions live in their own table with a 24h expiry and can be
 	// invalidated via logout, decoupled from the long-lived integration key
 	// used by Sonarr/Radarr webhooks (Phase 1.3 P1 finding).
-	token, expiresAt, err := s.createSession(ctx, c.Request.UserAgent(), c.ClientIP())
+	token, err := auth.GenerateAPIKey()
 	if err != nil {
-		logger.Errorf("Login: failed to create session: %v", err)
+		logger.Errorf("Login: failed to generate session token: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
+		return
+	}
+	session, err := s.sessions.Create(ctx, token, defaultSessionTTL, c.Request.UserAgent(), c.ClientIP())
+	if err != nil {
+		logger.Errorf("Login: failed to persist session: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create session"})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"token":      token,
-		"expires_at": expiresAt.Format(time.RFC3339),
+		"token":      session.Token,
+		"expires_at": session.ExpiresAt.Format(time.RFC3339),
 		"message":    "Login successful",
 	})
 	logger.Infof("User logged in successfully from %s", c.ClientIP())

--- a/internal/api/handlers_auth_test.go
+++ b/internal/api/handlers_auth_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/eventbus"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // =============================================================================
@@ -78,6 +79,7 @@ func createAuthErrorTestServer(t *testing.T, db *sql.DB) *RESTServer {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/eventbus"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // setupTestDB creates a temporary database with schema for testing
@@ -125,6 +126,7 @@ func setupTestServer(t *testing.T, db *sql.DB) (*gin.Engine, func()) {
 		db:       db,
 		eventBus: eb,
 		hub:      hub,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Register routes manually for testing
@@ -434,6 +436,7 @@ func TestAuthMiddleware_NoToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key
@@ -469,6 +472,7 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key
@@ -505,6 +509,7 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key
@@ -541,6 +546,7 @@ func TestAuthMiddleware_BearerToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key
@@ -577,6 +583,7 @@ func TestAuthMiddleware_QueryToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key
@@ -687,6 +694,7 @@ func setupAuthTestServer(t *testing.T, db *sql.DB) (*gin.Engine, string, func())
 		db:       db,
 		eventBus: eb,
 		hub:      hub,
+		sessions: repository.NewSessionRepository(db),
 	}
 
 	// Setup API key for authentication

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/metrics"
 	"github.com/mescon/Healarr/internal/notifier"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/services"
 	"github.com/mescon/Healarr/internal/web"
 )
@@ -68,6 +69,7 @@ type RESTServer struct {
 	hub            *WebSocketHub
 	startTime      time.Time
 	toolChecker    *integration.ToolChecker
+	sessions       *repository.SessionRepository
 }
 
 // ServerDeps contains all dependencies required for the REST server
@@ -213,6 +215,7 @@ func NewRESTServer(deps ServerDeps) *RESTServer {
 		hub:            NewWebSocketHub(deps.EventBus, deps.Metrics),
 		startTime:      time.Now(),
 		toolChecker:    toolChecker,
+		sessions:       repository.NewSessionRepository(deps.DB),
 	}
 
 	s.setupRoutes()
@@ -615,10 +618,18 @@ func (s *RESTServer) verifyAPIToken(token string) error {
 	}
 
 	// Session token path (browsers).
-	if sessErr := s.validateSession(ctx, token); sessErr == nil {
+	sessErr := s.sessions.Validate(ctx, token)
+	if sessErr == nil {
+		// Bump last_used_at on a successful validation. We don't fail the
+		// request if this update errors — the session is valid, the bump
+		// is purely diagnostic ("when did this session last act?").
+		if bumpErr := s.sessions.BumpLastUsed(ctx, token); bumpErr != nil {
+			logger.Debugf("session last_used_at update failed: %v", bumpErr)
+		}
 		return nil
-	} else if !errors.Is(sessErr, sql.ErrNoRows) && !errors.Is(sessErr, errSessionExpired) {
-		// Unknown token (no row) and expired sessions both surface as
+	}
+	if !errors.Is(sessErr, repository.ErrNotFound) && !errors.Is(sessErr, repository.ErrSessionExpired) {
+		// Unknown token and expired sessions both surface as
 		// errInvalidToken to the middleware; any OTHER error (e.g. DB
 		// failure) needs to be returned so the middleware logs it
 		// distinctly rather than treating it as a bad token.

--- a/internal/api/rest_test.go
+++ b/internal/api/rest_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/eventbus"
+	"github.com/mescon/Healarr/internal/repository"
 
 	_ "modernc.org/sqlite" // SQLite driver
 )
@@ -522,7 +523,7 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'test-secret-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db}
+		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
 
 		err = s.verifyAPIToken("test-secret-key")
 		assert.NoError(t, err)
@@ -550,7 +551,7 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db}
+		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
 
 		err = s.verifyAPIToken("wrong-key")
 		assert.Equal(t, errInvalidToken, err)
@@ -564,7 +565,7 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db}
+		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
 
 		err = s.verifyAPIToken("any-token")
 		assert.Error(t, err)
@@ -576,7 +577,7 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		s := &RESTServer{db: db}
+		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
 
 		err = s.verifyAPIToken("any-token")
 		assert.Error(t, err)
@@ -595,7 +596,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -629,7 +630,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -655,7 +656,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'valid-api-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -676,7 +677,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		defer db.Close()
 
 		// No settings table - will cause DB error
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -702,7 +703,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'bearer-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -728,7 +729,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'query-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -754,7 +755,7 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'apikey-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New()}
+		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,88 +1,12 @@
 package api
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/logger"
 )
-
-// defaultSessionTTL is how long a newly issued session token remains valid.
-// Long enough for normal browser use without daily re-logins; short enough
-// that a leaked token expires automatically if logout was missed.
-const defaultSessionTTL = 24 * time.Hour
-
-// errSessionExpired indicates a session row exists but is past its expires_at.
-var errSessionExpired = errors.New("session expired")
-
-// createSession generates a fresh session token, persists it with an expiry,
-// and returns the token + expiry time for the caller to send to the client.
-//
-// The token uses the same 32-byte cryptographic primitive as the master API
-// key but is stored in a separate table so it can be expired/revoked
-// independently of the integration key used by Sonarr/Radarr webhooks.
-func (s *RESTServer) createSession(ctx context.Context, userAgent, ipAddress string) (string, time.Time, error) {
-	token, err := auth.GenerateAPIKey()
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("generate session token: %w", err)
-	}
-
-	now := time.Now().UTC()
-	expiresAt := now.Add(defaultSessionTTL)
-
-	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, token, now, expiresAt, now, userAgent, ipAddress)
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("persist session: %w", err)
-	}
-
-	return token, expiresAt, nil
-}
-
-// validateSession looks up the token in the sessions table. If found and
-// unexpired, it bumps last_used_at and returns nil. If the token isn't a
-// known session, returns sql.ErrNoRows so the caller can distinguish
-// "this is not a session token, try the master key path" from "this is
-// an expired/known-bad session token."
-func (s *RESTServer) validateSession(ctx context.Context, token string) error {
-	var expiresAt time.Time
-	err := s.db.QueryRowContext(ctx,
-		`SELECT expires_at FROM sessions WHERE token = ?`, token).Scan(&expiresAt)
-	if err != nil {
-		// sql.ErrNoRows or any other DB error — propagate so the caller
-		// can decide whether to try the master-key path.
-		return err
-	}
-
-	if time.Now().UTC().After(expiresAt) {
-		return errSessionExpired
-	}
-
-	// Bump last_used_at on a successful validation. We don't fail the
-	// request if this update errors — the session is valid, the bump is
-	// purely diagnostic ("when did this session last act?").
-	if _, updateErr := s.db.ExecContext(ctx,
-		`UPDATE sessions SET last_used_at = ? WHERE token = ?`,
-		time.Now().UTC(), token); updateErr != nil {
-		logger.Debugf("session last_used_at update failed for token: %v", updateErr)
-	}
-
-	return nil
-}
-
-// deleteSession removes a session row, used by logout.
-func (s *RESTServer) deleteSession(ctx context.Context, token string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE token = ?`, token)
-	return err
-}
 
 // handleLogout invalidates the session token from the request. Returns 200
 // in both the "session deleted" and "no such session" cases — logout should
@@ -95,28 +19,10 @@ func (s *RESTServer) handleLogout(c *gin.Context) {
 		return
 	}
 
-	if err := s.deleteSession(c.Request.Context(), token); err != nil {
+	if err := s.sessions.Delete(c.Request.Context(), token); err != nil {
 		// DB failure during logout is logged but doesn't change the
 		// response — the token might still be valid if we say so.
 		logger.Errorf("Logout: failed to delete session: %v", err)
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "Logged out"})
 }
-
-// expiredSessionsSweep deletes session rows whose expires_at is in the past.
-// Called periodically from the existing maintenance goroutine; bounded by
-// the number of expired sessions, so a single DELETE is fine without LIMIT.
-//
-//nolint:unused // exposed for the maintenance scheduler to wire in
-func (s *RESTServer) expiredSessionsSweep(ctx context.Context) (int64, error) {
-	res, err := s.db.ExecContext(ctx,
-		`DELETE FROM sessions WHERE expires_at < ?`, time.Now().UTC())
-	if err != nil {
-		return 0, err
-	}
-	n, _ := res.RowsAffected()
-	return n, nil
-}
-
-// (no errInvalidSession alias yet — callers in this package use sql.ErrNoRows
-// directly via errors.Is.)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,17 @@
+// Package repository contains domain-specific persistence adapters.
+//
+// The goal of this package is to keep raw SQL out of handler and service
+// code: each repository wraps the queries for one aggregate (sessions,
+// notifications, scans, ...) behind a typed Go API. Callers exchange
+// domain values and typed errors with the repository; only the repository
+// itself knows the schema, parameter order, and SQL dialect.
+//
+// This is the Phase 3 foundation; see remediation_plan.md.
+package repository
+
+import "errors"
+
+// ErrNotFound is returned by repository lookups when no row matches.
+// Callers should compare with errors.Is so DB-driver wrappings stay
+// transparent.
+var ErrNotFound = errors.New("repository: not found")

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrSessionExpired is returned when a session row exists but its
+// expires_at is in the past. Distinguished from ErrNotFound so callers
+// can decide whether to surface "your session expired, log in again"
+// versus "this token isn't ours, try a different auth path."
+var ErrSessionExpired = errors.New("repository: session expired")
+
+// Session is a value snapshot of a row in the sessions table.
+type Session struct {
+	Token      string
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	LastUsedAt time.Time
+	UserAgent  string
+	IPAddress  string
+}
+
+// SessionRepository persists per-login browser session tokens.
+//
+// Sessions are kept separate from the master API key (used by Sonarr /
+// Radarr integrations) so a leaked browser token can be revoked without
+// rotating the integration key. See migration 005_sessions.sql.
+type SessionRepository struct {
+	db *sql.DB
+}
+
+// NewSessionRepository returns a repository backed by the given DB handle.
+func NewSessionRepository(db *sql.DB) *SessionRepository {
+	return &SessionRepository{db: db}
+}
+
+// Create inserts a new session row valid for ttl from now.
+func (r *SessionRepository) Create(ctx context.Context, token string, ttl time.Duration, userAgent, ipAddress string) (Session, error) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(ttl)
+
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, token, now, expiresAt, now, userAgent, ipAddress)
+	if err != nil {
+		return Session{}, fmt.Errorf("persist session: %w", err)
+	}
+
+	return Session{
+		Token:      token,
+		CreatedAt:  now,
+		ExpiresAt:  expiresAt,
+		LastUsedAt: now,
+		UserAgent:  userAgent,
+		IPAddress:  ipAddress,
+	}, nil
+}
+
+// Validate returns nil if the token corresponds to a known, unexpired
+// session row. Returns ErrNotFound if no row matches, ErrSessionExpired
+// if the row exists but is past expires_at, or a wrapped DB error
+// otherwise.
+//
+// Validate does NOT update last_used_at; callers that want to record
+// activity should follow with BumpLastUsed (whose error is purely
+// diagnostic and safe to log-and-ignore).
+func (r *SessionRepository) Validate(ctx context.Context, token string) error {
+	var expiresAt time.Time
+	err := r.db.QueryRowContext(ctx,
+		`SELECT expires_at FROM sessions WHERE token = ?`, token).Scan(&expiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("lookup session: %w", err)
+	}
+	if time.Now().UTC().After(expiresAt) {
+		return ErrSessionExpired
+	}
+	return nil
+}
+
+// BumpLastUsed updates last_used_at to now for the given token. Returns
+// nil if no row matched — this update is diagnostic ("when did this
+// session last act?"), so a missing row is not an error.
+func (r *SessionRepository) BumpLastUsed(ctx context.Context, token string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE sessions SET last_used_at = ? WHERE token = ?`,
+		time.Now().UTC(), token)
+	return err
+}
+
+// Delete removes the session row for token. Returns nil if no row
+// matched — logout is idempotent from the client's perspective.
+func (r *SessionRepository) Delete(ctx context.Context, token string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM sessions WHERE token = ?`, token)
+	return err
+}
+
+// SweepExpired deletes session rows whose expires_at is in the past and
+// returns the number of rows removed. Bounded by the number of expired
+// sessions, so a single DELETE without LIMIT is fine.
+func (r *SessionRepository) SweepExpired(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM sessions WHERE expires_at < ?`, time.Now().UTC())
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}

--- a/internal/repository/session_test.go
+++ b/internal/repository/session_test.go
@@ -1,0 +1,195 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const sessionSchema = `
+CREATE TABLE sessions (
+	token         TEXT      PRIMARY KEY,
+	created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	expires_at    TIMESTAMP NOT NULL,
+	last_used_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	user_agent    TEXT,
+	ip_address    TEXT
+);
+`
+
+func newSessionTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(sessionSchema); err != nil {
+		t.Fatalf("create sessions schema: %v", err)
+	}
+	return db
+}
+
+func TestSessionRepository_Create_persistsRow(t *testing.T) {
+	repo := NewSessionRepository(newSessionTestDB(t))
+
+	session, err := repo.Create(context.Background(), "tok-abc", time.Hour, "ua/1.0", "192.0.2.1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if session.Token != "tok-abc" {
+		t.Errorf("Token = %q, want %q", session.Token, "tok-abc")
+	}
+	if !session.ExpiresAt.After(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("ExpiresAt = %v, expected ~1h in future", session.ExpiresAt)
+	}
+	if session.UserAgent != "ua/1.0" || session.IPAddress != "192.0.2.1" {
+		t.Errorf("metadata not stored: ua=%q ip=%q", session.UserAgent, session.IPAddress)
+	}
+}
+
+func TestSessionRepository_Validate_active(t *testing.T) {
+	repo := NewSessionRepository(newSessionTestDB(t))
+	if _, err := repo.Create(context.Background(), "tok", time.Hour, "", ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := repo.Validate(context.Background(), "tok"); err != nil {
+		t.Errorf("Validate active token returned %v, want nil", err)
+	}
+}
+
+func TestSessionRepository_Validate_notFound(t *testing.T) {
+	repo := NewSessionRepository(newSessionTestDB(t))
+
+	err := repo.Validate(context.Background(), "no-such-token")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Validate unknown token = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSessionRepository_Validate_expired(t *testing.T) {
+	db := newSessionTestDB(t)
+	// Insert an already-expired row directly so we don't depend on time travel.
+	past := time.Now().UTC().Add(-time.Hour)
+	if _, err := db.Exec(
+		`INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"old-tok", past, past, past, "", "",
+	); err != nil {
+		t.Fatalf("seed expired session: %v", err)
+	}
+
+	err := NewSessionRepository(db).Validate(context.Background(), "old-tok")
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Errorf("Validate expired token = %v, want ErrSessionExpired", err)
+	}
+}
+
+func TestSessionRepository_BumpLastUsed_updatesRow(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewSessionRepository(db)
+
+	originalLastUsed := time.Now().UTC().Add(-time.Hour)
+	if _, err := db.Exec(
+		`INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"tok", originalLastUsed, time.Now().UTC().Add(time.Hour), originalLastUsed, "", "",
+	); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if err := repo.BumpLastUsed(context.Background(), "tok"); err != nil {
+		t.Fatalf("BumpLastUsed: %v", err)
+	}
+
+	var bumpedRaw string
+	if err := db.QueryRow(`SELECT last_used_at FROM sessions WHERE token = ?`, "tok").Scan(&bumpedRaw); err != nil {
+		t.Fatalf("query last_used_at: %v", err)
+	}
+	bumped, err := time.Parse(time.RFC3339Nano, bumpedRaw)
+	if err != nil {
+		// SQLite TIMESTAMP storage varies — fall back to the common forms.
+		bumped, err = time.Parse("2006-01-02 15:04:05.999999999-07:00", bumpedRaw)
+		if err != nil {
+			t.Fatalf("parse last_used_at %q: %v", bumpedRaw, err)
+		}
+	}
+	if !bumped.After(originalLastUsed) {
+		t.Errorf("last_used_at = %v not after original %v", bumped, originalLastUsed)
+	}
+}
+
+func TestSessionRepository_BumpLastUsed_missingTokenIsNotError(t *testing.T) {
+	repo := NewSessionRepository(newSessionTestDB(t))
+	// Bumping a token that doesn't exist is fine — last_used_at is purely
+	// diagnostic, so a no-op update isn't an error condition.
+	if err := repo.BumpLastUsed(context.Background(), "nope"); err != nil {
+		t.Errorf("BumpLastUsed on missing token: %v", err)
+	}
+}
+
+func TestSessionRepository_Delete_removesRow(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewSessionRepository(db)
+
+	if _, err := repo.Create(context.Background(), "tok", time.Hour, "", ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.Delete(context.Background(), "tok"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE token = ?`, "tok").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}
+
+func TestSessionRepository_SweepExpired(t *testing.T) {
+	db := newSessionTestDB(t)
+	repo := NewSessionRepository(db)
+
+	now := time.Now().UTC()
+	rows := []struct {
+		token   string
+		expires time.Time
+	}{
+		{"keep-1", now.Add(time.Hour)},
+		{"keep-2", now.Add(2 * time.Hour)},
+		{"drop-1", now.Add(-time.Minute)},
+		{"drop-2", now.Add(-time.Hour)},
+	}
+	for _, row := range rows {
+		if _, err := db.Exec(
+			`INSERT INTO sessions (token, created_at, expires_at, last_used_at, user_agent, ip_address)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			row.token, now, row.expires, now, "", "",
+		); err != nil {
+			t.Fatalf("seed %s: %v", row.token, err)
+		}
+	}
+
+	n, err := repo.SweepExpired(context.Background())
+	if err != nil {
+		t.Fatalf("SweepExpired: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("SweepExpired returned %d, want 2", n)
+	}
+
+	var remaining int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&remaining); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if remaining != 2 {
+		t.Errorf("rows remaining = %d, want 2", remaining)
+	}
+}


### PR DESCRIPTION
## Summary

First PR of Phase 3 (DB integrity + Repository layer). Introduces \`internal/repository\` and migrates the sessions table — the smallest cohesive target (5 SQL sites, no other writers) — to demonstrate the pattern.

### Design

- **\`repository.ErrNotFound\`** — shared sentinel future repos return for missing rows.
- **\`SessionRepository.Validate\`** — returns \`ErrNotFound\` / \`ErrSessionExpired\` instead of leaking \`sql.ErrNoRows\`, so callers outside the DB layer don't need to import \`database/sql\` to distinguish auth outcomes.
- **\`Create/Validate/BumpLastUsed/Delete/SweepExpired\`** — split rather than fused so \`Validate\` stays pure-read (caller decides whether to bump). \`BumpLastUsed\` is best-effort and missing-row-safe; \`Delete\` is idempotent (logout).

### Layering changes

- \`internal/api/sessions.go\` shrinks from 122 lines to just \`handleLogout\` (HTTP wrapping).
- \`defaultSessionTTL\` moves to \`handlers_auth.go\` — TTL is a policy decision owned by auth, not persistence.
- \`RESTServer\` gains a \`sessions *repository.SessionRepository\` field initialised in \`NewRESTServer\`.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/session_test.go\` covers Create, Validate (active/notfound/expired), BumpLastUsed (existing/missing), Delete, SweepExpired
- [x] Existing api tests updated: \`sessions: repository.NewSessionRepository(db)\` added to test-fixture RESTServer constructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API session tokens now automatically expire after 24 hours
  * Sessions now track user agent and client IP address for security auditing
  * Session last-used timestamps are recorded to monitor token activity
  * Automatic cleanup process removes expired sessions from the system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->