### PR TITLE
feat(repository): extract scan_paths into typed repository (Phase 3.3)

### DIFF
--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -110,50 +110,34 @@ func (s *RESTServer) exportArrInstances(ctx context.Context) ([]gin.H, error) {
 }
 
 // exportScanPaths exports scan paths from the database.
-func (s *RESTServer) exportScanPaths() ([]gin.H, error) {
-	rows, err := s.db.Query(`SELECT local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run,
-		detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours
-		FROM scan_paths`)
+func (s *RESTServer) exportScanPaths(ctx context.Context) ([]gin.H, error) {
+	rows, err := s.scanPaths.ListAll(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("query scan_paths: %w", err)
 	}
-	defer rows.Close()
 
 	var paths []gin.H
-	for rows.Next() {
-		var localPath, arrPath, detectionMethod, detectionMode string
-		var arrInstanceID sql.NullInt64
-		var enabled, autoRemediate, dryRun bool
-		var detectionArgs sql.NullString
-		var maxRetries int
-		var verificationTimeout sql.NullInt64
-		if err := rows.Scan(&localPath, &arrPath, &arrInstanceID, &enabled, &autoRemediate, &dryRun,
-			&detectionMethod, &detectionArgs, &detectionMode, &maxRetries, &verificationTimeout); err != nil {
-			return nil, fmt.Errorf("scan scan_paths row: %w", err)
-		}
+	for _, sp := range rows {
 		path := gin.H{
-			"local_path": localPath, "arr_path": arrPath, "enabled": enabled,
-			"auto_remediate": autoRemediate, "dry_run": dryRun, "detection_method": detectionMethod,
-			"detection_mode": detectionMode, "max_retries": maxRetries,
+			"local_path": sp.LocalPath, "arr_path": sp.ArrPath, "enabled": sp.Enabled,
+			"auto_remediate": sp.AutoRemediate, "dry_run": sp.DryRun, "detection_method": sp.DetectionMethod,
+			"detection_mode": sp.DetectionMode, "max_retries": sp.MaxRetries,
 		}
-		if arrInstanceID.Valid {
-			path["arr_instance_id"] = arrInstanceID.Int64
+		if sp.ArrInstanceID.Valid {
+			path["arr_instance_id"] = sp.ArrInstanceID.Int64
 		}
-		if detectionArgs.Valid && detectionArgs.String != "" {
+		if sp.DetectionArgs.Valid && sp.DetectionArgs.String != "" {
 			var args []string
-			if err := json.Unmarshal([]byte(detectionArgs.String), &args); err == nil {
+			if err := json.Unmarshal([]byte(sp.DetectionArgs.String), &args); err == nil {
 				path["detection_args"] = args
 			} else {
-				path["detection_args"] = detectionArgs.String
+				path["detection_args"] = sp.DetectionArgs.String
 			}
 		}
-		if verificationTimeout.Valid {
-			path["verification_timeout_hours"] = verificationTimeout.Int64
+		if sp.VerificationTimeoutHours.Valid {
+			path["verification_timeout_hours"] = sp.VerificationTimeoutHours.Int64
 		}
 		paths = append(paths, path)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate scan_paths: %w", err)
 	}
 	return paths, nil
 }
@@ -230,7 +214,7 @@ func (s *RESTServer) exportConfig(c *gin.Context) {
 		export["arr_instances"] = instances
 	}
 
-	paths, err := s.exportScanPaths()
+	paths, err := s.exportScanPaths(c.Request.Context())
 	if err != nil {
 		logger.Errorf("exportConfig: %v", err)
 		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
@@ -393,55 +377,68 @@ func normalizeDetectionArgs(raw json.RawMessage) string {
 
 // importScanPaths imports scan paths and returns count and path ID mapping.
 // Skips duplicates based on local_path to prevent creating multiple entries for the same path.
-func (s *RESTServer) importScanPaths(paths []importScanPath) (int, map[string]int64) {
+func (s *RESTServer) importScanPaths(ctx context.Context, paths []importScanPath) (int, map[string]int64) {
 	count := 0
 	pathIDs := make(map[string]int64)
 	for i := range paths {
 		path := &paths[i]
 
 		// Check if a scan path with the same local_path already exists
-		var existingID int64
-		err := s.db.QueryRow("SELECT id FROM scan_paths WHERE local_path = ?", path.LocalPath).Scan(&existingID)
+		existingID, err := s.scanPaths.FindIDByLocalPath(ctx, path.LocalPath)
 		if err == nil {
 			// Path already exists, add to mapping but don't count as imported
 			logger.Debugf("Skipping duplicate scan path %s (existing ID: %d)", path.LocalPath, existingID)
 			pathIDs[path.LocalPath] = existingID
 			continue
 		}
+		if !errors.Is(err, repository.ErrNotFound) {
+			logger.Errorf("Failed to check for duplicate scan path %s: %v", path.LocalPath, err)
+			continue
+		}
 
 		normalizeScanPathDefaults(path)
 
-		result, err := s.db.Exec(`INSERT INTO scan_paths
-			(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			path.LocalPath, path.ArrPath, path.ArrInstanceID, path.Enabled, path.AutoRemediate, path.DryRun,
-			path.DetectionMethod, normalizeDetectionArgs(path.DetectionArgs), path.DetectionMode, path.MaxRetries, path.VerificationTimeoutHours)
-		if err == nil {
-			count++
-			if newID, idErr := result.LastInsertId(); idErr == nil {
-				pathIDs[path.LocalPath] = newID
-			} else {
-				logger.Warnf("Failed to get ID for imported scan path %s: %v (schedule import will use DB lookup)", path.LocalPath, idErr)
-			}
-		} else {
-			logger.Errorf("Failed to import scan path %s: %v", path.LocalPath, err)
+		fields := repository.ScanPathFields{
+			LocalPath:         path.LocalPath,
+			ArrPath:           path.ArrPath,
+			Enabled:           path.Enabled,
+			AutoRemediate:     path.AutoRemediate,
+			DryRun:            path.DryRun,
+			DetectionMethod:   path.DetectionMethod,
+			DetectionArgsJSON: normalizeDetectionArgs(path.DetectionArgs),
+			DetectionMode:     path.DetectionMode,
+			MaxRetries:        path.MaxRetries,
 		}
+		if path.ArrInstanceID != nil {
+			fields.ArrInstanceID = sql.NullInt64{Int64: int64(*path.ArrInstanceID), Valid: true}
+		}
+		if path.VerificationTimeoutHours != nil {
+			fields.VerificationTimeoutHours = sql.NullInt64{Int64: int64(*path.VerificationTimeoutHours), Valid: true}
+		}
+		newID, err := s.scanPaths.Create(ctx, fields)
+		if err != nil {
+			logger.Errorf("Failed to import scan path %s: %v", path.LocalPath, err)
+			continue
+		}
+		count++
+		pathIDs[path.LocalPath] = newID
 	}
 	return count, pathIDs
 }
 
 // importSchedules imports schedules using the path ID mapping.
 // Skips duplicates based on scan_path_id + cron_expression to prevent duplicate schedules.
-func (s *RESTServer) importSchedules(schedules []importSchedule, pathIDs map[string]int64) int {
+func (s *RESTServer) importSchedules(ctx context.Context, schedules []importSchedule, pathIDs map[string]int64) int {
 	count := 0
 	for _, sched := range schedules {
 		scanPathID, exists := pathIDs[sched.LocalPath]
 		if !exists {
-			row := s.db.QueryRow("SELECT id FROM scan_paths WHERE local_path = ?", sched.LocalPath)
-			if err := row.Scan(&scanPathID); err != nil {
+			found, err := s.scanPaths.FindIDByLocalPath(ctx, sched.LocalPath)
+			if err != nil {
 				logger.Errorf("Failed to find scan path for schedule (local_path=%s): %v", sched.LocalPath, err)
 				continue
 			}
+			scanPathID = found
 		}
 
 		// Check if a schedule with the same path and cron expression already exists
@@ -527,8 +524,8 @@ func (s *RESTServer) importConfig(c *gin.Context) {
 	}
 
 	arrCount := s.importArrInstances(c.Request.Context(), req.ArrInstances)
-	pathCount, pathIDs := s.importScanPaths(req.ScanPaths)
-	schedCount := s.importSchedules(req.Schedules, pathIDs)
+	pathCount, pathIDs := s.importScanPaths(c.Request.Context(), req.ScanPaths)
+	schedCount := s.importSchedules(c.Request.Context(), req.Schedules, pathIDs)
 	notifCount := s.importNotifications(req.Notifications)
 
 	// Reload path mappings and scheduler

--- a/internal/api/handlers_paths.go
+++ b/internal/api/handlers_paths.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -14,7 +15,32 @@ import (
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
+
+// scanPathFieldsFromRequest builds the persistence-layer field bundle
+// from the validated scan-path request and its already-canonicalized
+// detection_args JSON.
+func scanPathFieldsFromRequest(req *scanPathRequest, detectionArgsJSON []byte) repository.ScanPathFields {
+	fields := repository.ScanPathFields{
+		LocalPath:         req.LocalPath,
+		ArrPath:           req.ArrPath,
+		Enabled:           req.Enabled,
+		AutoRemediate:     req.AutoRemediate,
+		DryRun:            req.DryRun,
+		DetectionMethod:   req.DetectionMethod,
+		DetectionArgsJSON: string(detectionArgsJSON),
+		DetectionMode:     req.DetectionMode,
+		MaxRetries:        req.MaxRetries,
+	}
+	if req.ArrInstanceID != nil {
+		fields.ArrInstanceID = sql.NullInt64{Int64: int64(*req.ArrInstanceID), Valid: true}
+	}
+	if req.VerificationTimeoutHours != nil {
+		fields.VerificationTimeoutHours = sql.NullInt64{Int64: int64(*req.VerificationTimeoutHours), Valid: true}
+	}
+	return fields
+}
 
 const errMsgReloadPathMappings = "Failed to reload path mappings: %v"
 
@@ -127,62 +153,46 @@ func prepareScanPathRequest(req *scanPathRequest, c *gin.Context) ([]byte, bool)
 }
 
 func (s *RESTServer) getScanPaths(c *gin.Context) {
-	rows, err := s.db.Query("SELECT id, local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours FROM scan_paths")
+	rows, err := s.scanPaths.ListAll(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	var paths []gin.H
-	for rows.Next() {
-		var id int
-		var localPath, arrPath string
-		var arrInstanceID sql.NullInt64
-		var enabled, autoRemediate, dryRun bool
-		var detectionMethod, detectionMode string
-		var detectionArgs sql.NullString
-		var maxRetries int
-		var verificationTimeoutHours sql.NullInt64
-		if rows.Scan(&id, &localPath, &arrPath, &arrInstanceID, &enabled, &autoRemediate, &dryRun, &detectionMethod, &detectionArgs, &detectionMode, &maxRetries, &verificationTimeoutHours) != nil {
-			continue
-		}
+	paths := make([]gin.H, 0, len(rows))
+	for _, p := range rows {
 		path := gin.H{
-			"id":               id,
-			"local_path":       localPath,
-			"arr_path":         arrPath,
-			"enabled":          enabled,
-			"auto_remediate":   autoRemediate,
-			"dry_run":          dryRun,
-			"detection_method": detectionMethod,
-			"detection_mode":   detectionMode,
-			"max_retries":      maxRetries,
+			"id":               p.ID,
+			"local_path":       p.LocalPath,
+			"arr_path":         p.ArrPath,
+			"enabled":          p.Enabled,
+			"auto_remediate":   p.AutoRemediate,
+			"dry_run":          p.DryRun,
+			"detection_method": p.DetectionMethod,
+			"detection_mode":   p.DetectionMode,
+			"max_retries":      p.MaxRetries,
 		}
-		if arrInstanceID.Valid {
-			path["arr_instance_id"] = arrInstanceID.Int64
+		if p.ArrInstanceID.Valid {
+			path["arr_instance_id"] = p.ArrInstanceID.Int64
 		} else {
 			path["arr_instance_id"] = nil
 		}
-		if detectionArgs.Valid && detectionArgs.String != "" {
+		if p.DetectionArgs.Valid && p.DetectionArgs.String != "" {
 			var args []string
-			if err := json.Unmarshal([]byte(detectionArgs.String), &args); err == nil {
+			if err := json.Unmarshal([]byte(p.DetectionArgs.String), &args); err == nil {
 				path["detection_args"] = args
 			} else {
-				path["detection_args"] = detectionArgs.String
+				path["detection_args"] = p.DetectionArgs.String
 			}
 		} else {
 			path["detection_args"] = nil
 		}
-		if verificationTimeoutHours.Valid {
-			path["verification_timeout_hours"] = verificationTimeoutHours.Int64
+		if p.VerificationTimeoutHours.Valid {
+			path["verification_timeout_hours"] = p.VerificationTimeoutHours.Int64
 		} else {
 			path["verification_timeout_hours"] = nil
 		}
 		paths = append(paths, path)
-	}
-	if rows.Err() != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading scan paths"})
-		return
 	}
 	c.JSON(http.StatusOK, paths)
 }
@@ -274,12 +284,7 @@ func (s *RESTServer) createScanPath(c *gin.Context) {
 		return
 	}
 
-	_, err := s.db.Exec(`INSERT INTO scan_paths
-		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		req.LocalPath, req.ArrPath, req.ArrInstanceID, req.Enabled, req.AutoRemediate,
-		req.DryRun, req.DetectionMethod, detectionArgsJSON, req.DetectionMode, req.MaxRetries, req.VerificationTimeoutHours)
-	if err != nil {
+	if _, err := s.scanPaths.Create(c.Request.Context(), scanPathFieldsFromRequest(&req, detectionArgsJSON)); err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
@@ -292,9 +297,12 @@ func (s *RESTServer) createScanPath(c *gin.Context) {
 }
 
 func (s *RESTServer) deleteScanPath(c *gin.Context) {
-	id := c.Param("id")
-	_, err := s.db.Exec("DELETE FROM scan_paths WHERE id = ?", id)
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan path ID"})
+		return
+	}
+	if err := s.scanPaths.Delete(c.Request.Context(), id); err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
@@ -407,15 +415,12 @@ func (s *RESTServer) updateScanPath(c *gin.Context) {
 		return
 	}
 
-	_, err := s.db.Exec(`UPDATE scan_paths SET
-		local_path = ?, arr_path = ?, arr_instance_id = ?, enabled = ?,
-		auto_remediate = ?, dry_run = ?, detection_method = ?, detection_args = ?,
-		detection_mode = ?, max_retries = ?, verification_timeout_hours = ?
-		WHERE id = ?`,
-		req.LocalPath, req.ArrPath, req.ArrInstanceID, req.Enabled,
-		req.AutoRemediate, req.DryRun, req.DetectionMethod, detectionArgsJSON,
-		req.DetectionMode, req.MaxRetries, req.VerificationTimeoutHours, id)
-	if err != nil {
+	idInt, parseErr := strconv.ParseInt(id, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan path ID"})
+		return
+	}
+	if err := s.scanPaths.Update(c.Request.Context(), idInt, scanPathFieldsFromRequest(&req, detectionArgsJSON)); err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
@@ -507,9 +512,13 @@ func (s *RESTServer) validateScanPath(c *gin.Context) {
 	id := c.Param("id")
 
 	// Get the path from database
-	var localPath string
-	err := s.db.QueryRow("SELECT local_path FROM scan_paths WHERE id = ?", id).Scan(&localPath)
-	if err == sql.ErrNoRows {
+	idInt, parseErr := strconv.ParseInt(id, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan path ID"})
+		return
+	}
+	path, err := s.scanPaths.GetByID(c.Request.Context(), idInt)
+	if errors.Is(err, repository.ErrNotFound) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Scan path not found"})
 		return
 	}
@@ -517,6 +526,7 @@ func (s *RESTServer) validateScanPath(c *gin.Context) {
 		respondDatabaseError(c, err)
 		return
 	}
+	localPath := path.LocalPath
 
 	// Check if path exists and is accessible
 	info, err := os.Stat(localPath)

--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -71,6 +71,7 @@ func setupPathsTestServer(t *testing.T, db *sql.DB) (*gin.Engine, string, func()
 		hub:        hub,
 		pathMapper: mockPathMapper,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()
@@ -1828,6 +1829,7 @@ func setupPathsTestServerWithPathMapper(t *testing.T, db *sql.DB, pm *testutil.M
 		hub:        hub,
 		pathMapper: pm,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()

--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -21,11 +23,12 @@ func (s *RESTServer) triggerScan(c *gin.Context) {
 	}
 
 	// Look up path
-	var localPath string
-	if s.db.QueryRow("SELECT local_path FROM scan_paths WHERE id = ?", req.PathID).Scan(&localPath) != nil {
+	path, err := s.scanPaths.GetByID(c.Request.Context(), req.PathID)
+	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Path not found"})
 		return
 	}
+	localPath := path.LocalPath
 
 	// Check if scan is already in progress
 	if s.scanner.IsPathBeingScanned(localPath) {
@@ -216,9 +219,8 @@ func (s *RESTServer) rescanPath(c *gin.Context) {
 	}
 
 	// Find the scan_path that matches this path (to get the path_id)
-	var pathID int64
-	err = s.db.QueryRow("SELECT id FROM scan_paths WHERE local_path = ? AND enabled = 1", path).Scan(&pathID)
-	if err == sql.ErrNoRows {
+	pathID, err := s.scanPaths.FindEnabledIDByLocalPath(c.Request.Context(), path)
+	if errors.Is(err, repository.ErrNotFound) {
 		// Path might not be in scan_paths (e.g., webhook scan) - scan directly
 		safego.Run("rescan-file", func() {
 			if scanErr := s.scanner.ScanFile(path); scanErr != nil {
@@ -396,24 +398,16 @@ func (s *RESTServer) getScanFiles(c *gin.Context) {
 
 // triggerScanAll triggers scans for all enabled paths
 func (s *RESTServer) triggerScanAll(c *gin.Context) {
-	rows, err := s.db.Query("SELECT id, local_path FROM scan_paths WHERE enabled = 1")
+	paths, err := s.scanPaths.ListEnabled(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
 	started := 0
 	skipped := 0
-	for rows.Next() {
-		var pathID int64
-		var localPath string
-		if err := rows.Scan(&pathID, &localPath); err != nil {
-			logger.Errorf("Failed to scan row in triggerScanAll: %v", err)
-			continue
-		}
-
-		if s.scanner.IsPathBeingScanned(localPath) {
+	for _, p := range paths {
+		if s.scanner.IsPathBeingScanned(p.LocalPath) {
 			skipped++
 			continue
 		}
@@ -422,13 +416,8 @@ func (s *RESTServer) triggerScanAll(c *gin.Context) {
 			if err := s.scanner.ScanPath(pid, path); err != nil {
 				logger.Errorf("Scan failed for path %d (%s): %v", pid, path, err)
 			}
-		}(pathID, localPath)
+		}(p.ID, p.LocalPath)
 		started++
-	}
-
-	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating scan paths: %v", err)
-		// Continue with partial results since some scans may have started
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -68,7 +68,15 @@ func setupScansTestDB(t *testing.T) (*sql.DB, func()) {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			local_path TEXT NOT NULL,
 			arr_path TEXT,
+			arr_instance_id INTEGER,
 			enabled BOOLEAN DEFAULT 1,
+			auto_remediate BOOLEAN DEFAULT 0,
+			dry_run BOOLEAN DEFAULT 0,
+			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+			detection_args TEXT,
+			detection_mode TEXT NOT NULL DEFAULT 'quick',
+			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -108,7 +116,7 @@ func createScansTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus) *RES
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:     r,
 		db:         db,
 		eventBus:   eb,
@@ -118,6 +126,8 @@ func createScansTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus) *RES
 		hub:        NewWebSocketHub(eb),
 		startTime:  time.Now(),
 	}
+	s.initRepositories()
+	return s
 }
 
 func TestTriggerScan_PathNotFound(t *testing.T) {
@@ -153,7 +163,7 @@ func TestTriggerScan_Success(t *testing.T) {
 	defer eb.Shutdown()
 
 	// Insert a scan path
-	_, err := db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/media")
+	_, err := db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, ?, 1)", "/test/media", "/arr/media")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
@@ -988,16 +998,16 @@ func TestTriggerScanAll_WithPaths(t *testing.T) {
 	defer eb.Shutdown()
 
 	// Insert enabled scan paths
-	_, err := db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/path1")
+	_, err := db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/path1")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
-	_, err = db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/path2")
+	_, err = db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/path2")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
 	// Insert disabled path (should not be scanned)
-	_, err = db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 0)", "/test/disabled")
+	_, err = db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 0)", "/test/disabled")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
@@ -1115,7 +1125,7 @@ func createMockScanServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus, scann
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:    r,
 		db:        db,
 		eventBus:  eb,
@@ -1124,6 +1134,8 @@ func createMockScanServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus, scann
 		hub:       NewWebSocketHub(eb),
 		startTime: time.Now(),
 	}
+	s.initRepositories()
+	return s
 }
 
 func TestPauseAllScans_WithActiveScans(t *testing.T) {
@@ -1287,7 +1299,7 @@ func TestRescanPath_SuccessWithScanPath(t *testing.T) {
 	}
 
 	// Insert a scan_path that matches
-	_, err = db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/media/shows")
+	_, err = db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/media/shows")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
@@ -1374,7 +1386,7 @@ func TestTriggerScan_ScanAlreadyRunning(t *testing.T) {
 	defer eb.Shutdown()
 
 	// Insert a scan path
-	_, err := db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/media")
+	_, err := db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/media")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
@@ -1406,11 +1418,11 @@ func TestTriggerScanAll_WithSkippedScans(t *testing.T) {
 	defer eb.Shutdown()
 
 	// Insert enabled scan paths
-	_, err := db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/path1")
+	_, err := db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/path1")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
-	_, err = db.Exec("INSERT INTO scan_paths (local_path, enabled) VALUES (?, 1)", "/test/path2")
+	_, err = db.Exec("INSERT INTO scan_paths (local_path, arr_path, enabled) VALUES (?, '', 1)", "/test/path2")
 	if err != nil {
 		t.Fatalf("Failed to insert scan path: %v", err)
 	}
@@ -1462,7 +1474,7 @@ func createMockScanServerWithPathCheck(t *testing.T, db *sql.DB, eb *eventbus.Ev
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:    r,
 		db:        db,
 		eventBus:  eb,
@@ -1471,6 +1483,8 @@ func createMockScanServerWithPathCheck(t *testing.T, db *sql.DB, eb *eventbus.Ev
 		hub:       NewWebSocketHub(eb),
 		startTime: time.Now(),
 	}
+	s.initRepositories()
+	return s
 }
 
 func TestGetScanDetails_DBError(t *testing.T) {

--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -81,9 +81,8 @@ func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 	status.HasInstances = instanceCount > 0
 
 	// Check for configured scan paths
-	var pathCount int
-	err = s.db.QueryRow("SELECT COUNT(*) FROM scan_paths").Scan(&pathCount)
-	if err != nil && err != sql.ErrNoRows {
+	pathCount, err := s.scanPaths.Count(c.Request.Context())
+	if err != nil {
 		logger.Errorf("Failed to check scan paths: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -222,24 +222,19 @@ type PathHealth struct {
 // GET /api/stats/path-health
 func (s *RESTServer) getPathHealth(c *gin.Context) {
 	// Get all configured scan paths
-	pathRows, err := s.db.Query(`SELECT id, local_path, enabled FROM scan_paths ORDER BY local_path`)
+	scanPaths, err := s.scanPaths.ListOrderedByLocalPath(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer pathRows.Close()
 
-	var paths []PathHealth
-	for pathRows.Next() {
-		var p PathHealth
-		if pathRows.Scan(&p.PathID, &p.LocalPath, &p.Enabled) != nil {
-			continue
-		}
-		paths = append(paths, p)
-	}
-	if err := pathRows.Err(); err != nil {
-		respondDatabaseError(c, err)
-		return
+	paths := make([]PathHealth, 0, len(scanPaths))
+	for _, sp := range scanPaths {
+		paths = append(paths, PathHealth{
+			PathID:    int(sp.ID),
+			LocalPath: sp.LocalPath,
+			Enabled:   sp.Enabled,
+		})
 	}
 
 	if len(paths) == 0 {

--- a/internal/api/handlers_stats_test.go
+++ b/internal/api/handlers_stats_test.go
@@ -71,8 +71,16 @@ func setupStatsTestDB(t *testing.T) (*sql.DB, func()) {
 		CREATE TABLE scan_paths (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			local_path TEXT NOT NULL UNIQUE,
-			arr_path TEXT,
-			enabled BOOLEAN DEFAULT 1
+			arr_path TEXT NOT NULL DEFAULT '',
+			arr_instance_id INTEGER,
+			enabled BOOLEAN DEFAULT 1,
+			auto_remediate BOOLEAN DEFAULT 0,
+			dry_run BOOLEAN DEFAULT 0,
+			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+			detection_args TEXT,
+			detection_mode TEXT NOT NULL DEFAULT 'quick',
+			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER
 		);
 
 		CREATE VIEW corruption_status AS
@@ -171,7 +179,7 @@ func createStatsTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus) *RES
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	return &RESTServer{
+	s := &RESTServer{
 		router:     r,
 		db:         db,
 		eventBus:   eb,
@@ -181,6 +189,8 @@ func createStatsTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus) *RES
 		hub:        NewWebSocketHub(eb),
 		startTime:  time.Now(),
 	}
+	s.initRepositories()
+	return s
 }
 
 func TestGetDashboardStats_EmptyDB(t *testing.T) {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -71,6 +71,7 @@ type RESTServer struct {
 	toolChecker    *integration.ToolChecker
 	sessions       *repository.SessionRepository
 	arrInstances   *repository.ArrInstanceRepository
+	scanPaths      *repository.ScanPathRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -80,6 +81,7 @@ type RESTServer struct {
 func (s *RESTServer) initRepositories() {
 	s.sessions = repository.NewSessionRepository(s.db)
 	s.arrInstances = repository.NewArrInstanceRepository(s.db)
+	s.scanPaths = repository.NewScanPathRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server

--- a/internal/repository/scan_path.go
+++ b/internal/repository/scan_path.go
@@ -1,0 +1,256 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ScanPath is a row from the scan_paths table — one configured filesystem
+// directory the scanner walks for corruption.
+//
+// DetectionMethod / DetectionMode are stored as plain strings rather than
+// the typed enums from internal/integration to keep this package
+// integration-free (avoids an import cycle once arr_client.go's SQL also
+// migrates here). Callers convert via integration.ParseDetectionMethod /
+// ParseDetectionMode at the HTTP boundary.
+type ScanPath struct {
+	ID                       int64
+	LocalPath                string
+	ArrPath                  string
+	ArrInstanceID            sql.NullInt64
+	Enabled                  bool
+	AutoRemediate            bool
+	DryRun                   bool
+	DetectionMethod          string
+	DetectionArgs            sql.NullString // JSON-encoded []string, or NULL
+	DetectionMode            string
+	MaxRetries               int
+	VerificationTimeoutHours sql.NullInt64
+}
+
+// ScanPathFields is the input shape shared by Create and Update — all the
+// editable columns of scan_paths, in one struct.
+//
+// DetectionArgsJSON should be the JSON encoding of []string (or empty
+// string for NULL). The encoding belongs to the HTTP handler that owns
+// the request shape; the repo just stores the bytes.
+type ScanPathFields struct {
+	LocalPath                string
+	ArrPath                  string
+	ArrInstanceID            sql.NullInt64
+	Enabled                  bool
+	AutoRemediate            bool
+	DryRun                   bool
+	DetectionMethod          string
+	DetectionArgsJSON        string
+	DetectionMode            string
+	MaxRetries               int
+	VerificationTimeoutHours sql.NullInt64
+}
+
+// ScanPathRepository wraps the scan_paths table.
+type ScanPathRepository struct {
+	db *sql.DB
+}
+
+// NewScanPathRepository returns a repository backed by db.
+func NewScanPathRepository(db *sql.DB) *ScanPathRepository {
+	return &ScanPathRepository{db: db}
+}
+
+const scanPathColumns = `id, local_path, arr_path, arr_instance_id, enabled,
+	auto_remediate, dry_run, detection_method, detection_args, detection_mode,
+	max_retries, verification_timeout_hours`
+
+func scanScanPathRow(scanner interface {
+	Scan(dest ...interface{}) error
+}, p *ScanPath) error {
+	return scanner.Scan(
+		&p.ID, &p.LocalPath, &p.ArrPath, &p.ArrInstanceID, &p.Enabled,
+		&p.AutoRemediate, &p.DryRun, &p.DetectionMethod, &p.DetectionArgs,
+		&p.DetectionMode, &p.MaxRetries, &p.VerificationTimeoutHours,
+	)
+}
+
+// Count returns the total number of rows.
+func (r *ScanPathRepository) Count(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM scan_paths`).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count scan_paths: %w", err)
+	}
+	return n, nil
+}
+
+// ListAll returns every row, ordered by id ASC.
+func (r *ScanPathRepository) ListAll(ctx context.Context) ([]ScanPath, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+scanPathColumns+` FROM scan_paths ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query scan_paths: %w", err)
+	}
+	defer rows.Close()
+
+	var paths []ScanPath
+	for rows.Next() {
+		var p ScanPath
+		if err := scanScanPathRow(rows, &p); err != nil {
+			return nil, fmt.Errorf("scan scan_paths row: %w", err)
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scan_paths: %w", err)
+	}
+	return paths, nil
+}
+
+// ListEnabled returns rows where enabled = 1, ordered by id ASC.
+func (r *ScanPathRepository) ListEnabled(ctx context.Context) ([]ScanPath, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+scanPathColumns+` FROM scan_paths WHERE enabled = 1 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("query enabled scan_paths: %w", err)
+	}
+	defer rows.Close()
+
+	var paths []ScanPath
+	for rows.Next() {
+		var p ScanPath
+		if err := scanScanPathRow(rows, &p); err != nil {
+			return nil, fmt.Errorf("scan scan_paths row: %w", err)
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scan_paths: %w", err)
+	}
+	return paths, nil
+}
+
+// ListOrderedByLocalPath returns every row, ordered alphabetically by
+// local_path (used by the path-health stats endpoint to present a stable
+// UI ordering independent of insertion order).
+func (r *ScanPathRepository) ListOrderedByLocalPath(ctx context.Context) ([]ScanPath, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+scanPathColumns+` FROM scan_paths ORDER BY local_path`)
+	if err != nil {
+		return nil, fmt.Errorf("query scan_paths ordered: %w", err)
+	}
+	defer rows.Close()
+
+	var paths []ScanPath
+	for rows.Next() {
+		var p ScanPath
+		if err := scanScanPathRow(rows, &p); err != nil {
+			return nil, fmt.Errorf("scan scan_paths row: %w", err)
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scan_paths: %w", err)
+	}
+	return paths, nil
+}
+
+// GetByID returns the row matching id, or ErrNotFound.
+func (r *ScanPathRepository) GetByID(ctx context.Context, id int64) (ScanPath, error) {
+	var p ScanPath
+	err := scanScanPathRow(
+		r.db.QueryRowContext(ctx, `SELECT `+scanPathColumns+` FROM scan_paths WHERE id = ?`, id),
+		&p,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ScanPath{}, ErrNotFound
+	}
+	if err != nil {
+		return ScanPath{}, fmt.Errorf("get scan_path: %w", err)
+	}
+	return p, nil
+}
+
+// FindIDByLocalPath returns the id of the row whose local_path matches,
+// or ErrNotFound if none exists. Used by config-import dedup.
+func (r *ScanPathRepository) FindIDByLocalPath(ctx context.Context, localPath string) (int64, error) {
+	var id int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id FROM scan_paths WHERE local_path = ?`, localPath).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find scan_path by local_path: %w", err)
+	}
+	return id, nil
+}
+
+// FindEnabledIDByLocalPath returns the id of an *enabled* row whose
+// local_path matches, or ErrNotFound. Used by the rescan path to refuse
+// scans against disabled or unknown paths.
+func (r *ScanPathRepository) FindEnabledIDByLocalPath(ctx context.Context, localPath string) (int64, error) {
+	var id int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id FROM scan_paths WHERE local_path = ? AND enabled = 1`, localPath).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find enabled scan_path by local_path: %w", err)
+	}
+	return id, nil
+}
+
+// Create inserts a new row and returns its id.
+func (r *ScanPathRepository) Create(ctx context.Context, f ScanPathFields) (int64, error) {
+	var detectionArgs interface{}
+	if f.DetectionArgsJSON != "" {
+		detectionArgs = f.DetectionArgsJSON
+	}
+	res, err := r.db.ExecContext(ctx, `INSERT INTO scan_paths
+		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run,
+		 detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		f.LocalPath, f.ArrPath, f.ArrInstanceID, f.Enabled, f.AutoRemediate, f.DryRun,
+		f.DetectionMethod, detectionArgs, f.DetectionMode, f.MaxRetries, f.VerificationTimeoutHours,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert scan_path: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// Update replaces all editable columns of the row matching id.
+func (r *ScanPathRepository) Update(ctx context.Context, id int64, f ScanPathFields) error {
+	var detectionArgs interface{}
+	if f.DetectionArgsJSON != "" {
+		detectionArgs = f.DetectionArgsJSON
+	}
+	_, err := r.db.ExecContext(ctx, `UPDATE scan_paths SET
+		local_path = ?, arr_path = ?, arr_instance_id = ?, enabled = ?,
+		auto_remediate = ?, dry_run = ?, detection_method = ?, detection_args = ?,
+		detection_mode = ?, max_retries = ?, verification_timeout_hours = ?
+		WHERE id = ?`,
+		f.LocalPath, f.ArrPath, f.ArrInstanceID, f.Enabled,
+		f.AutoRemediate, f.DryRun, f.DetectionMethod, detectionArgs,
+		f.DetectionMode, f.MaxRetries, f.VerificationTimeoutHours, id,
+	)
+	if err != nil {
+		return fmt.Errorf("update scan_path: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row matching id. Returns nil if no row matched.
+func (r *ScanPathRepository) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM scan_paths WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete scan_path: %w", err)
+	}
+	return nil
+}

--- a/internal/repository/scan_path_test.go
+++ b/internal/repository/scan_path_test.go
@@ -1,0 +1,232 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const scanPathSchema = `
+CREATE TABLE scan_paths (
+	id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+	local_path                 TEXT NOT NULL UNIQUE,
+	arr_path                   TEXT NOT NULL,
+	arr_instance_id            INTEGER,
+	enabled                    BOOLEAN DEFAULT 1,
+	auto_remediate             BOOLEAN DEFAULT 0,
+	dry_run                    BOOLEAN DEFAULT 0,
+	detection_method           TEXT NOT NULL DEFAULT 'ffprobe',
+	detection_args             TEXT,
+	detection_mode             TEXT NOT NULL DEFAULT 'quick',
+	max_retries                INTEGER DEFAULT 3,
+	verification_timeout_hours INTEGER,
+	created_at                 TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newScanPathTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(scanPathSchema); err != nil {
+		t.Fatalf("create scan_paths schema: %v", err)
+	}
+	return db
+}
+
+func defaultFields(localPath string) ScanPathFields {
+	return ScanPathFields{
+		LocalPath:       localPath,
+		ArrPath:         "/arr" + localPath,
+		Enabled:         true,
+		DetectionMethod: "ffprobe",
+		DetectionMode:   "quick",
+		MaxRetries:      3,
+	}
+}
+
+func TestScanPathRepository_Create_andGetByID(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+
+	f := defaultFields("/movies")
+	f.ArrInstanceID = sql.NullInt64{Int64: 7, Valid: true}
+	f.DetectionArgsJSON = `["-v","quiet"]`
+	f.VerificationTimeoutHours = sql.NullInt64{Int64: 24, Valid: true}
+
+	id, err := repo.Create(ctx, f)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == 0 {
+		t.Error("Create returned id=0")
+	}
+
+	got, err := repo.GetByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.LocalPath != "/movies" || got.ArrPath != "/arr/movies" || !got.Enabled {
+		t.Errorf("unexpected row: %+v", got)
+	}
+	if !got.ArrInstanceID.Valid || got.ArrInstanceID.Int64 != 7 {
+		t.Errorf("ArrInstanceID = %+v, want valid 7", got.ArrInstanceID)
+	}
+	if got.DetectionArgs.String != `["-v","quiet"]` {
+		t.Errorf("DetectionArgs = %q, want JSON array", got.DetectionArgs.String)
+	}
+	if !got.VerificationTimeoutHours.Valid || got.VerificationTimeoutHours.Int64 != 24 {
+		t.Errorf("VerificationTimeoutHours = %+v, want valid 24", got.VerificationTimeoutHours)
+	}
+}
+
+func TestScanPathRepository_Create_emptyDetectionArgsStoresNull(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	id, err := repo.Create(context.Background(), defaultFields("/p"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := repo.GetByID(context.Background(), id)
+	if got.DetectionArgs.Valid {
+		t.Errorf("expected DetectionArgs NULL, got %q", got.DetectionArgs.String)
+	}
+}
+
+func TestScanPathRepository_GetByID_notFound(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	if _, err := repo.GetByID(context.Background(), 99); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanPathRepository_FindIDByLocalPath(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultFields("/movies"))
+
+	got, err := repo.FindIDByLocalPath(ctx, "/movies")
+	if err != nil || got != id {
+		t.Errorf("FindIDByLocalPath = (%d, %v), want (%d, nil)", got, err, id)
+	}
+
+	if _, err := repo.FindIDByLocalPath(ctx, "/nowhere"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanPathRepository_FindEnabledIDByLocalPath_skipsDisabled(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+	f := defaultFields("/movies")
+	f.Enabled = false
+	_, _ = repo.Create(ctx, f)
+
+	if _, err := repo.FindEnabledIDByLocalPath(ctx, "/movies"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("disabled-row lookup = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanPathRepository_ListAll_andListEnabled(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+
+	f1 := defaultFields("/a")
+	f2 := defaultFields("/b")
+	f2.Enabled = false
+	f3 := defaultFields("/c")
+	for _, f := range []ScanPathFields{f1, f2, f3} {
+		if _, err := repo.Create(ctx, f); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	all, err := repo.ListAll(ctx)
+	if err != nil || len(all) != 3 {
+		t.Fatalf("ListAll = (%d, %v), want (3, nil)", len(all), err)
+	}
+
+	enabled, err := repo.ListEnabled(ctx)
+	if err != nil || len(enabled) != 2 {
+		t.Fatalf("ListEnabled = (%d, %v), want (2, nil)", len(enabled), err)
+	}
+	for _, p := range enabled {
+		if !p.Enabled {
+			t.Errorf("ListEnabled returned disabled row: %+v", p)
+		}
+	}
+}
+
+func TestScanPathRepository_ListOrderedByLocalPath(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+	// Insert in non-alphabetical order.
+	for _, path := range []string{"/zulu", "/alpha", "/mike"} {
+		if _, err := repo.Create(ctx, defaultFields(path)); err != nil {
+			t.Fatalf("Create %s: %v", path, err)
+		}
+	}
+
+	ordered, err := repo.ListOrderedByLocalPath(ctx)
+	if err != nil {
+		t.Fatalf("ListOrderedByLocalPath: %v", err)
+	}
+	if len(ordered) != 3 || ordered[0].LocalPath != "/alpha" ||
+		ordered[1].LocalPath != "/mike" || ordered[2].LocalPath != "/zulu" {
+		t.Errorf("unexpected order: %+v", ordered)
+	}
+}
+
+func TestScanPathRepository_Update(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultFields("/old"))
+
+	updated := defaultFields("/new")
+	updated.Enabled = false
+	updated.MaxRetries = 7
+	if err := repo.Update(ctx, id, updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, _ := repo.GetByID(ctx, id)
+	if got.LocalPath != "/new" || got.Enabled || got.MaxRetries != 7 {
+		t.Errorf("Update did not apply: %+v", got)
+	}
+}
+
+func TestScanPathRepository_Delete(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultFields("/x"))
+
+	if err := repo.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.GetByID(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("After Delete: GetByID = %v, want ErrNotFound", err)
+	}
+
+	if err := repo.Delete(ctx, 9999); err != nil {
+		t.Errorf("Delete missing id = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestScanPathRepository_Count(t *testing.T) {
+	repo := NewScanPathRepository(newScanPathTestDB(t))
+	ctx := context.Background()
+
+	if n, _ := repo.Count(ctx); n != 0 {
+		t.Errorf("Count empty = %d, want 0", n)
+	}
+	_, _ = repo.Create(ctx, defaultFields("/a"))
+	_, _ = repo.Create(ctx, defaultFields("/b"))
+	if n, _ := repo.Count(ctx); n != 2 {
+		t.Errorf("Count = %d, want 2", n)
+	}
+}


### PR DESCRIPTION
## Summary

Third Phase 3 PR. Migrates the scan_paths table to \`ScanPathRepository\` — 13 handler-layer SQL sites across 6 files:

| File | Sites |
|---|---|
| handlers_paths.go | 5 (list, create, delete, update, validate) |
| handlers_config.go | 3 (export, import dedup, import insert) + 1 join lookup in importSchedules |
| handlers_scans.go | 3 (trigger lookup, enabled-id lookup for rescan, list-enabled for triggerScanAll) |
| handlers_stats.go | 1 (path-health) |
| handlers_setup.go | 1 (count) |

**Deferred:** 6 service-layer sites in \`scheduler.go\`, \`verifier.go\`, \`path_mapper.go\`, \`scanner.go\`. They cross a package boundary and want their own PR to think about service-layer dependency injection.

## Design notes

- \`DetectionMethod\` / \`DetectionMode\` stored as plain string fields, not the typed enums from \`internal/integration\` — keeps \`internal/repository\` integration-free so the deferred service-layer migration doesn't introduce an import cycle. Callers still validate via \`integration.ParseDetectionMethod\` / \`ParseDetectionMode\` at the HTTP boundary (the Phase 2 work already does this).
- \`FindEnabledIDByLocalPath\` is its own method (not a flag on \`FindIDByLocalPath\`) because the rescan handler must refuse scans against disabled paths — encoding that invariant in the method name beats threading a bool through every call site.
- \`ScanPathFields\` is the shared input for \`Create\` / \`Update\`. Empty \`DetectionArgsJSON\` stores as SQL NULL.
- Three handler files now pass \`c.Request.Context()\` to refactored helpers (\`exportScanPaths\`, \`importScanPaths\`, \`importSchedules\`) — repo \`QueryContext\` now gets the request's cancellation scope.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/scan_path_test.go\` covers Create (with/without optional fields), GetByID (hit/miss), FindIDByLocalPath (hit/miss), FindEnabledIDByLocalPath (skips disabled), ListAll, ListEnabled, ListOrderedByLocalPath (verifies alphabetical sort), Update, Delete (idempotent), Count
- [x] Test schemas for handlers_scans_test, handlers_stats_test updated to match the full production scan_paths shape