### PR TITLE
feat(repository): extract arr_instances into typed repository (Phase 3.2)

### DIFF
--- a/internal/api/handlers_arr.go
+++ b/internal/api/handlers_arr.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"database/sql"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/network"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // errInvalidURLScheme is returned when a URL has an invalid scheme.
@@ -64,44 +66,34 @@ func validateArrURL(rawURL string) error {
 }
 
 func (s *RESTServer) getArrInstances(c *gin.Context) {
-	rows, err := s.db.Query("SELECT id, name, type, url, api_key, enabled, webhook_secret FROM arr_instances")
+	rows, err := s.arrInstances.ListAll(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	instances := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var id int
-		var name, arrType, url, apiKey string
-		var enabled bool
-		var webhookSecret sql.NullString
-		if err := rows.Scan(&id, &name, &arrType, &url, &apiKey, &enabled, &webhookSecret); err != nil {
-			logger.Warnf("Failed to scan arr_instances row: %v", err)
-			continue
-		}
-		// Decrypt API key for display
-		decryptedKey, err := crypto.Decrypt(apiKey)
+	instances := make([]map[string]interface{}, 0, len(rows))
+	for _, inst := range rows {
+		decryptedKey, err := crypto.Decrypt(inst.EncryptedAPIKey)
 		if err != nil {
-			logger.Errorf("Failed to decrypt API key for instance %d: %v", id, err)
+			logger.Errorf("Failed to decrypt API key for instance %d: %v", inst.ID, err)
 			decryptedKey = "[DECRYPTION_ERROR]"
 		}
 		entry := map[string]interface{}{
-			"id":      id,
-			"name":    name,
-			"type":    arrType,
-			"url":     url,
+			"id":      inst.ID,
+			"name":    inst.Name,
+			"type":    inst.Type,
+			"url":     inst.URL,
 			"api_key": decryptedKey,
-			"enabled": enabled,
+			"enabled": inst.Enabled,
 		}
 		// Webhook secret may be NULL for legacy instances; surface a sentinel
 		// so the UI can show a "no webhook secret configured — generate one"
 		// affordance without confusing it for a normal value.
-		if webhookSecret.Valid && webhookSecret.String != "" {
-			decryptedSecret, derr := crypto.Decrypt(webhookSecret.String)
+		if inst.EncryptedWebhookSecret.Valid && inst.EncryptedWebhookSecret.String != "" {
+			decryptedSecret, derr := crypto.Decrypt(inst.EncryptedWebhookSecret.String)
 			if derr != nil {
-				logger.Errorf("Failed to decrypt webhook secret for instance %d: %v", id, derr)
+				logger.Errorf("Failed to decrypt webhook secret for instance %d: %v", inst.ID, derr)
 				decryptedSecret = "[DECRYPTION_ERROR]"
 			}
 			entry["webhook_secret"] = decryptedSecret
@@ -109,12 +101,6 @@ func (s *RESTServer) getArrInstances(c *gin.Context) {
 			entry["webhook_secret"] = nil
 		}
 		instances = append(instances, entry)
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading arr instances"})
-		logger.Errorf("Error iterating arr instances: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, instances)
@@ -142,18 +128,12 @@ func (s *RESTServer) generateInstanceName(arrType string) string {
 
 	// Count existing instances of this base type
 	var count int
-	baseType := arrType
+	ctx := context.Background()
 	if strings.HasPrefix(arrType, "whisparr") {
 		// Count all whisparr variants together
-		err := s.db.QueryRow("SELECT COUNT(*) FROM arr_instances WHERE type LIKE 'whisparr%'").Scan(&count)
-		if err != nil {
-			count = 0
-		}
+		count, _ = s.arrInstances.CountByTypePrefix(ctx, "whisparr")
 	} else {
-		err := s.db.QueryRow("SELECT COUNT(*) FROM arr_instances WHERE type = ?", baseType).Scan(&count)
-		if err != nil {
-			count = 0
-		}
+		count, _ = s.arrInstances.CountByType(ctx, arrType)
 	}
 
 	if count == 0 {
@@ -220,14 +200,18 @@ func (s *RESTServer) createArrInstance(c *gin.Context) {
 		return
 	}
 
-	result, err := s.db.Exec(
-		"INSERT INTO arr_instances (name, type, url, api_key, enabled, webhook_secret) VALUES (?, ?, ?, ?, ?, ?)",
-		instanceName, req.Type, req.URL, encryptedKey, req.Enabled, encryptedSecret)
+	id, err := s.arrInstances.Create(c.Request.Context(), repository.CreateArrInstanceParams{
+		Name:                   instanceName,
+		Type:                   req.Type,
+		URL:                    req.URL,
+		EncryptedAPIKey:        encryptedKey,
+		Enabled:                req.Enabled,
+		EncryptedWebhookSecret: encryptedSecret,
+	})
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	id, _ := result.LastInsertId()
 
 	c.JSON(http.StatusCreated, gin.H{
 		"id":             id,
@@ -258,16 +242,17 @@ func (s *RESTServer) regenerateWebhookSecret(c *gin.Context) {
 		return
 	}
 
-	result, err := s.db.Exec(
-		"UPDATE arr_instances SET webhook_secret = ? WHERE id = ?",
-		encryptedSecret, id)
-	if err != nil {
-		respondDatabaseError(c, err)
+	idInt, parseErr := strconv.ParseInt(id, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid instance ID"})
 		return
 	}
-	n, _ := result.RowsAffected()
-	if n == 0 {
+	switch err := s.arrInstances.UpdateWebhookSecret(c.Request.Context(), idInt, encryptedSecret); {
+	case errors.Is(err, repository.ErrNotFound):
 		c.JSON(http.StatusNotFound, gin.H{"error": "Instance not found"})
+		return
+	case err != nil:
+		respondDatabaseError(c, err)
 		return
 	}
 
@@ -275,9 +260,12 @@ func (s *RESTServer) regenerateWebhookSecret(c *gin.Context) {
 }
 
 func (s *RESTServer) deleteArrInstance(c *gin.Context) {
-	id := c.Param("id")
-	_, err := s.db.Exec("DELETE FROM arr_instances WHERE id = ?", id)
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid instance ID"})
+		return
+	}
+	if err := s.arrInstances.Delete(c.Request.Context(), id); err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
@@ -312,9 +300,18 @@ func (s *RESTServer) updateArrInstance(c *gin.Context) {
 		return
 	}
 
-	_, err = s.db.Exec("UPDATE arr_instances SET name = ?, type = ?, url = ?, api_key = ?, enabled = ? WHERE id = ?",
-		req.Name, req.Type, req.URL, encryptedKey, req.Enabled, id)
-	if err != nil {
+	idInt, parseErr := strconv.ParseInt(id, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid instance ID"})
+		return
+	}
+	if err := s.arrInstances.Update(c.Request.Context(), idInt, repository.UpdateArrInstanceParams{
+		Name:            req.Name,
+		Type:            req.Type,
+		URL:             req.URL,
+		EncryptedAPIKey: encryptedKey,
+		Enabled:         req.Enabled,
+	}); err != nil {
 		respondDatabaseError(c, err)
 		return
 	}

--- a/internal/api/handlers_arr_test.go
+++ b/internal/api/handlers_arr_test.go
@@ -109,6 +109,7 @@ func setupArrTestServer(t *testing.T, db *sql.DB) (*gin.Engine, string, func()) 
 		eventBus: eb,
 		hub:      hub,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()
@@ -777,6 +778,7 @@ func setupArrTestServerWithClient(t *testing.T, db *sql.DB, arrClient integratio
 		hub:       hub,
 		arrClient: arrClient,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()
@@ -927,6 +929,7 @@ func TestGetArrRootFolders_NoClient(t *testing.T) {
 		hub:       hub,
 		arrClient: nil, // No client
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -1160,6 +1163,7 @@ func TestGenerateInstanceName_FirstInstance(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// No existing instances - should get base name without number
 	name := s.generateInstanceName("sonarr")
@@ -1176,6 +1180,7 @@ func TestGenerateInstanceName_SecondInstance(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// Add one existing instance
 	_, err := db.Exec("INSERT INTO arr_instances (name, type, url, api_key, enabled) VALUES (?, ?, ?, ?, ?)",
@@ -1197,6 +1202,7 @@ func TestGenerateInstanceName_ThirdInstance(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// Add two existing instances
 	_, err := db.Exec("INSERT INTO arr_instances (name, type, url, api_key, enabled) VALUES (?, ?, ?, ?, ?)",
@@ -1221,6 +1227,7 @@ func TestGenerateInstanceName_Radarr(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// No existing Radarr instances
 	name := s.generateInstanceName("radarr")
@@ -1237,6 +1244,7 @@ func TestGenerateInstanceName_Whisparr(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// Add one whisparr-v3 instance
 	_, err := db.Exec("INSERT INTO arr_instances (name, type, url, api_key, enabled) VALUES (?, ?, ?, ?, ?)",
@@ -1258,6 +1266,7 @@ func TestGenerateInstanceName_UnknownType(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// Unknown type should capitalize first letter
 	name := s.generateInstanceName("lidarr")
@@ -1274,6 +1283,7 @@ func TestGenerateInstanceName_EmptyType(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// Empty type should use "Instance" as fallback
 	name := s.generateInstanceName("")
@@ -1290,6 +1300,7 @@ func TestGenerateInstanceName_SonarrV3(t *testing.T) {
 		router: r,
 		db:     db,
 	}
+	s.initRepositories()
 
 	// sonarr-v3 should use "Sonarr" display name
 	name := s.generateInstanceName("sonarr-v3")

--- a/internal/api/handlers_auth_test.go
+++ b/internal/api/handlers_auth_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/eventbus"
-	"github.com/mescon/Healarr/internal/repository"
 )
 
 // =============================================================================
@@ -75,12 +74,13 @@ func createAuthErrorTestServer(t *testing.T, db *sql.DB) *RESTServer {
 
 	eb := eventbus.NewEventBus(db)
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
+	return s
 }
 
 // =============================================================================

--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,6 +18,7 @@ import (
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/notifier"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -83,21 +86,15 @@ func (s *RESTServer) restartServer(c *gin.Context) {
 // exportArrInstances exports arr instances from the database. Returns the
 // rows and any query/iteration error so the caller can fail the export
 // instead of returning a partial result the user wouldn't know is broken.
-func (s *RESTServer) exportArrInstances() ([]gin.H, error) {
-	rows, err := s.db.Query("SELECT name, type, url, api_key, enabled FROM arr_instances")
+func (s *RESTServer) exportArrInstances(ctx context.Context) ([]gin.H, error) {
+	rows, err := s.arrInstances.ListAll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("query arr_instances: %w", err)
 	}
-	defer rows.Close()
 
 	var instances []gin.H
-	for rows.Next() {
-		var name, arrType, url, encryptedKey string
-		var enabled bool
-		if err := rows.Scan(&name, &arrType, &url, &encryptedKey, &enabled); err != nil {
-			return nil, fmt.Errorf("scan arr_instance: %w", err)
-		}
-		decryptedKey, err := crypto.Decrypt(encryptedKey)
+	for _, row := range rows {
+		decryptedKey, err := crypto.Decrypt(row.EncryptedAPIKey)
 		if err != nil {
 			// Per-row decrypt failure is recorded as a sentinel; we don't
 			// fail the whole export because the rest of the data is still
@@ -106,11 +103,8 @@ func (s *RESTServer) exportArrInstances() ([]gin.H, error) {
 			decryptedKey = "[DECRYPTION_ERROR]"
 		}
 		instances = append(instances, gin.H{
-			"name": name, "type": arrType, "url": url, "api_key": decryptedKey, "enabled": enabled,
+			"name": row.Name, "type": row.Type, "url": row.URL, "api_key": decryptedKey, "enabled": row.Enabled,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate arr_instances: %w", err)
 	}
 	return instances, nil
 }
@@ -226,7 +220,7 @@ func (s *RESTServer) exportConfig(c *gin.Context) {
 		"version":     config.Version,
 	}
 
-	instances, err := s.exportArrInstances()
+	instances, err := s.exportArrInstances(c.Request.Context())
 	if err != nil {
 		logger.Errorf("exportConfig: %v", err)
 		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
@@ -316,15 +310,18 @@ type importNotification struct {
 
 // importArrInstances imports arr instances and returns the count.
 // Skips duplicates based on URL to prevent creating multiple entries for the same instance.
-func (s *RESTServer) importArrInstances(instances []importArrInstance) int {
+func (s *RESTServer) importArrInstances(ctx context.Context, instances []importArrInstance) int {
 	count := 0
 	for _, inst := range instances {
 		// Check if an instance with the same URL already exists
-		var existingID int
-		err := s.db.QueryRow("SELECT id FROM arr_instances WHERE url = ?", inst.URL).Scan(&existingID)
+		existingID, err := s.arrInstances.FindIDByURL(ctx, inst.URL)
 		if err == nil {
 			// Instance already exists, skip
 			logger.Debugf("Skipping duplicate arr instance with URL %s (existing ID: %d)", inst.URL, existingID)
+			continue
+		}
+		if !errors.Is(err, repository.ErrNotFound) {
+			logger.Errorf("Failed to check for duplicate arr instance %s: %v", inst.Name, err)
 			continue
 		}
 
@@ -333,13 +330,17 @@ func (s *RESTServer) importArrInstances(instances []importArrInstance) int {
 			logger.Errorf("Failed to encrypt API key for import: %v", err)
 			continue
 		}
-		_, err = s.db.Exec("INSERT INTO arr_instances (name, type, url, api_key, enabled) VALUES (?, ?, ?, ?, ?)",
-			inst.Name, inst.Type, inst.URL, encryptedKey, inst.Enabled)
-		if err == nil {
-			count++
-		} else {
+		if _, err := s.arrInstances.Create(ctx, repository.CreateArrInstanceParams{
+			Name:            inst.Name,
+			Type:            inst.Type,
+			URL:             inst.URL,
+			EncryptedAPIKey: encryptedKey,
+			Enabled:         inst.Enabled,
+		}); err != nil {
 			logger.Errorf("Failed to import arr instance %s: %v", inst.Name, err)
+			continue
 		}
+		count++
 	}
 	return count
 }
@@ -525,7 +526,7 @@ func (s *RESTServer) importConfig(c *gin.Context) {
 		return
 	}
 
-	arrCount := s.importArrInstances(req.ArrInstances)
+	arrCount := s.importArrInstances(c.Request.Context(), req.ArrInstances)
 	pathCount, pathIDs := s.importScanPaths(req.ScanPaths)
 	schedCount := s.importSchedules(req.Schedules, pathIDs)
 	notifCount := s.importNotifications(req.Notifications)

--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -64,6 +64,7 @@ func setupConfigTestDB(t *testing.T) (*sql.DB, func()) {
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
 			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -128,6 +129,7 @@ func setupConfigTestServer(t *testing.T, db *sql.DB, pm *testutil.MockPathMapper
 		hub:        hub,
 		pathMapper: pm,
 	}
+	s.initRepositories()
 
 	// Optionally add notifier service
 	if withNotifier {
@@ -180,6 +182,7 @@ func setupConfigTestServerWithScheduler(t *testing.T, db *sql.DB, pm *testutil.M
 		scheduler:  scheduler,
 		notifier:   n,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()
@@ -627,6 +630,7 @@ func TestDownloadDatabaseBackup_Success(t *testing.T) {
 		eventBus: eb,
 		hub:      NewWebSocketHub(eb),
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()

--- a/internal/api/handlers_health.go
+++ b/internal/api/handlers_health.go
@@ -47,11 +47,10 @@ type arrHealthResult struct {
 func (s *RESTServer) checkArrInstancesHealth(ctx context.Context) arrHealthResult {
 	result := arrHealthResult{}
 
-	rows, err := s.db.QueryContext(ctx, "SELECT url, api_key FROM arr_instances WHERE enabled = 1")
+	rows, err := s.arrInstances.ListEnabled(ctx)
 	if err != nil {
 		return result
 	}
-	defer rows.Close()
 
 	// Collect all instances first
 	type arrInstance struct {
@@ -60,21 +59,13 @@ func (s *RESTServer) checkArrInstancesHealth(ctx context.Context) arrHealthResul
 	}
 	var instances []arrInstance
 
-	for rows.Next() {
-		var url, encryptedKey string
-		if rows.Scan(&url, &encryptedKey) != nil {
-			continue
-		}
-		decryptedKey, err := crypto.Decrypt(encryptedKey)
+	for _, row := range rows {
+		decryptedKey, err := crypto.Decrypt(row.EncryptedAPIKey)
 		if err != nil {
 			logger.Errorf("Failed to decrypt API key in health check: %v", err)
 			continue
 		}
-		instances = append(instances, arrInstance{url, decryptedKey})
-	}
-	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating arr instances for health check: %v", err)
-		return result
+		instances = append(instances, arrInstance{row.URL, decryptedKey})
 	}
 
 	result.total = len(instances)

--- a/internal/api/handlers_health_test.go
+++ b/internal/api/handlers_health_test.go
@@ -80,6 +80,7 @@ func setupTestDBForHealth(t *testing.T) (*sql.DB, string, func()) {
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
 			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -225,6 +226,7 @@ func setupHealthTestServer(t *testing.T, db *sql.DB, dbPath string) (*gin.Engine
 		hub:        hub,
 		startTime:  time.Now().Add(-1 * time.Hour), // Started 1 hour ago
 	}
+	s.initRepositories()
 
 	// Set up a test config with the database path
 	config.SetForTesting(&config.Config{
@@ -518,6 +520,7 @@ func TestHandleHealth_UptimeFormatting(t *testing.T) {
 				hub:        hub,
 				startTime:  tt.startTime,
 			}
+			s.initRepositories()
 
 			config.SetForTesting(&config.Config{
 				DatabasePath: dbPath,

--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -72,9 +72,8 @@ func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 	status.HasAPIKey = apiKeyExists > 0
 
 	// Check for configured instances
-	var instanceCount int
-	err = s.db.QueryRow("SELECT COUNT(*) FROM arr_instances").Scan(&instanceCount)
-	if err != nil && err != sql.ErrNoRows {
+	instanceCount, err := s.arrInstances.Count(c.Request.Context())
+	if err != nil {
 		logger.Errorf("Failed to check instances: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return

--- a/internal/api/handlers_setup_test.go
+++ b/internal/api/handlers_setup_test.go
@@ -56,7 +56,8 @@ func setupSetupTestDB(t *testing.T) (*sql.DB, string, func()) {
 			type TEXT NOT NULL,
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
-			enabled INTEGER DEFAULT 1
+			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT
 		);
 
 		CREATE TABLE scan_paths (
@@ -96,11 +97,13 @@ func createSetupTestServer(t *testing.T, db *sql.DB) *RESTServer {
 
 	eb := eventbus.NewEventBus(db)
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:   r,
 		db:       db,
 		eventBus: eb,
 	}
+	s.initRepositories()
+	return s
 }
 
 // =============================================================================

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/eventbus"
-	"github.com/mescon/Healarr/internal/repository"
 )
 
 // setupTestDB creates a temporary database with schema for testing
@@ -126,8 +125,8 @@ func setupTestServer(t *testing.T, db *sql.DB) (*gin.Engine, func()) {
 		db:       db,
 		eventBus: eb,
 		hub:      hub,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Register routes manually for testing
 	api := r.Group("/api")
@@ -436,8 +435,8 @@ func TestAuthMiddleware_NoToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -472,8 +471,8 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -509,8 +508,8 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -546,8 +545,8 @@ func TestAuthMiddleware_BearerToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -583,8 +582,8 @@ func TestAuthMiddleware_QueryToken(t *testing.T) {
 		router:   r,
 		db:       db,
 		eventBus: eb,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key
 	apiKey, _ := auth.GenerateAPIKey()
@@ -694,8 +693,8 @@ func setupAuthTestServer(t *testing.T, db *sql.DB) (*gin.Engine, string, func())
 		db:       db,
 		eventBus: eb,
 		hub:      hub,
-		sessions: repository.NewSessionRepository(db),
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, _ := auth.GenerateAPIKey()

--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"crypto/subtle"
-	"database/sql"
 	"net/http"
 	"strconv"
 
@@ -56,18 +55,15 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 	// Load the instance: enabled flag + (encrypted) per-instance webhook secret
 	// if one has been generated. Missing webhook_secret column on legacy
 	// rows scans into a NULL sql.NullString.
-	var enabled bool
-	var webhookSecret sql.NullString
-	err = s.db.QueryRow(
-		"SELECT enabled, webhook_secret FROM arr_instances WHERE id = ?",
-		instanceID).Scan(&enabled, &webhookSecret)
+	instance, err := s.arrInstances.GetByID(c.Request.Context(), instanceID)
 	if err != nil {
 		logger.Errorf("Webhook rejected: Instance %d not found", instanceID)
 		c.JSON(http.StatusNotFound, gin.H{"error": "Instance not found"})
 		return
 	}
+	webhookSecret := instance.EncryptedWebhookSecret
 
-	if !enabled {
+	if !instance.Enabled {
 		logger.Infof("Webhook rejected: Instance %d is disabled", instanceID)
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error":   "This *arr instance is currently disabled",

--- a/internal/api/handlers_webhook_test.go
+++ b/internal/api/handlers_webhook_test.go
@@ -126,6 +126,7 @@ func setupWebhookTestServer(t *testing.T, db *sql.DB, pm *testutil.MockPathMappe
 		pathMapper: pm,
 		scanner:    scanner,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()
@@ -542,6 +543,7 @@ func TestWebhook_DecryptError(t *testing.T) {
 		pathMapper: mockPM,
 		scanner:    mockScanner,
 	}
+	s.initRepositories()
 
 	r.POST("/api/webhook/:instance_id", s.handleWebhook)
 

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -70,6 +70,16 @@ type RESTServer struct {
 	startTime      time.Time
 	toolChecker    *integration.ToolChecker
 	sessions       *repository.SessionRepository
+	arrInstances   *repository.ArrInstanceRepository
+}
+
+// initRepositories populates the domain repository fields from s.db. Called
+// from NewRESTServer and from test fixtures that construct &RESTServer{}
+// directly — keeps the prod / test wiring in lockstep as more repositories
+// land in Phase 3.
+func (s *RESTServer) initRepositories() {
+	s.sessions = repository.NewSessionRepository(s.db)
+	s.arrInstances = repository.NewArrInstanceRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server
@@ -215,8 +225,8 @@ func NewRESTServer(deps ServerDeps) *RESTServer {
 		hub:            NewWebSocketHub(deps.EventBus, deps.Metrics),
 		startTime:      time.Now(),
 		toolChecker:    toolChecker,
-		sessions:       repository.NewSessionRepository(deps.DB),
 	}
+	s.initRepositories()
 
 	s.setupRoutes()
 

--- a/internal/api/rest_test.go
+++ b/internal/api/rest_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/eventbus"
-	"github.com/mescon/Healarr/internal/repository"
 
 	_ "modernc.org/sqlite" // SQLite driver
 )
@@ -523,7 +522,8 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'test-secret-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db}
+		s.initRepositories()
 
 		err = s.verifyAPIToken("test-secret-key")
 		assert.NoError(t, err)
@@ -551,7 +551,8 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db}
+		s.initRepositories()
 
 		err = s.verifyAPIToken("wrong-key")
 		assert.Equal(t, errInvalidToken, err)
@@ -565,7 +566,8 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		_, err = db.Exec(`CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT)`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db}
+		s.initRepositories()
 
 		err = s.verifyAPIToken("any-token")
 		assert.Error(t, err)
@@ -577,7 +579,8 @@ func TestRESTServer_VerifyAPIToken(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		s := &RESTServer{db: db, sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db}
+		s.initRepositories()
 
 		err = s.verifyAPIToken("any-token")
 		assert.Error(t, err)
@@ -596,7 +599,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		require.NoError(t, err)
 		defer db.Close()
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -630,7 +634,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'correct-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -656,7 +661,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'valid-api-key')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -677,7 +683,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		defer db.Close()
 
 		// No settings table - will cause DB error
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -703,7 +710,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'bearer-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -729,7 +737,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'query-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")
@@ -755,7 +764,8 @@ func TestRESTServer_AuthMiddleware(t *testing.T) {
 		_, err = db.Exec(`INSERT INTO settings (key, value) VALUES ('api_key', 'apikey-token')`)
 		require.NoError(t, err)
 
-		s := &RESTServer{db: db, router: gin.New(), sessions: repository.NewSessionRepository(db)}
+		s := &RESTServer{db: db, router: gin.New()}
+		s.initRepositories()
 
 		s.router.GET("/protected", s.authMiddleware(), func(c *gin.Context) {
 			c.String(http.StatusOK, "success")

--- a/internal/repository/arr_instance.go
+++ b/internal/repository/arr_instance.go
@@ -1,0 +1,236 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ArrInstance is a row from the arr_instances table.
+//
+// The api_key and webhook_secret columns hold *encrypted* values; the
+// repository never encrypts/decrypts. Callers decrypt on read and encrypt
+// on write at the HTTP/service boundary, so the secret-handling policy
+// stays out of the persistence layer.
+type ArrInstance struct {
+	ID                     int64
+	Name                   string
+	Type                   string // sonarr / radarr / whisparr-v2 / whisparr-v3
+	URL                    string
+	EncryptedAPIKey        string
+	Enabled                bool
+	EncryptedWebhookSecret sql.NullString
+}
+
+// CreateArrInstanceParams is the input shape for ArrInstanceRepository.Create.
+//
+// EncryptedWebhookSecret is optional: a zero-length string is stored as
+// SQL NULL (legacy instances created before per-instance webhook secrets
+// existed). Callers that mint a fresh secret pass it as a non-empty
+// encrypted string.
+type CreateArrInstanceParams struct {
+	Name                   string
+	Type                   string
+	URL                    string
+	EncryptedAPIKey        string
+	Enabled                bool
+	EncryptedWebhookSecret string
+}
+
+// UpdateArrInstanceParams is the input shape for ArrInstanceRepository.Update.
+// Webhook secret rotation is intentionally a separate method (UpdateWebhookSecret)
+// so an instance-edit form can't accidentally clear or replace the secret.
+type UpdateArrInstanceParams struct {
+	Name            string
+	Type            string
+	URL             string
+	EncryptedAPIKey string
+	Enabled         bool
+}
+
+// ArrInstanceRepository wraps the arr_instances table.
+type ArrInstanceRepository struct {
+	db *sql.DB
+}
+
+// NewArrInstanceRepository returns a repository backed by db.
+func NewArrInstanceRepository(db *sql.DB) *ArrInstanceRepository {
+	return &ArrInstanceRepository{db: db}
+}
+
+// Count returns the total number of arr_instances rows.
+func (r *ArrInstanceRepository) Count(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM arr_instances`).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count arr_instances: %w", err)
+	}
+	return n, nil
+}
+
+// CountByType returns the number of arr_instances rows with type = arrType.
+func (r *ArrInstanceRepository) CountByType(ctx context.Context, arrType string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM arr_instances WHERE type = ?`, arrType).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count by type: %w", err)
+	}
+	return n, nil
+}
+
+// CountByTypePrefix returns the number of rows whose type starts with the
+// given prefix — used to group whisparr-v2 and whisparr-v3 together when
+// generating display names.
+func (r *ArrInstanceRepository) CountByTypePrefix(ctx context.Context, prefix string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM arr_instances WHERE type LIKE ?`, prefix+"%").Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count by type prefix: %w", err)
+	}
+	return n, nil
+}
+
+// ListAll returns every arr_instance row, ordered by id ASC.
+func (r *ArrInstanceRepository) ListAll(ctx context.Context) ([]ArrInstance, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, name, type, url, api_key, enabled, webhook_secret FROM arr_instances ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query arr_instances: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []ArrInstance
+	for rows.Next() {
+		var inst ArrInstance
+		if err := rows.Scan(
+			&inst.ID, &inst.Name, &inst.Type, &inst.URL,
+			&inst.EncryptedAPIKey, &inst.Enabled, &inst.EncryptedWebhookSecret,
+		); err != nil {
+			return nil, fmt.Errorf("scan arr_instance: %w", err)
+		}
+		instances = append(instances, inst)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate arr_instances: %w", err)
+	}
+	return instances, nil
+}
+
+// ListEnabled returns only rows where enabled = 1, ordered by id ASC.
+func (r *ArrInstanceRepository) ListEnabled(ctx context.Context) ([]ArrInstance, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, name, type, url, api_key, enabled, webhook_secret FROM arr_instances WHERE enabled = 1 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query enabled arr_instances: %w", err)
+	}
+	defer rows.Close()
+
+	var instances []ArrInstance
+	for rows.Next() {
+		var inst ArrInstance
+		if err := rows.Scan(
+			&inst.ID, &inst.Name, &inst.Type, &inst.URL,
+			&inst.EncryptedAPIKey, &inst.Enabled, &inst.EncryptedWebhookSecret,
+		); err != nil {
+			return nil, fmt.Errorf("scan arr_instance: %w", err)
+		}
+		instances = append(instances, inst)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate arr_instances: %w", err)
+	}
+	return instances, nil
+}
+
+// GetByID returns the row matching id, or ErrNotFound.
+func (r *ArrInstanceRepository) GetByID(ctx context.Context, id int64) (ArrInstance, error) {
+	var inst ArrInstance
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, name, type, url, api_key, enabled, webhook_secret FROM arr_instances WHERE id = ?`, id).
+		Scan(&inst.ID, &inst.Name, &inst.Type, &inst.URL,
+			&inst.EncryptedAPIKey, &inst.Enabled, &inst.EncryptedWebhookSecret)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ArrInstance{}, ErrNotFound
+	}
+	if err != nil {
+		return ArrInstance{}, fmt.Errorf("get arr_instance: %w", err)
+	}
+	return inst, nil
+}
+
+// FindIDByURL returns the id of the row matching url, or ErrNotFound if no
+// such row exists. Used by config import to skip duplicate URLs.
+func (r *ArrInstanceRepository) FindIDByURL(ctx context.Context, url string) (int64, error) {
+	var id int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id FROM arr_instances WHERE url = ?`, url).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find arr_instance by url: %w", err)
+	}
+	return id, nil
+}
+
+// Create inserts a new row and returns its id.
+func (r *ArrInstanceRepository) Create(ctx context.Context, p CreateArrInstanceParams) (int64, error) {
+	var webhookSecret interface{}
+	if p.EncryptedWebhookSecret != "" {
+		webhookSecret = p.EncryptedWebhookSecret
+	}
+	res, err := r.db.ExecContext(ctx,
+		`INSERT INTO arr_instances (name, type, url, api_key, enabled, webhook_secret) VALUES (?, ?, ?, ?, ?, ?)`,
+		p.Name, p.Type, p.URL, p.EncryptedAPIKey, p.Enabled, webhookSecret)
+	if err != nil {
+		return 0, fmt.Errorf("insert arr_instance: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// Update replaces the row's name/type/url/api_key/enabled. Does NOT touch
+// webhook_secret — use UpdateWebhookSecret to rotate it.
+func (r *ArrInstanceRepository) Update(ctx context.Context, id int64, p UpdateArrInstanceParams) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE arr_instances SET name = ?, type = ?, url = ?, api_key = ?, enabled = ? WHERE id = ?`,
+		p.Name, p.Type, p.URL, p.EncryptedAPIKey, p.Enabled, id)
+	if err != nil {
+		return fmt.Errorf("update arr_instance: %w", err)
+	}
+	return nil
+}
+
+// UpdateWebhookSecret rotates an instance's webhook_secret to the given
+// (already-encrypted) value. Returns ErrNotFound if no row matched.
+func (r *ArrInstanceRepository) UpdateWebhookSecret(ctx context.Context, id int64, encryptedSecret string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE arr_instances SET webhook_secret = ? WHERE id = ?`,
+		encryptedSecret, id)
+	if err != nil {
+		return fmt.Errorf("update webhook_secret: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Delete removes the row matching id. Returns nil if no row matched.
+func (r *ArrInstanceRepository) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM arr_instances WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete arr_instance: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/arr_instance_test.go
+++ b/internal/repository/arr_instance_test.go
@@ -1,0 +1,242 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const arrInstanceSchema = `
+CREATE TABLE arr_instances (
+	id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	name           TEXT NOT NULL,
+	type           TEXT NOT NULL,
+	url            TEXT NOT NULL,
+	api_key        TEXT NOT NULL,
+	enabled        INTEGER DEFAULT 1,
+	webhook_secret TEXT,
+	created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newArrInstanceTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(arrInstanceSchema); err != nil {
+		t.Fatalf("create arr_instances schema: %v", err)
+	}
+	return db
+}
+
+func TestArrInstanceRepository_Count_empty(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	n, err := repo.Count(context.Background())
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Count = %d, want 0", n)
+	}
+}
+
+func TestArrInstanceRepository_Create_andGetByID(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+
+	id, err := repo.Create(context.Background(), CreateArrInstanceParams{
+		Name:                   "Sonarr",
+		Type:                   "sonarr",
+		URL:                    "http://localhost:8989",
+		EncryptedAPIKey:        "enc-key",
+		Enabled:                true,
+		EncryptedWebhookSecret: "enc-secret",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == 0 {
+		t.Error("Create returned id=0")
+	}
+
+	got, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Name != "Sonarr" || got.URL != "http://localhost:8989" {
+		t.Errorf("unexpected row: %+v", got)
+	}
+	if !got.EncryptedWebhookSecret.Valid || got.EncryptedWebhookSecret.String != "enc-secret" {
+		t.Errorf("webhook_secret not preserved: %+v", got.EncryptedWebhookSecret)
+	}
+}
+
+func TestArrInstanceRepository_Create_nullWebhookSecret(t *testing.T) {
+	// Empty EncryptedWebhookSecret should land as SQL NULL, matching the
+	// legacy instance shape that pre-dates per-instance webhook secrets.
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+
+	id, err := repo.Create(context.Background(), CreateArrInstanceParams{
+		Name:            "Radarr",
+		Type:            "radarr",
+		URL:             "http://localhost:7878",
+		EncryptedAPIKey: "k",
+		Enabled:         true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, _ := repo.GetByID(context.Background(), id)
+	if got.EncryptedWebhookSecret.Valid {
+		t.Errorf("expected webhook_secret NULL, got %q", got.EncryptedWebhookSecret.String)
+	}
+}
+
+func TestArrInstanceRepository_GetByID_notFound(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	_, err := repo.GetByID(context.Background(), 999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestArrInstanceRepository_FindIDByURL(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	id, _ := repo.Create(context.Background(), CreateArrInstanceParams{
+		Name: "S", Type: "sonarr", URL: "http://a", EncryptedAPIKey: "k", Enabled: true,
+	})
+
+	got, err := repo.FindIDByURL(context.Background(), "http://a")
+	if err != nil || got != id {
+		t.Errorf("FindIDByURL = (%d, %v), want (%d, nil)", got, err, id)
+	}
+
+	_, err = repo.FindIDByURL(context.Background(), "http://nowhere")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("FindIDByURL missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestArrInstanceRepository_ListAll_andListEnabled(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	ctx := context.Background()
+	mustCreate := func(p CreateArrInstanceParams) int64 {
+		id, err := repo.Create(ctx, p)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		return id
+	}
+	mustCreate(CreateArrInstanceParams{Name: "a", Type: "sonarr", URL: "http://a", EncryptedAPIKey: "k", Enabled: true})
+	mustCreate(CreateArrInstanceParams{Name: "b", Type: "radarr", URL: "http://b", EncryptedAPIKey: "k", Enabled: false})
+	mustCreate(CreateArrInstanceParams{Name: "c", Type: "sonarr", URL: "http://c", EncryptedAPIKey: "k", Enabled: true})
+
+	all, err := repo.ListAll(ctx)
+	if err != nil || len(all) != 3 {
+		t.Fatalf("ListAll = (%d, %v), want (3, nil)", len(all), err)
+	}
+
+	enabled, err := repo.ListEnabled(ctx)
+	if err != nil || len(enabled) != 2 {
+		t.Fatalf("ListEnabled = (%d, %v), want (2, nil)", len(enabled), err)
+	}
+	for _, inst := range enabled {
+		if !inst.Enabled {
+			t.Errorf("ListEnabled returned disabled row: %+v", inst)
+		}
+	}
+}
+
+func TestArrInstanceRepository_CountByType_andPrefix(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	ctx := context.Background()
+	for _, p := range []CreateArrInstanceParams{
+		{Name: "s1", Type: "sonarr", URL: "http://s1", EncryptedAPIKey: "k", Enabled: true},
+		{Name: "s2", Type: "sonarr", URL: "http://s2", EncryptedAPIKey: "k", Enabled: true},
+		{Name: "w1", Type: "whisparr-v2", URL: "http://w1", EncryptedAPIKey: "k", Enabled: true},
+		{Name: "w2", Type: "whisparr-v3", URL: "http://w2", EncryptedAPIKey: "k", Enabled: true},
+		{Name: "r1", Type: "radarr", URL: "http://r1", EncryptedAPIKey: "k", Enabled: true},
+	} {
+		if _, err := repo.Create(ctx, p); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	if n, _ := repo.CountByType(ctx, "sonarr"); n != 2 {
+		t.Errorf("CountByType sonarr = %d, want 2", n)
+	}
+	if n, _ := repo.CountByTypePrefix(ctx, "whisparr"); n != 2 {
+		t.Errorf("CountByTypePrefix whisparr = %d, want 2", n)
+	}
+}
+
+func TestArrInstanceRepository_Update(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, CreateArrInstanceParams{
+		Name: "old", Type: "sonarr", URL: "http://old", EncryptedAPIKey: "k", Enabled: true,
+		EncryptedWebhookSecret: "secret-stays",
+	})
+
+	if err := repo.Update(ctx, id, UpdateArrInstanceParams{
+		Name: "new", Type: "radarr", URL: "http://new", EncryptedAPIKey: "k2", Enabled: false,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, _ := repo.GetByID(ctx, id)
+	if got.Name != "new" || got.URL != "http://new" || got.Enabled {
+		t.Errorf("Update did not apply: %+v", got)
+	}
+	// Webhook secret should be unchanged — UpdateArrInstanceParams intentionally
+	// excludes it, so a routine instance edit can't accidentally clear it.
+	if got.EncryptedWebhookSecret.String != "secret-stays" {
+		t.Errorf("Update clobbered webhook_secret: %q", got.EncryptedWebhookSecret.String)
+	}
+}
+
+func TestArrInstanceRepository_UpdateWebhookSecret(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, CreateArrInstanceParams{
+		Name: "x", Type: "sonarr", URL: "http://x", EncryptedAPIKey: "k", Enabled: true,
+	})
+
+	if err := repo.UpdateWebhookSecret(ctx, id, "fresh-secret"); err != nil {
+		t.Fatalf("UpdateWebhookSecret: %v", err)
+	}
+	got, _ := repo.GetByID(ctx, id)
+	if !got.EncryptedWebhookSecret.Valid || got.EncryptedWebhookSecret.String != "fresh-secret" {
+		t.Errorf("UpdateWebhookSecret did not apply: %+v", got.EncryptedWebhookSecret)
+	}
+
+	if err := repo.UpdateWebhookSecret(ctx, 9999, "secret"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("UpdateWebhookSecret missing id = %v, want ErrNotFound", err)
+	}
+}
+
+func TestArrInstanceRepository_Delete(t *testing.T) {
+	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, CreateArrInstanceParams{
+		Name: "x", Type: "sonarr", URL: "http://x", EncryptedAPIKey: "k", Enabled: true,
+	})
+
+	if err := repo.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.GetByID(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("After Delete: GetByID = %v, want ErrNotFound", err)
+	}
+
+	// Deleting an absent id is not an error (idempotent).
+	if err := repo.Delete(ctx, 9999); err != nil {
+		t.Errorf("Delete missing id = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Second Phase 3 PR. Migrates the arr_instances table to \`ArrInstanceRepository\` — 13 handler-layer SQL sites across 5 files:

| File | Sites migrated |
|---|---|
| handlers_arr.go | 7 (list, count×2, create, update, delete, rotate webhook secret) |
| handlers_config.go | 3 (export, import dedup, import insert) |
| handlers_webhook.go | 1 (load instance for webhook auth) |
| handlers_health.go | 1 (enabled-instance health check) |
| handlers_setup.go | 1 (instance-count for setup status) |

**Deferred:** 3 SQL sites in \`internal/integration/arr_client.go\`. Migrating those today would create an import cycle (integration owns the \`ArrType\` enum that the repo could use). Cycle resolution belongs in its own PR.

## Design notes

- \`Update\` replaces name/type/url/api_key/enabled but **not** webhook_secret. Webhook-secret rotation is a separate \`UpdateWebhookSecret\` method, so a routine instance-edit form can't accidentally clear or rotate the secret as a side-effect.
- Repo is encryption-agnostic — \`EncryptedAPIKey\` / \`EncryptedWebhookSecret\` field names make the boundary explicit; callers encrypt/decrypt at the HTTP edge.
- \`GetByID\`, \`FindIDByURL\`, \`UpdateWebhookSecret\` return \`ErrNotFound\` for clean 404 mapping.
- Empty \`EncryptedWebhookSecret\` is stored as SQL NULL — matches the legacy-instance shape the config-import path produces.

## RESTServer.initRepositories()

New helper that populates all domain-repo fields from \`s.db\`. \`NewRESTServer\` calls it; test fixtures that build \`&RESTServer{}\` directly call it after construction. Adding a new repo in future Phase 3 PRs means one line in \`initRepositories\` rather than 10 test fixtures.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/arr_instance_test.go\` covers Count, Create (with and without webhook_secret), GetByID (hit/miss), FindIDByURL (hit/miss), ListAll, ListEnabled, CountByType, CountByTypePrefix, Update (preserves webhook_secret), UpdateWebhookSecret (hit/miss), Delete (idempotent)
- [x] Three test schemas updated to include the \`webhook_secret\` column (they pre-dated migration 006_webhook_secret.sql)