### PR TITLE
feat(repository): extract scan_schedules into typed repository (Phase 3.4)

### DIFF
--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -143,30 +143,17 @@ func (s *RESTServer) exportScanPaths(ctx context.Context) ([]gin.H, error) {
 }
 
 // exportSchedules exports scan schedules from the database.
-func (s *RESTServer) exportSchedules() ([]gin.H, error) {
-	rows, err := s.db.Query(`
-		SELECT ss.cron_expression, ss.enabled, sp.local_path
-		FROM scan_schedules ss
-		JOIN scan_paths sp ON ss.scan_path_id = sp.id
-	`)
+func (s *RESTServer) exportSchedules(ctx context.Context) ([]gin.H, error) {
+	rows, err := s.schedules.ListWithPaths(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("query scan_schedules: %w", err)
 	}
-	defer rows.Close()
 
 	var schedules []gin.H
-	for rows.Next() {
-		var cronExpr, localPath string
-		var enabled bool
-		if err := rows.Scan(&cronExpr, &enabled, &localPath); err != nil {
-			return nil, fmt.Errorf("scan scan_schedule row: %w", err)
-		}
+	for _, sched := range rows {
 		schedules = append(schedules, gin.H{
-			"local_path": localPath, "cron_expression": cronExpr, "enabled": enabled,
+			"local_path": sched.LocalPath, "cron_expression": sched.CronExpression, "enabled": sched.Enabled,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate scan_schedules: %w", err)
 	}
 	return schedules, nil
 }
@@ -224,7 +211,7 @@ func (s *RESTServer) exportConfig(c *gin.Context) {
 		export["scan_paths"] = paths
 	}
 
-	schedules, err := s.exportSchedules()
+	schedules, err := s.exportSchedules(c.Request.Context())
 	if err != nil {
 		logger.Errorf("exportConfig: %v", err)
 		respondWithError(c, http.StatusInternalServerError, "Failed to export configuration", err)
@@ -442,21 +429,19 @@ func (s *RESTServer) importSchedules(ctx context.Context, schedules []importSche
 		}
 
 		// Check if a schedule with the same path and cron expression already exists
-		var existingID int
-		err := s.db.QueryRow("SELECT id FROM scan_schedules WHERE scan_path_id = ? AND cron_expression = ?",
-			scanPathID, sched.CronExpression).Scan(&existingID)
-		if err == nil {
+		if _, err := s.schedules.FindIDByPathAndCron(ctx, scanPathID, sched.CronExpression); err == nil {
 			logger.Debugf("Skipping duplicate schedule for path ID %d with cron %s", scanPathID, sched.CronExpression)
+			continue
+		} else if !errors.Is(err, repository.ErrNotFound) {
+			logger.Errorf("Failed to check for duplicate schedule for %s: %v", sched.LocalPath, err)
 			continue
 		}
 
-		_, err = s.db.Exec("INSERT INTO scan_schedules (scan_path_id, cron_expression, enabled) VALUES (?, ?, ?)",
-			scanPathID, sched.CronExpression, sched.Enabled)
-		if err == nil {
-			count++
-		} else {
+		if _, err := s.schedules.Create(ctx, scanPathID, sched.CronExpression, sched.Enabled); err != nil {
 			logger.Errorf("Failed to import schedule for %s: %v", sched.LocalPath, err)
+			continue
 		}
+		count++
 	}
 	return count
 }

--- a/internal/api/handlers_schedules.go
+++ b/internal/api/handlers_schedules.go
@@ -8,36 +8,21 @@ import (
 )
 
 func (s *RESTServer) getSchedules(c *gin.Context) {
-	rows, err := s.db.Query(`
-		SELECT s.id, s.scan_path_id, p.local_path, s.cron_expression, s.enabled
-		FROM scan_schedules s
-		JOIN scan_paths p ON s.scan_path_id = p.id
-	`)
+	rows, err := s.schedules.ListWithPaths(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	schedules := make([]gin.H, 0)
-	for rows.Next() {
-		var id, scanPathID int
-		var localPath, cronExpr string
-		var enabled bool
-		if rows.Scan(&id, &scanPathID, &localPath, &cronExpr, &enabled) != nil {
-			continue
-		}
+	schedules := make([]gin.H, 0, len(rows))
+	for _, sched := range rows {
 		schedules = append(schedules, gin.H{
-			"id":              id,
-			"scan_path_id":    scanPathID,
-			"local_path":      localPath,
-			"cron_expression": cronExpr,
-			"enabled":         enabled,
+			"id":              sched.ID,
+			"scan_path_id":    sched.ScanPathID,
+			"local_path":      sched.LocalPath,
+			"cron_expression": sched.CronExpression,
+			"enabled":         sched.Enabled,
 		})
-	}
-	if rows.Err() != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading schedules"})
-		return
 	}
 	c.JSON(http.StatusOK, schedules)
 }

--- a/internal/api/handlers_schedules_test.go
+++ b/internal/api/handlers_schedules_test.go
@@ -60,6 +60,7 @@ func setupSchedulesTestServer(t *testing.T, db *sql.DB, scheduler *testutil.Mock
 		hub:       hub,
 		scheduler: scheduler,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -72,6 +72,7 @@ type RESTServer struct {
 	sessions       *repository.SessionRepository
 	arrInstances   *repository.ArrInstanceRepository
 	scanPaths      *repository.ScanPathRepository
+	schedules      *repository.ScheduleRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -82,6 +83,7 @@ func (s *RESTServer) initRepositories() {
 	s.sessions = repository.NewSessionRepository(s.db)
 	s.arrInstances = repository.NewArrInstanceRepository(s.db)
 	s.scanPaths = repository.NewScanPathRepository(s.db)
+	s.schedules = repository.NewScheduleRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server

--- a/internal/repository/schedule.go
+++ b/internal/repository/schedule.go
@@ -1,0 +1,178 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Schedule is a row from the scan_schedules table.
+type Schedule struct {
+	ID             int64
+	ScanPathID     int64
+	CronExpression string
+	Enabled        bool
+}
+
+// ScheduleWithPath augments Schedule with the local_path of the joined
+// scan_paths row — what the schedules list endpoint and the config-export
+// path both need.
+type ScheduleWithPath struct {
+	Schedule
+	LocalPath string
+}
+
+// ScheduleRepository wraps the scan_schedules table.
+type ScheduleRepository struct {
+	db *sql.DB
+}
+
+// NewScheduleRepository returns a repository backed by db.
+func NewScheduleRepository(db *sql.DB) *ScheduleRepository {
+	return &ScheduleRepository{db: db}
+}
+
+// ListEnabled returns rows where enabled = 1. Used by the scheduler at
+// startup to (re)register cron jobs.
+func (r *ScheduleRepository) ListEnabled(ctx context.Context) ([]Schedule, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, scan_path_id, cron_expression, enabled FROM scan_schedules WHERE enabled = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("query enabled schedules: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Schedule
+	for rows.Next() {
+		var s Schedule
+		if err := rows.Scan(&s.ID, &s.ScanPathID, &s.CronExpression, &s.Enabled); err != nil {
+			return nil, fmt.Errorf("scan schedule row: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schedules: %w", err)
+	}
+	return out, nil
+}
+
+// ListWithPaths returns every schedule joined with its scan_path's
+// local_path. Skips rows whose scan_path has been deleted (INNER JOIN).
+func (r *ScheduleRepository) ListWithPaths(ctx context.Context) ([]ScheduleWithPath, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT s.id, s.scan_path_id, p.local_path, s.cron_expression, s.enabled
+		FROM scan_schedules s
+		JOIN scan_paths p ON s.scan_path_id = p.id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query schedules with paths: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ScheduleWithPath
+	for rows.Next() {
+		var sp ScheduleWithPath
+		if err := rows.Scan(&sp.ID, &sp.ScanPathID, &sp.LocalPath, &sp.CronExpression, &sp.Enabled); err != nil {
+			return nil, fmt.Errorf("scan schedule-with-path row: %w", err)
+		}
+		out = append(out, sp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schedules with paths: %w", err)
+	}
+	return out, nil
+}
+
+// GetByID returns the row matching id, or ErrNotFound.
+func (r *ScheduleRepository) GetByID(ctx context.Context, id int64) (Schedule, error) {
+	var s Schedule
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, scan_path_id, cron_expression, enabled FROM scan_schedules WHERE id = ?`, id,
+	).Scan(&s.ID, &s.ScanPathID, &s.CronExpression, &s.Enabled)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Schedule{}, ErrNotFound
+	}
+	if err != nil {
+		return Schedule{}, fmt.Errorf("get schedule: %w", err)
+	}
+	return s, nil
+}
+
+// FindIDByPathAndCron returns the id of the row with the given
+// scan_path_id and cron_expression, or ErrNotFound. Used by config-import
+// dedup so the same (path, cron) tuple isn't inserted twice.
+func (r *ScheduleRepository) FindIDByPathAndCron(ctx context.Context, scanPathID int64, cronExpr string) (int64, error) {
+	var id int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id FROM scan_schedules WHERE scan_path_id = ? AND cron_expression = ?`,
+		scanPathID, cronExpr).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("find schedule by (path, cron): %w", err)
+	}
+	return id, nil
+}
+
+// Create inserts a new schedule and returns its id.
+func (r *ScheduleRepository) Create(ctx context.Context, scanPathID int64, cronExpr string, enabled bool) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`INSERT INTO scan_schedules (scan_path_id, cron_expression, enabled) VALUES (?, ?, ?)`,
+		scanPathID, cronExpr, enabled)
+	if err != nil {
+		return 0, fmt.Errorf("insert schedule: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// Update updates the row's enabled flag and, if cronExpr is non-empty,
+// the cron_expression. The "keep existing cron when string is empty"
+// shape matches the existing PATCH semantics where omitting
+// cron_expression means "leave it alone."
+func (r *ScheduleRepository) Update(ctx context.Context, id int64, cronExpr string, enabled bool) error {
+	var err error
+	if cronExpr == "" {
+		_, err = r.db.ExecContext(ctx,
+			`UPDATE scan_schedules SET enabled = ? WHERE id = ?`, enabled, id)
+	} else {
+		_, err = r.db.ExecContext(ctx,
+			`UPDATE scan_schedules SET enabled = ?, cron_expression = ? WHERE id = ?`,
+			enabled, cronExpr, id)
+	}
+	if err != nil {
+		return fmt.Errorf("update schedule: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row matching id. Returns nil if no row matched.
+func (r *ScheduleRepository) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM scan_schedules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete schedule: %w", err)
+	}
+	return nil
+}
+
+// DeleteOrphaned removes schedules whose scan_path_id no longer exists.
+// Returns the count of removed rows.
+func (r *ScheduleRepository) DeleteOrphaned(ctx context.Context) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM scan_schedules
+		WHERE scan_path_id NOT IN (SELECT id FROM scan_paths)
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("delete orphaned schedules: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/internal/repository/schedule_test.go
+++ b/internal/repository/schedule_test.go
@@ -1,0 +1,217 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const scheduleSchema = `
+CREATE TABLE scan_paths (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	local_path TEXT NOT NULL UNIQUE,
+	arr_path TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE scan_schedules (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	scan_path_id    INTEGER NOT NULL,
+	cron_expression TEXT NOT NULL,
+	enabled         BOOLEAN DEFAULT 1,
+	created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newScheduleTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(scheduleSchema); err != nil {
+		t.Fatalf("create schedule schema: %v", err)
+	}
+	return db
+}
+
+func seedScanPath(t *testing.T, db *sql.DB, localPath string) int64 {
+	t.Helper()
+	res, err := db.Exec(`INSERT INTO scan_paths (local_path, arr_path) VALUES (?, ?)`, localPath, "/arr"+localPath)
+	if err != nil {
+		t.Fatalf("seed scan_path: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestScheduleRepository_Create_andListEnabled(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+
+	id, err := repo.Create(context.Background(), pathID, "0 * * * *", true)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == 0 {
+		t.Error("Create returned id=0")
+	}
+
+	enabled, err := repo.ListEnabled(context.Background())
+	if err != nil || len(enabled) != 1 {
+		t.Fatalf("ListEnabled = (%d, %v), want (1, nil)", len(enabled), err)
+	}
+	if enabled[0].CronExpression != "0 * * * *" || !enabled[0].Enabled {
+		t.Errorf("unexpected row: %+v", enabled[0])
+	}
+}
+
+func TestScheduleRepository_ListEnabled_skipsDisabled(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	_, _ = repo.Create(context.Background(), pathID, "0 * * * *", true)
+	_, _ = repo.Create(context.Background(), pathID, "0 0 * * *", false)
+
+	enabled, err := repo.ListEnabled(context.Background())
+	if err != nil || len(enabled) != 1 {
+		t.Fatalf("ListEnabled = (%d, %v), want (1, nil)", len(enabled), err)
+	}
+}
+
+func TestScheduleRepository_ListWithPaths(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/movies")
+	_, _ = repo.Create(context.Background(), pathID, "0 * * * *", true)
+
+	rows, err := repo.ListWithPaths(context.Background())
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("ListWithPaths = (%d, %v), want (1, nil)", len(rows), err)
+	}
+	if rows[0].LocalPath != "/movies" {
+		t.Errorf("LocalPath = %q, want /movies", rows[0].LocalPath)
+	}
+}
+
+func TestScheduleRepository_ListWithPaths_skipsOrphans(t *testing.T) {
+	// A schedule referencing a deleted scan_path should be excluded by the
+	// INNER JOIN (the export endpoint doesn't show stale rows).
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	_, _ = repo.Create(context.Background(), pathID, "0 * * * *", true)
+	// Insert a schedule referencing a non-existent scan_path.
+	if _, err := db.Exec(
+		`INSERT INTO scan_schedules (scan_path_id, cron_expression, enabled) VALUES (?, ?, ?)`,
+		999, "0 0 * * *", true,
+	); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	rows, err := repo.ListWithPaths(context.Background())
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("ListWithPaths = (%d, %v), want (1, nil) - orphan should be filtered", len(rows), err)
+	}
+}
+
+func TestScheduleRepository_GetByID_notFound(t *testing.T) {
+	repo := NewScheduleRepository(newScheduleTestDB(t))
+	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScheduleRepository_FindIDByPathAndCron(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	id, _ := repo.Create(context.Background(), pathID, "0 * * * *", true)
+
+	got, err := repo.FindIDByPathAndCron(context.Background(), pathID, "0 * * * *")
+	if err != nil || got != id {
+		t.Errorf("FindIDByPathAndCron = (%d, %v), want (%d, nil)", got, err, id)
+	}
+
+	if _, err := repo.FindIDByPathAndCron(context.Background(), pathID, "5 * * * *"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScheduleRepository_Update_cronAndEnabled(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	id, _ := repo.Create(context.Background(), pathID, "0 * * * *", true)
+
+	if err := repo.Update(context.Background(), id, "5 * * * *", false); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ := repo.GetByID(context.Background(), id)
+	if got.CronExpression != "5 * * * *" || got.Enabled {
+		t.Errorf("Update did not apply: %+v", got)
+	}
+}
+
+func TestScheduleRepository_Update_emptyCronOnlyChangesEnabled(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	id, _ := repo.Create(context.Background(), pathID, "0 * * * *", true)
+
+	if err := repo.Update(context.Background(), id, "", false); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ := repo.GetByID(context.Background(), id)
+	if got.CronExpression != "0 * * * *" {
+		t.Errorf("Update with empty cron clobbered cron_expression: %q", got.CronExpression)
+	}
+	if got.Enabled {
+		t.Errorf("Update did not disable: %+v", got)
+	}
+}
+
+func TestScheduleRepository_Delete(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	id, _ := repo.Create(context.Background(), pathID, "0 * * * *", true)
+
+	if err := repo.Delete(context.Background(), id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.GetByID(context.Background(), id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("After Delete: GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScheduleRepository_DeleteOrphaned(t *testing.T) {
+	db := newScheduleTestDB(t)
+	repo := NewScheduleRepository(db)
+	pathID := seedScanPath(t, db, "/a")
+	_, _ = repo.Create(context.Background(), pathID, "0 * * * *", true)
+	// Insert orphans directly (their scan_path_id doesn't exist).
+	if _, err := db.Exec(
+		`INSERT INTO scan_schedules (scan_path_id, cron_expression, enabled) VALUES (?, ?, ?), (?, ?, ?)`,
+		888, "0 0 * * *", true, 999, "0 12 * * *", true,
+	); err != nil {
+		t.Fatalf("seed orphans: %v", err)
+	}
+
+	n, err := repo.DeleteOrphaned(context.Background())
+	if err != nil {
+		t.Fatalf("DeleteOrphaned: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("DeleteOrphaned removed %d, want 2", n)
+	}
+
+	// The valid schedule should still be there.
+	enabled, _ := repo.ListEnabled(context.Background())
+	if len(enabled) != 1 {
+		t.Errorf("after DeleteOrphaned, ListEnabled = %d, want 1", len(enabled))
+	}
+}

--- a/internal/services/scheduler.go
+++ b/internal/services/scheduler.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // dbQueryTimeout is the maximum time to wait for a database query during scheduler operations.
@@ -31,20 +33,24 @@ type Scheduler interface {
 
 // SchedulerService manages scheduled scan jobs using cron expressions.
 type SchedulerService struct {
-	db      *sql.DB
-	scanner *ScannerService
-	cron    *cron.Cron
-	jobs    map[int]cron.EntryID
-	mu      sync.Mutex
+	db        *sql.DB
+	schedules *repository.ScheduleRepository
+	scanPaths *repository.ScanPathRepository
+	scanner   *ScannerService
+	cron      *cron.Cron
+	jobs      map[int]cron.EntryID
+	mu        sync.Mutex
 }
 
 // NewSchedulerService creates a new SchedulerService with the given database and scanner.
 func NewSchedulerService(db *sql.DB, scanner *ScannerService) *SchedulerService {
 	return &SchedulerService{
-		db:      db,
-		scanner: scanner,
-		cron:    cron.New(),
-		jobs:    make(map[int]cron.EntryID),
+		db:        db,
+		schedules: repository.NewScheduleRepository(db),
+		scanPaths: repository.NewScanPathRepository(db),
+		scanner:   scanner,
+		cron:      cron.New(),
+		jobs:      make(map[int]cron.EntryID),
 	}
 }
 
@@ -81,49 +87,30 @@ func (s *SchedulerService) LoadSchedules() error {
 	ctx, cancel := context.WithTimeout(context.Background(), dbQueryTimeout)
 	defer cancel()
 
-	rows, err := s.db.QueryContext(ctx, "SELECT id, scan_path_id, cron_expression, enabled FROM scan_schedules WHERE enabled = 1")
+	enabled, err := s.schedules.ListEnabled(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to query schedules: %w", err)
 	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			logger.Debugf("Scheduler: error closing rows: %v", err)
-		}
-	}()
 
 	logger.Debugf("Scheduler: iterating over schedules...")
 	count := 0
 	skipped := 0
-	for rows.Next() {
-		var id, scanPathID int
-		var cronExpr string
-		var enabled bool
-		if err := rows.Scan(&id, &scanPathID, &cronExpr, &enabled); err != nil {
-			logger.Errorf("Failed to scan schedule row: %v", err)
-			skipped++
-			continue
-		}
-
-		logger.Debugf("Scheduler: processing schedule %d (path_id=%d, cron=%s)", id, scanPathID, cronExpr)
+	for _, sched := range enabled {
+		logger.Debugf("Scheduler: processing schedule %d (path_id=%d, cron=%s)", sched.ID, sched.ScanPathID, sched.CronExpression)
 
 		// Pre-validate cron expression before attempting to add job
-		if _, parseErr := cron.ParseStandard(cronExpr); parseErr != nil {
-			logger.Errorf("Schedule %d has invalid cron expression '%s': %v - skipping", id, cronExpr, parseErr)
+		if _, parseErr := cron.ParseStandard(sched.CronExpression); parseErr != nil {
+			logger.Errorf("Schedule %d has invalid cron expression '%s': %v - skipping", sched.ID, sched.CronExpression, parseErr)
 			skipped++
 			continue
 		}
 
-		if err := s.addJob(id, scanPathID, cronExpr); err != nil {
-			logger.Errorf("Failed to add job for schedule %d: %v", id, err)
+		if err := s.addJob(int(sched.ID), int(sched.ScanPathID), sched.CronExpression); err != nil {
+			logger.Errorf("Failed to add job for schedule %d: %v", sched.ID, err)
 			skipped++
 		} else {
 			count++
 		}
-	}
-
-	// Check for iteration errors
-	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating schedule rows: %v", err)
 	}
 
 	if skipped > 0 {
@@ -140,14 +127,14 @@ func (s *SchedulerService) addJob(scheduleID, scanPathID int, cronExpr string) e
 	defer cancel()
 
 	// Verify scan path exists
-	var localPath string
-	err := s.db.QueryRowContext(ctx, "SELECT local_path FROM scan_paths WHERE id = ?", scanPathID).Scan(&localPath)
+	scanPath, err := s.scanPaths.GetByID(ctx, int64(scanPathID))
+	if errors.Is(err, repository.ErrNotFound) {
+		return fmt.Errorf("scan path %d not found (may have been deleted)", scanPathID)
+	}
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return fmt.Errorf("scan path %d not found (may have been deleted)", scanPathID)
-		}
 		return fmt.Errorf("failed to query scan path %d: %w", scanPathID, err)
 	}
+	localPath := scanPath.LocalPath
 
 	logger.Debugf("Scheduler: adding cron job for schedule %d (path: %s)", scheduleID, localPath)
 
@@ -174,12 +161,7 @@ func (s *SchedulerService) AddSchedule(scanPathID int, cronExpr string) (int64, 
 		return 0, fmt.Errorf("invalid cron expression: %v", err)
 	}
 
-	res, err := s.db.Exec("INSERT INTO scan_schedules (scan_path_id, cron_expression, enabled) VALUES (?, ?, 1)", scanPathID, cronExpr)
-	if err != nil {
-		return 0, err
-	}
-
-	id, err := res.LastInsertId()
+	id, err := s.schedules.Create(context.Background(), int64(scanPathID), cronExpr, true)
 	if err != nil {
 		return 0, err
 	}
@@ -195,8 +177,7 @@ func (s *SchedulerService) AddSchedule(scanPathID int, cronExpr string) (int64, 
 
 // DeleteSchedule removes a schedule by ID from the database and cron engine.
 func (s *SchedulerService) DeleteSchedule(id int) error {
-	_, err := s.db.Exec("DELETE FROM scan_schedules WHERE id = ?", id)
-	if err != nil {
+	if err := s.schedules.Delete(context.Background(), int64(id)); err != nil {
 		return err
 	}
 
@@ -217,18 +198,9 @@ func (s *SchedulerService) CleanupOrphanedSchedules() (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), dbQueryTimeout)
 	defer cancel()
 
-	// Find and delete schedules where the scan_path no longer exists
-	result, err := s.db.ExecContext(ctx, `
-		DELETE FROM scan_schedules
-		WHERE scan_path_id NOT IN (SELECT id FROM scan_paths)
-	`)
+	affected, err := s.schedules.DeleteOrphaned(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to cleanup orphaned schedules: %w", err)
-	}
-
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get affected rows: %w", err)
 	}
 
 	if affected > 0 {
@@ -248,17 +220,7 @@ func (s *SchedulerService) UpdateSchedule(id int, cronExpr string, enabled bool)
 	}
 
 	// Update DB
-	query := "UPDATE scan_schedules SET enabled = ?"
-	args := []interface{}{enabled}
-	if cronExpr != "" {
-		query += ", cron_expression = ?"
-		args = append(args, cronExpr)
-	}
-	query += " WHERE id = ?"
-	args = append(args, id)
-
-	_, err := s.db.Exec(query, args...)
-	if err != nil {
+	if err := s.schedules.Update(context.Background(), int64(id), cronExpr, enabled); err != nil {
 		return err
 	}
 
@@ -275,14 +237,12 @@ func (s *SchedulerService) UpdateSchedule(id int, cronExpr string, enabled bool)
 	// If enabled, add new job
 	if enabled {
 		// We need the scan_path_id and current cron expression (if not updated)
-		var scanPathID int
-		var currentCron string
-		err := s.db.QueryRow("SELECT scan_path_id, cron_expression FROM scan_schedules WHERE id = ?", id).Scan(&scanPathID, &currentCron)
+		sched, err := s.schedules.GetByID(context.Background(), int64(id))
 		if err != nil {
 			return fmt.Errorf("failed to fetch updated schedule: %v", err)
 		}
 
-		if err := s.addJob(id, scanPathID, currentCron); err != nil {
+		if err := s.addJob(id, int(sched.ScanPathID), sched.CronExpression); err != nil {
 			logger.Errorf("Failed to reschedule job %d: %v", id, err)
 		}
 	}

--- a/internal/services/scheduler_test.go
+++ b/internal/services/scheduler_test.go
@@ -142,7 +142,15 @@ func TestSchedulerService_LoadSchedules_WithValidSchedule(t *testing.T) {
 			id INTEGER PRIMARY KEY,
 			local_path TEXT NOT NULL,
 			arr_path TEXT NOT NULL,
-			enabled BOOLEAN DEFAULT 1
+			arr_instance_id INTEGER,
+			enabled BOOLEAN DEFAULT 1,
+			auto_remediate BOOLEAN DEFAULT 0,
+			dry_run BOOLEAN DEFAULT 0,
+			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+			detection_args TEXT,
+			detection_mode TEXT NOT NULL DEFAULT 'quick',
+			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER
 		);
 		CREATE TABLE scan_schedules (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary

Fourth Phase 3 PR. Migrates the scan_schedules table to \`ScheduleRepository\` — **all 10 SQL sites** across both handler and service layers. This is the first Phase 3 PR that crosses package boundaries: the scheduler service uses a repository now too.

| Layer | File | Sites |
|---|---|---|
| Service | scheduler.go | 6 (list-enabled, addJob path lookup, create, delete, cleanup, update, refresh-after-update) |
| Handler | handlers_schedules.go | 1 (list-with-paths) |
| Handler | handlers_config.go | 3 (export, import dedup, import create) |

## Design notes

- \`ScheduleWithPath\` augments \`Schedule\` with \`local_path\` from \`scan_paths\` — encapsulates the JOIN in one place rather than duplicating SQL across the schedules-list endpoint, the config-export, and any future caller.
- \`Update(ctx, id, cronExpr, enabled)\` preserves the existing \"empty cron means leave unchanged\" PATCH semantic from handlers_schedules.go's updateSchedule — branch is now inside the repo so the caller doesn't build SQL dynamically.
- \`DeleteOrphaned\` consolidates the \`DELETE … WHERE scan_path_id NOT IN (SELECT id FROM scan_paths)\` cleanup query.
- \`SchedulerService\` constructor signature **unchanged**: it builds its repos from the \`*sql.DB\` it already takes (\`NewScheduleRepository(db)\` + \`NewScanPathRepository(db)\`), so no caller updates anywhere.
- Reuses \`ScanPathRepository\` from #199 for the one scan_paths lookup in scheduler.go — the deferred-service-layer site I called out in that PR is now closed.

## Test plan

- [x] \`go test ./...\` — all packages pass (including scheduler integration tests)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/schedule_test.go\` covers Create, ListEnabled (filters disabled), ListWithPaths (filters orphans via INNER JOIN), GetByID, FindIDByPathAndCron, Update (with/without cron), Delete, DeleteOrphaned
- [x] Service-layer test schemas in scheduler_test.go updated to match repo SELECT shape