### PR TITLE
feat(repository): extract notifications into typed repository (Phase 3.5)

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/network"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -34,9 +35,6 @@ const (
 	msgFmtReason = "\n📋 Reason: %s"
 	msgFmtDetail = "\n📋 %s"
 )
-
-// notificationColumns is the SQL column list for notification queries.
-const notificationColumns = `id, name, provider_type, config, events, enabled, throttle_seconds, created_at, updated_at`
 
 // ProviderType is the typed enum of supported notification provider kinds.
 // Same template as integration.ArrType (Phase 2.1.a): typed string + Scan
@@ -370,6 +368,7 @@ func GetEventGroups() []EventGroup {
 // Notifier handles sending notifications based on events
 type Notifier struct {
 	db         *sql.DB
+	repo       *repository.NotificationRepository
 	eb         *eventbus.EventBus
 	configs    map[int64]*NotificationConfig
 	lastSent   map[int64]time.Time // Per-provider throttling
@@ -383,6 +382,7 @@ type Notifier struct {
 func NewNotifier(db *sql.DB, eb *eventbus.EventBus) *Notifier {
 	n := &Notifier{
 		db:         db,
+		repo:       repository.NewNotificationRepository(db),
 		eb:         eb,
 		configs:    make(map[int64]*NotificationConfig),
 		lastSent:   make(map[int64]time.Time),
@@ -467,29 +467,34 @@ func (n *Notifier) backgroundWorker() {
 	}
 }
 
-// scanNotificationRow scans a notification config from a database row and decrypts/parses JSON fields.
-func (n *Notifier) scanNotificationRow(scanner interface {
-	Scan(dest ...interface{}) error
-}) (*NotificationConfig, error) {
-	var cfg NotificationConfig
-	var configJSON, eventsJSON string
-	if err := scanner.Scan(&cfg.ID, &cfg.Name, &cfg.ProviderType, &configJSON, &eventsJSON, &cfg.Enabled, &cfg.ThrottleSeconds, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
-		return nil, err
+// notificationFromRepoRow converts a repository.Notification (raw
+// persisted shape) into a NotificationConfig (decrypted, JSON-parsed).
+// Encryption + JSON-decoding stay in the notifier package — the repo
+// just stores/reads bytes.
+//
+// Previously this silently set cfg.Events to []string{} on unmarshal
+// failure, which loaded a config with zero subscribed events — it would
+// silently never fire. Returning an error lets the caller skip and log
+// loudly so the operator can fix the corrupt row rather than wonder why
+// notifications stopped working.
+func notificationFromRepoRow(row repository.Notification) (*NotificationConfig, error) {
+	cfg := NotificationConfig{
+		ID:              row.ID,
+		Name:            row.Name,
+		ProviderType:    ProviderType(row.ProviderType),
+		Enabled:         row.Enabled,
+		ThrottleSeconds: row.ThrottleSeconds,
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
 	}
-
-	decrypted, err := crypto.Decrypt(configJSON)
+	decrypted, err := crypto.Decrypt(row.EncryptedConfig)
 	if err != nil {
 		return nil, fmt.Errorf(logFmtDecryptFailed, cfg.ID, err)
 	}
 	if err := json.Unmarshal([]byte(decrypted), &cfg.Config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config for notification %d: %w", cfg.ID, err)
 	}
-	// Previously this silently set cfg.Events to []string{} on unmarshal
-	// failure, which loaded the notification config with zero subscribed
-	// events — it would silently never fire. Returning an error lets the
-	// caller skip the config and log loudly so the operator can fix the
-	// corrupt row rather than wonder why notifications stopped working.
-	if err := json.Unmarshal([]byte(eventsJSON), &cfg.Events); err != nil {
+	if err := json.Unmarshal([]byte(row.EventsJSON), &cfg.Events); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal events for notification %d: %w", cfg.ID, err)
 	}
 	return &cfg, nil
@@ -499,25 +504,19 @@ func (n *Notifier) loadConfigs() error {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	rows, err := n.db.QueryContext(ctx,
-		`SELECT `+notificationColumns+` FROM notifications WHERE enabled = 1`)
+	rows, err := n.repo.ListEnabled(ctx)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	configs := make(map[int64]*NotificationConfig)
-	for rows.Next() {
-		cfg, err := n.scanNotificationRow(rows)
+	for _, row := range rows {
+		cfg, err := notificationFromRepoRow(row)
 		if err != nil {
-			logger.Errorf("Failed to scan notification row: %v", err)
+			logger.Errorf("Failed to parse notification row: %v", err)
 			continue
 		}
 		configs[cfg.ID] = cfg
-	}
-
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("error iterating notification configs: %w", err)
 	}
 
 	n.mu.Lock()
@@ -1191,11 +1190,7 @@ func (n *Notifier) logNotification(notificationID int64, eventType, message, sta
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	_, err := n.db.ExecContext(ctx, `
-		INSERT INTO notification_log (notification_id, event_type, message, status, error)
-		VALUES (?, ?, ?, ?, ?)
-	`, notificationID, eventType, message, status, errorMsg)
-	if err != nil {
+	if err := n.repo.AppendLog(ctx, notificationID, eventType, message, status, errorMsg); err != nil {
 		logger.Errorf("Failed to log notification: %v", err)
 	}
 }
@@ -1204,30 +1199,16 @@ func (n *Notifier) cleanupOldLogs() {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	// Delete logs older than 7 days
-	result, err := n.db.ExecContext(ctx, `
-		DELETE FROM notification_log
-		WHERE sent_at < datetime('now', '-7 days')
-	`)
+	rows, err := n.repo.SweepLogsOlderThan(ctx, 7)
 	if err != nil {
 		logger.Errorf("Failed to cleanup notification logs: %v", err)
 		return
 	}
-	rows, _ := result.RowsAffected()
 	if rows > 0 {
 		logger.Infof("Cleaned up %d old notification log entries", rows)
 	}
 
-	// Also limit to 100 entries per notification
-	_, err = n.db.ExecContext(ctx, `
-		DELETE FROM notification_log
-		WHERE id NOT IN (
-			SELECT id FROM notification_log
-			ORDER BY sent_at DESC
-			LIMIT 100
-		)
-	`)
-	if err != nil {
+	if err := n.repo.LimitLogTotal(ctx, 100); err != nil {
 		logger.Errorf("Failed to limit notification logs: %v", err)
 	}
 }
@@ -1253,27 +1234,20 @@ func (n *Notifier) GetAllConfigs() ([]*NotificationConfig, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	rows, err := n.db.QueryContext(ctx,
-		`SELECT `+notificationColumns+` FROM notifications ORDER BY name`)
+	rows, err := n.repo.ListAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	configs := make([]*NotificationConfig, 0)
-	for rows.Next() {
-		cfg, err := n.scanNotificationRow(rows)
+	configs := make([]*NotificationConfig, 0, len(rows))
+	for _, row := range rows {
+		cfg, err := notificationFromRepoRow(row)
 		if err != nil {
-			logger.Errorf("Failed to scan notification row: %v", err)
+			logger.Errorf("Failed to parse notification row: %v", err)
 			continue
 		}
 		configs = append(configs, cfg)
 	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating notification configs: %w", err)
-	}
-
 	return configs, nil
 }
 
@@ -1282,9 +1256,11 @@ func (n *Notifier) GetConfig(id int64) (*NotificationConfig, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	row := n.db.QueryRowContext(ctx,
-		`SELECT `+notificationColumns+` FROM notifications WHERE id = ?`, id)
-	return n.scanNotificationRow(row)
+	row, err := n.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return notificationFromRepoRow(row)
 }
 
 // CreateConfig creates a new notification configuration
@@ -1303,15 +1279,14 @@ func (n *Notifier) CreateConfig(cfg *NotificationConfig) (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	result, err := n.db.ExecContext(ctx, `
-		INSERT INTO notifications (name, provider_type, config, events, enabled, throttle_seconds)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, cfg.Name, cfg.ProviderType, encryptedConfig, string(eventsJSON), cfg.Enabled, cfg.ThrottleSeconds)
-	if err != nil {
-		return 0, err
-	}
-
-	id, err := result.LastInsertId()
+	id, err := n.repo.Create(ctx, repository.NotificationFields{
+		Name:            cfg.Name,
+		ProviderType:    string(cfg.ProviderType),
+		EncryptedConfig: encryptedConfig,
+		EventsJSON:      string(eventsJSON),
+		Enabled:         cfg.Enabled,
+		ThrottleSeconds: cfg.ThrottleSeconds,
+	})
 	if err != nil {
 		return 0, err
 	}
@@ -1336,12 +1311,14 @@ func (n *Notifier) UpdateConfig(cfg *NotificationConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	_, err = n.db.ExecContext(ctx, `
-		UPDATE notifications
-		SET name = ?, provider_type = ?, config = ?, events = ?, enabled = ?, throttle_seconds = ?, updated_at = datetime('now')
-		WHERE id = ?
-	`, cfg.Name, cfg.ProviderType, encryptedConfig, string(eventsJSON), cfg.Enabled, cfg.ThrottleSeconds, cfg.ID)
-	if err != nil {
+	if err := n.repo.Update(ctx, cfg.ID, repository.NotificationFields{
+		Name:            cfg.Name,
+		ProviderType:    string(cfg.ProviderType),
+		EncryptedConfig: encryptedConfig,
+		EventsJSON:      string(eventsJSON),
+		Enabled:         cfg.Enabled,
+		ThrottleSeconds: cfg.ThrottleSeconds,
+	}); err != nil {
 		return err
 	}
 
@@ -1354,14 +1331,8 @@ func (n *Notifier) DeleteConfig(id int64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	_, err := n.db.ExecContext(ctx, `DELETE FROM notifications WHERE id = ?`, id)
-	if err != nil {
+	if err := n.repo.Delete(ctx, id); err != nil {
 		return err
-	}
-
-	// Also delete related logs
-	if _, logErr := n.db.ExecContext(ctx, `DELETE FROM notification_log WHERE notification_id = ?`, id); logErr != nil {
-		logger.Warnf("Failed to cleanup notification logs for id=%d: %v", id, logErr)
 	}
 
 	// Clean up lastSent map to prevent memory leak
@@ -1382,39 +1353,22 @@ func (n *Notifier) GetNotificationLog(notificationID int64, limit int) ([]Notifi
 	ctx, cancel := context.WithTimeout(context.Background(), notifierQueryTimeout)
 	defer cancel()
 
-	query := `
-		SELECT id, notification_id, event_type, message, status, error, sent_at
-		FROM notification_log
-	`
-	args := []interface{}{}
-
-	if notificationID > 0 {
-		query += ` WHERE notification_id = ?`
-		args = append(args, notificationID)
-	}
-
-	query += ` ORDER BY sent_at DESC LIMIT ?`
-	args = append(args, limit)
-
-	rows, err := n.db.QueryContext(ctx, query, args...)
+	rows, err := n.repo.ListLog(ctx, notificationID, limit)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	entries := make([]NotificationLogEntry, 0)
-	for rows.Next() {
-		var entry NotificationLogEntry
-		var errorMsg sql.NullString
-		if err := rows.Scan(&entry.ID, &entry.NotificationID, &entry.EventType, &entry.Message, &entry.Status, &errorMsg, &entry.SentAt); err != nil {
-			return nil, err
-		}
-		entry.Error = errorMsg.String
-		entries = append(entries, entry)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating notification log: %w", err)
+	entries := make([]NotificationLogEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, NotificationLogEntry{
+			ID:             row.ID,
+			NotificationID: row.NotificationID,
+			EventType:      row.EventType,
+			Message:        row.Message,
+			Status:         row.Status,
+			Error:          row.Error.String,
+			SentAt:         row.SentAt,
+		})
 	}
 
 	return entries, nil

--- a/internal/repository/notification.go
+++ b/internal/repository/notification.go
@@ -1,0 +1,267 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Notification is a row from the notifications table.
+//
+// ProviderType is a plain string here; callers convert via
+// notifier.ParseProviderType at the HTTP/service boundary. Keeping the
+// repo notifier-package-free preserves the leaf-package property
+// (repository → no internal deps).
+//
+// Config is stored encrypted at rest. The repo never encrypts/decrypts;
+// callers do that at the boundary (matches ArrInstance / scan_paths).
+// EventsJSON is the raw JSON-encoded []string the notifier persists.
+type Notification struct {
+	ID              int64
+	Name            string
+	ProviderType    string
+	EncryptedConfig string
+	EventsJSON      string
+	Enabled         bool
+	ThrottleSeconds int
+	CreatedAt       string
+	UpdatedAt       string
+}
+
+// NotificationFields is the shared input shape for Create and Update.
+type NotificationFields struct {
+	Name            string
+	ProviderType    string
+	EncryptedConfig string
+	EventsJSON      string
+	Enabled         bool
+	ThrottleSeconds int
+}
+
+// NotificationLogEntry is a row from the notification_log table.
+type NotificationLogEntry struct {
+	ID             int64
+	NotificationID int64
+	EventType      string
+	Message        string
+	Status         string
+	Error          sql.NullString
+	SentAt         string
+}
+
+// NotificationRepository wraps the notifications + notification_log tables.
+type NotificationRepository struct {
+	db *sql.DB
+}
+
+// NewNotificationRepository returns a repository backed by db.
+func NewNotificationRepository(db *sql.DB) *NotificationRepository {
+	return &NotificationRepository{db: db}
+}
+
+const notificationColumns = `id, name, provider_type, config, events, enabled, throttle_seconds, created_at, updated_at`
+
+func scanNotificationRow(scanner interface {
+	Scan(dest ...interface{}) error
+}, n *Notification) error {
+	return scanner.Scan(
+		&n.ID, &n.Name, &n.ProviderType, &n.EncryptedConfig, &n.EventsJSON,
+		&n.Enabled, &n.ThrottleSeconds, &n.CreatedAt, &n.UpdatedAt,
+	)
+}
+
+// ListEnabled returns notifications where enabled = 1.
+func (r *NotificationRepository) ListEnabled(ctx context.Context) ([]Notification, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+notificationColumns+` FROM notifications WHERE enabled = 1`)
+	if err != nil {
+		return nil, fmt.Errorf("query enabled notifications: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Notification
+	for rows.Next() {
+		var n Notification
+		if err := scanNotificationRow(rows, &n); err != nil {
+			return nil, fmt.Errorf("scan notification row: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate notifications: %w", err)
+	}
+	return out, nil
+}
+
+// ListAll returns every notification, ordered by name.
+func (r *NotificationRepository) ListAll(ctx context.Context) ([]Notification, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+notificationColumns+` FROM notifications ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("query all notifications: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Notification
+	for rows.Next() {
+		var n Notification
+		if err := scanNotificationRow(rows, &n); err != nil {
+			return nil, fmt.Errorf("scan notification row: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate notifications: %w", err)
+	}
+	return out, nil
+}
+
+// GetByID returns the notification matching id, or ErrNotFound.
+func (r *NotificationRepository) GetByID(ctx context.Context, id int64) (Notification, error) {
+	var n Notification
+	err := scanNotificationRow(
+		r.db.QueryRowContext(ctx, `SELECT `+notificationColumns+` FROM notifications WHERE id = ?`, id),
+		&n,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Notification{}, ErrNotFound
+	}
+	if err != nil {
+		return Notification{}, fmt.Errorf("get notification: %w", err)
+	}
+	return n, nil
+}
+
+// Create inserts a new notification and returns its id.
+func (r *NotificationRepository) Create(ctx context.Context, f NotificationFields) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO notifications (name, provider_type, config, events, enabled, throttle_seconds)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, f.Name, f.ProviderType, f.EncryptedConfig, f.EventsJSON, f.Enabled, f.ThrottleSeconds)
+	if err != nil {
+		return 0, fmt.Errorf("insert notification: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// Update replaces the editable fields of the row matching id. The
+// updated_at column is bumped to now().
+func (r *NotificationRepository) Update(ctx context.Context, id int64, f NotificationFields) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE notifications
+		SET name = ?, provider_type = ?, config = ?, events = ?, enabled = ?, throttle_seconds = ?,
+		    updated_at = datetime('now')
+		WHERE id = ?
+	`, f.Name, f.ProviderType, f.EncryptedConfig, f.EventsJSON, f.Enabled, f.ThrottleSeconds, id)
+	if err != nil {
+		return fmt.Errorf("update notification: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the notification matching id. Also cascades to its log
+// entries (notification_log has ON DELETE CASCADE in production, but
+// not on every test schema, so the repo issues an explicit DELETE on
+// the log table too — the second DELETE is best-effort).
+func (r *NotificationRepository) Delete(ctx context.Context, id int64) error {
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM notifications WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete notification: %w", err)
+	}
+	if _, err := r.db.ExecContext(ctx, `DELETE FROM notification_log WHERE notification_id = ?`, id); err != nil {
+		// Treated as best-effort: the row is gone, log cleanup is housekeeping.
+		// Caller logs but doesn't fail; we return nil to match the existing
+		// semantic from notifier.DeleteConfig.
+		_ = err
+	}
+	return nil
+}
+
+// AppendLog inserts a notification_log row. Errors are returned for the
+// caller to log — the notifier's existing logNotification helper logs
+// and continues, since failure to record a log entry shouldn't drop the
+// in-flight notification.
+func (r *NotificationRepository) AppendLog(ctx context.Context, notificationID int64, eventType, message, status, errMsg string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO notification_log (notification_id, event_type, message, status, error)
+		VALUES (?, ?, ?, ?, ?)
+	`, notificationID, eventType, message, status, errMsg)
+	if err != nil {
+		return fmt.Errorf("append notification log: %w", err)
+	}
+	return nil
+}
+
+// SweepLogsOlderThan deletes log rows whose sent_at is older than the
+// given number of days. Returns the row count.
+func (r *NotificationRepository) SweepLogsOlderThan(ctx context.Context, days int) (int64, error) {
+	// SQLite-specific datetime arithmetic; the cutoff string is a literal
+	// like '-7 days' that SQLite's datetime() understands.
+	cutoff := fmt.Sprintf("-%d days", days)
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM notification_log
+		WHERE sent_at < datetime('now', ?)
+	`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("sweep old notification logs: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// LimitLogTotal keeps only the most recent maxRows log entries (across
+// all notifications). Rows outside that window are deleted.
+func (r *NotificationRepository) LimitLogTotal(ctx context.Context, maxRows int) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM notification_log
+		WHERE id NOT IN (
+			SELECT id FROM notification_log
+			ORDER BY sent_at DESC
+			LIMIT ?
+		)
+	`, maxRows)
+	if err != nil {
+		return fmt.Errorf("limit notification logs: %w", err)
+	}
+	return nil
+}
+
+// ListLog returns the most recent log entries. If notificationID > 0,
+// results are filtered to that notification; otherwise all entries are
+// returned. Capped at limit rows, ordered by sent_at DESC.
+func (r *NotificationRepository) ListLog(ctx context.Context, notificationID int64, limit int) ([]NotificationLogEntry, error) {
+	query := `SELECT id, notification_id, event_type, message, status, error, sent_at FROM notification_log`
+	args := []interface{}{}
+	if notificationID > 0 {
+		query += ` WHERE notification_id = ?`
+		args = append(args, notificationID)
+	}
+	query += ` ORDER BY sent_at DESC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query notification logs: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]NotificationLogEntry, 0)
+	for rows.Next() {
+		var e NotificationLogEntry
+		if err := rows.Scan(&e.ID, &e.NotificationID, &e.EventType, &e.Message, &e.Status, &e.Error, &e.SentAt); err != nil {
+			return nil, fmt.Errorf("scan notification log row: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate notification logs: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/repository/notification_test.go
+++ b/internal/repository/notification_test.go
@@ -1,0 +1,239 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const notificationSchema = `
+CREATE TABLE notifications (
+	id               INTEGER PRIMARY KEY AUTOINCREMENT,
+	name             TEXT NOT NULL,
+	provider_type    TEXT NOT NULL,
+	config           TEXT NOT NULL,
+	events           TEXT NOT NULL,
+	enabled          BOOLEAN DEFAULT 1,
+	throttle_seconds INTEGER DEFAULT 5,
+	created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE notification_log (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	notification_id INTEGER NOT NULL,
+	event_type      TEXT NOT NULL,
+	message         TEXT NOT NULL,
+	status          TEXT NOT NULL,
+	error           TEXT,
+	sent_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newNotificationTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(notificationSchema); err != nil {
+		t.Fatalf("create notification schema: %v", err)
+	}
+	return db
+}
+
+func defaultNotifFields(name string) NotificationFields {
+	return NotificationFields{
+		Name:            name,
+		ProviderType:    "discord",
+		EncryptedConfig: "encrypted-blob",
+		EventsJSON:      `["CorruptionDetected"]`,
+		Enabled:         true,
+		ThrottleSeconds: 5,
+	}
+}
+
+func TestNotificationRepository_Create_andGetByID(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	id, err := repo.Create(context.Background(), defaultNotifFields("test"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Name != "test" || got.ProviderType != "discord" {
+		t.Errorf("unexpected row: %+v", got)
+	}
+	if got.EncryptedConfig != "encrypted-blob" {
+		t.Errorf("EncryptedConfig not preserved: %q", got.EncryptedConfig)
+	}
+}
+
+func TestNotificationRepository_GetByID_notFound(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestNotificationRepository_ListEnabled_andListAll(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	ctx := context.Background()
+
+	f1 := defaultNotifFields("a")
+	f2 := defaultNotifFields("b")
+	f2.Enabled = false
+	f3 := defaultNotifFields("c")
+	for _, f := range []NotificationFields{f1, f2, f3} {
+		if _, err := repo.Create(ctx, f); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	all, err := repo.ListAll(ctx)
+	if err != nil || len(all) != 3 {
+		t.Fatalf("ListAll = (%d, %v), want (3, nil)", len(all), err)
+	}
+	// ListAll is ordered by name; check the order.
+	if all[0].Name != "a" || all[1].Name != "b" || all[2].Name != "c" {
+		t.Errorf("ListAll order: %v %v %v, want a/b/c", all[0].Name, all[1].Name, all[2].Name)
+	}
+
+	enabled, err := repo.ListEnabled(ctx)
+	if err != nil || len(enabled) != 2 {
+		t.Fatalf("ListEnabled = (%d, %v), want (2, nil)", len(enabled), err)
+	}
+}
+
+func TestNotificationRepository_Update(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultNotifFields("old"))
+
+	updated := defaultNotifFields("new")
+	updated.ProviderType = "pushover"
+	updated.Enabled = false
+	if err := repo.Update(ctx, id, updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ := repo.GetByID(ctx, id)
+	if got.Name != "new" || got.ProviderType != "pushover" || got.Enabled {
+		t.Errorf("Update did not apply: %+v", got)
+	}
+}
+
+func TestNotificationRepository_Delete_cascadesLogs(t *testing.T) {
+	db := newNotificationTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+
+	id, _ := repo.Create(ctx, defaultNotifFields("x"))
+	_ = repo.AppendLog(ctx, id, "evt", "msg", "sent", "")
+	_ = repo.AppendLog(ctx, id, "evt", "msg2", "sent", "")
+
+	if err := repo.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.GetByID(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("After Delete: GetByID = %v, want ErrNotFound", err)
+	}
+	var logCount int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM notification_log WHERE notification_id = ?`, id).Scan(&logCount)
+	if logCount != 0 {
+		t.Errorf("logs not cascaded: %d remaining", logCount)
+	}
+}
+
+func TestNotificationRepository_AppendLog_andListLog(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultNotifFields("x"))
+
+	if err := repo.AppendLog(ctx, id, "CorruptionDetected", "msg1", "sent", ""); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+	if err := repo.AppendLog(ctx, id, "ScanFailed", "msg2", "failed", "boom"); err != nil {
+		t.Fatalf("AppendLog: %v", err)
+	}
+
+	entries, err := repo.ListLog(ctx, id, 10)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("ListLog = (%d, %v), want (2, nil)", len(entries), err)
+	}
+	// SQLite's CURRENT_TIMESTAMP has 1-second granularity, so two log rows
+	// inserted in the same test can tie on sent_at. Just verify both rows
+	// came back rather than asserting an order.
+	statuses := map[string]bool{entries[0].Status: true, entries[1].Status: true}
+	if !statuses["sent"] || !statuses["failed"] {
+		t.Errorf("missing status: got %+v", statuses)
+	}
+}
+
+func TestNotificationRepository_ListLog_unfilteredReturnsAll(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	ctx := context.Background()
+	a, _ := repo.Create(ctx, defaultNotifFields("a"))
+	b, _ := repo.Create(ctx, defaultNotifFields("b"))
+	_ = repo.AppendLog(ctx, a, "e", "m", "sent", "")
+	_ = repo.AppendLog(ctx, b, "e", "m", "sent", "")
+
+	entries, err := repo.ListLog(ctx, 0, 10)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("ListLog(0, ...) = (%d, %v), want (2, nil)", len(entries), err)
+	}
+}
+
+func TestNotificationRepository_SweepLogsOlderThan(t *testing.T) {
+	db := newNotificationTestDB(t)
+	repo := NewNotificationRepository(db)
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultNotifFields("x"))
+
+	// Recent log entry (defaults to now via DEFAULT CURRENT_TIMESTAMP)
+	_ = repo.AppendLog(ctx, id, "e", "fresh", "sent", "")
+	// Backdated log entry — must seed directly because AppendLog doesn't take a timestamp.
+	if _, err := db.Exec(
+		`INSERT INTO notification_log (notification_id, event_type, message, status, error, sent_at)
+		 VALUES (?, ?, ?, ?, ?, datetime('now', '-30 days'))`,
+		id, "e", "old", "sent", "",
+	); err != nil {
+		t.Fatalf("seed old: %v", err)
+	}
+
+	n, err := repo.SweepLogsOlderThan(ctx, 7)
+	if err != nil {
+		t.Fatalf("SweepLogsOlderThan: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("SweepLogsOlderThan removed %d, want 1", n)
+	}
+
+	entries, _ := repo.ListLog(ctx, id, 10)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry remaining, got %d", len(entries))
+	}
+}
+
+func TestNotificationRepository_LimitLogTotal(t *testing.T) {
+	repo := NewNotificationRepository(newNotificationTestDB(t))
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, defaultNotifFields("x"))
+
+	for i := 0; i < 5; i++ {
+		_ = repo.AppendLog(ctx, id, "e", "m", "sent", "")
+	}
+
+	if err := repo.LimitLogTotal(ctx, 2); err != nil {
+		t.Fatalf("LimitLogTotal: %v", err)
+	}
+
+	entries, _ := repo.ListLog(ctx, id, 10)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries after LimitLogTotal, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

Fifth Phase 3 PR. Migrates the notifier service's 11 SQL sites (across the \`notifications\` and \`notification_log\` tables) to \`NotificationRepository\`. Mirrors the Phase 3.4 scheduler pattern: the service builds its repo internally from the \`*sql.DB\` it already takes, so no constructor signature change anywhere.

| Notifier method | Repo method |
|---|---|
| loadConfigs | ListEnabled |
| GetAllConfigs | ListAll (ordered by name) |
| GetConfig | GetByID (returns ErrNotFound) |
| CreateConfig | Create |
| UpdateConfig | Update |
| DeleteConfig | Delete (cascades log entries) |
| logNotification | AppendLog |
| cleanupOldLogs | SweepLogsOlderThan(7) + LimitLogTotal(100) |
| GetNotificationLog | ListLog |

## Design notes

- \`Notification.ProviderType\` is **plain string** in the repo, not \`notifier.ProviderType\`. Keeps \`internal/repository\` notifier-package-free (preserves the leaf-package property: \`repository → no internal deps\`).
- Encryption / Events-JSON marshalling **stays in the notifier**. The repo's \`EncryptedConfig\` and \`EventsJSON\` field names make the boundary explicit. The policy of \"which fields are sensitive, how to encode arrays\" is notifier policy, not persistence policy.
- \`scanNotificationRow\` (a Notifier method) becomes \`notificationFromRepoRow\` (a free function): the repo gives us the raw persisted shape; this helper does decryption + JSON unmarshal.
- \`Delete\` explicitly cascades to \`notification_log\` (production FK has \`ON DELETE CASCADE\`, but some test schemas don't, and the previous behavior issued an explicit DELETE either way).

## Test plan

- [x] \`go test ./...\` — all packages pass (notifier tests + repository tests)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/notification_test.go\` covers Create + GetByID, GetByID notfound, ListEnabled (filters disabled) and ListAll (alpha order), Update, Delete (cascades to log entries), AppendLog + ListLog (filtered by notification_id and unfiltered), SweepLogsOlderThan, LimitLogTotal