### PR TITLE
feat(repository): finish scan_paths service-layer migration (Phase 3.6)

### DIFF
--- a/internal/integration/path_mapper.go
+++ b/internal/integration/path_mapper.go
@@ -1,17 +1,21 @@
 package integration
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // SQLPathMapper translates between local filesystem paths and *arr paths.
 type SQLPathMapper struct {
-	db       *sql.DB
-	mappings []PathMapping
-	mu       sync.RWMutex
+	db        *sql.DB
+	scanPaths *repository.ScanPathRepository
+	mappings  []PathMapping
+	mu        sync.RWMutex
 }
 
 // PathMapping defines a mapping between a local path and its *arr equivalent.
@@ -23,7 +27,8 @@ type PathMapping struct {
 // NewPathMapper creates a SQLPathMapper and loads mappings from the database.
 func NewPathMapper(db *sql.DB) (*SQLPathMapper, error) {
 	pm := &SQLPathMapper{
-		db: db,
+		db:        db,
+		scanPaths: repository.NewScanPathRepository(db),
 	}
 	if err := pm.Reload(); err != nil {
 		return nil, err
@@ -35,27 +40,19 @@ func (pm *SQLPathMapper) Reload() error {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	rows, err := pm.db.Query("SELECT local_path, arr_path FROM scan_paths WHERE enabled = 1")
+	rows, err := pm.scanPaths.ListEnabled(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to query scan_paths: %w", err)
 	}
-	defer rows.Close()
 
-	var mappings []PathMapping
-	for rows.Next() {
-		var m PathMapping
-		if err := rows.Scan(&m.LocalPath, &m.ArrPath); err != nil {
-			return fmt.Errorf("failed to scan path mapping: %w", err)
-		}
+	mappings := make([]PathMapping, 0, len(rows))
+	for _, row := range rows {
 		// Ensure paths don't have trailing slashes for consistent matching,
 		// unless it's root (which shouldn't happen for media folders)
-		m.LocalPath = strings.TrimRight(m.LocalPath, "/")
-		m.ArrPath = strings.TrimRight(m.ArrPath, "/")
-		mappings = append(mappings, m)
-	}
-
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("error iterating path mappings: %w", err)
+		mappings = append(mappings, PathMapping{
+			LocalPath: strings.TrimRight(row.LocalPath, "/"),
+			ArrPath:   strings.TrimRight(row.ArrPath, "/"),
+		})
 	}
 
 	pm.mappings = mappings

--- a/internal/integration/path_mapper_test.go
+++ b/internal/integration/path_mapper_test.go
@@ -25,9 +25,15 @@ func newTestDBForPathMapper() (*sql.DB, error) {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			local_path TEXT NOT NULL,
 			arr_path TEXT NOT NULL,
+			arr_instance_id INTEGER,
 			auto_remediate INTEGER NOT NULL DEFAULT 0,
 			dry_run INTEGER NOT NULL DEFAULT 0,
 			enabled INTEGER NOT NULL DEFAULT 1,
+			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+			detection_args TEXT,
+			detection_mode TEXT NOT NULL DEFAULT 'quick',
+			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)
 	`)

--- a/internal/services/recovery_test.go
+++ b/internal/services/recovery_test.go
@@ -55,9 +55,15 @@ func setupRecoveryTestDB(t *testing.T) *sql.DB {
 			id INTEGER PRIMARY KEY,
 			local_path TEXT NOT NULL,
 			arr_path TEXT NOT NULL,
-			instance_id INTEGER,
+			arr_instance_id INTEGER,
 			enabled BOOLEAN DEFAULT 1,
-			max_retries INTEGER DEFAULT 3
+			auto_remediate BOOLEAN DEFAULT 0,
+			dry_run BOOLEAN DEFAULT 0,
+			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+			detection_args TEXT,
+			detection_mode TEXT NOT NULL DEFAULT 'quick',
+			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER
 		);
 	`)
 	if err != nil {
@@ -341,7 +347,7 @@ func TestGetLocalPath_WithMapper(t *testing.T) {
 
 	// Add a mapping (requires scan_paths table entry)
 	_, err := db.Exec(`
-		INSERT INTO scan_paths (id, local_path, arr_path, instance_id, enabled)
+		INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, enabled)
 		VALUES (?, ?, ?, ?, ?)
 	`, 1, "/local/media", "/arr/media", 1, true)
 	if err != nil {

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -306,6 +307,7 @@ type Scanner interface {
 // ScannerService manages file scanning operations for corruption detection.
 type ScannerService struct {
 	db          *sql.DB
+	scanPaths   *repository.ScanPathRepository
 	eventBus    *eventbus.EventBus
 	detector    integration.HealthChecker
 	pathMapper  integration.PathMapper
@@ -326,7 +328,7 @@ type ScannerService struct {
 
 // NewScannerService creates a new ScannerService with the given dependencies.
 func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.HealthChecker, pm integration.PathMapper) *ScannerService {
-	return &ScannerService{
+	s := &ScannerService{
 		db:              db,
 		eventBus:        eb,
 		detector:        detector,
@@ -335,6 +337,25 @@ func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.H
 		filesInProgress: make(map[string]bool),
 		shutdownCh:      make(chan struct{}),
 	}
+	s.initRepositories()
+	return s
+}
+
+// initRepositories populates the domain repository fields from s.db. Safe
+// to call multiple times; safe when s.db is nil. Called from
+// NewScannerService and also lazily from scanPathRepo() so existing tests
+// that construct &ScannerService{} directly don't need a fixture update
+// just to satisfy a new repo field.
+func (s *ScannerService) initRepositories() {
+	if s.scanPaths == nil && s.db != nil {
+		s.scanPaths = repository.NewScanPathRepository(s.db)
+	}
+}
+
+// scanPathRepo returns the lazy-initialized ScanPathRepository.
+func (s *ScannerService) scanPathRepo() *repository.ScanPathRepository {
+	s.initRepositories()
+	return s.scanPaths
 }
 
 // IsFileBeingScanned returns true if the given file is currently being scanned.
@@ -732,26 +753,24 @@ type scanPathSettings struct {
 // loadScanPathSettings loads the scan configuration from the database
 func (s *ScannerService) loadScanPathSettings(pathID int64) scanPathSettings {
 	var autoRemediate, dryRun bool
-	var detectionMethod, detectionMode string
-	var detectionArgsJSON sql.NullString
-
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	err := s.db.QueryRowContext(ctx, `
-		SELECT auto_remediate, dry_run, detection_method, detection_args, detection_mode
-		FROM scan_paths WHERE id = ?
-	`, pathID).Scan(&autoRemediate, &dryRun, &detectionMethod, &detectionArgsJSON, &detectionMode)
-
+	path, err := s.scanPathRepo().GetByID(ctx, pathID)
+	detectionMethod := "ffprobe"
+	detectionMode := "quick"
 	if err != nil {
 		logger.Errorf("Error querying scan path config: %v", err)
-		detectionMethod = "ffprobe"
-		detectionMode = "quick"
+	} else {
+		autoRemediate = path.AutoRemediate
+		dryRun = path.DryRun
+		detectionMethod = path.DetectionMethod
+		detectionMode = path.DetectionMode
 	}
 
 	var detectionArgs []string
-	if detectionArgsJSON.Valid && detectionArgsJSON.String != "" {
-		if err := json.Unmarshal([]byte(detectionArgsJSON.String), &detectionArgs); err != nil {
+	if err == nil && path.DetectionArgs.Valid && path.DetectionArgs.String != "" {
+		if err := json.Unmarshal([]byte(path.DetectionArgs.String), &detectionArgs); err != nil {
 			logger.Errorf("Error parsing detection args: %v", err)
 		}
 	}
@@ -1645,23 +1664,18 @@ func (s *ScannerService) refreshScanPathCache() error {
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	rows, err := s.db.QueryContext(ctx, "SELECT local_path, auto_remediate, COALESCE(dry_run, 0) FROM scan_paths WHERE enabled = 1")
+	rows, err := s.scanPathRepo().ListEnabled(ctx)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
-	cache := make([]scanPathConfig, 0, 10)
-	for rows.Next() {
-		var cfg scanPathConfig
-		if rows.Scan(&cfg.LocalPath, &cfg.AutoRemediate, &cfg.DryRun) != nil {
-			continue
-		}
-		cache = append(cache, cfg)
-	}
-
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("error iterating scan path cache: %w", err)
+	cache := make([]scanPathConfig, 0, len(rows))
+	for _, p := range rows {
+		cache = append(cache, scanPathConfig{
+			LocalPath:     p.LocalPath,
+			AutoRemediate: p.AutoRemediate,
+			DryRun:        p.DryRun,
+		})
 	}
 
 	s.scanPathCache = cache

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -1069,6 +1069,7 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		filesInProgress: make(map[string]bool),
 		shutdownCh:      make(chan struct{}),
 	}
+	scanner.initRepositories()
 
 	t.Run("returns error for no matching path", func(t *testing.T) {
 		_, _, err := scanner.getScanPathConfig("/non/existent/path/file.mkv")
@@ -1375,6 +1376,7 @@ func TestScannerService_ScanPathCache(t *testing.T) {
 		filesInProgress: make(map[string]bool),
 		shutdownCh:      make(chan struct{}),
 	}
+	scanner.initRepositories()
 
 	t.Run("cache is populated on first access", func(t *testing.T) {
 		// Insert test scan paths
@@ -1862,6 +1864,7 @@ func TestScannerService_RefreshScanPathCache(t *testing.T) {
 		filesInProgress: make(map[string]bool),
 		shutdownCh:      make(chan struct{}),
 	}
+	scanner.initRepositories()
 
 	t.Run("does not refresh when cache is valid", func(t *testing.T) {
 		// Insert a scan path

--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -60,6 +61,7 @@ type VerifierService struct {
 	pathMapper integration.PathMapper
 	arrClient  integration.ArrClient
 	db         *sql.DB
+	scanPaths  *repository.ScanPathRepository
 	clk        clock.Clock
 
 	// Graceful shutdown support
@@ -89,7 +91,7 @@ func NewVerifierService(eb *eventbus.EventBus, detector integration.HealthChecke
 	if len(clocks) > 0 && clocks[0] != nil {
 		c = clocks[0]
 	}
-	return &VerifierService{
+	v := &VerifierService{
 		eventBus:     eb,
 		detector:     detector,
 		pathMapper:   pm,
@@ -102,6 +104,10 @@ func NewVerifierService(eb *eventbus.EventBus, detector integration.HealthChecke
 		verifyMeta:   make(map[string]*VerificationMeta),
 		activeVerify: make(map[string]context.CancelFunc),
 	}
+	if db != nil {
+		v.scanPaths = repository.NewScanPathRepository(db)
+	}
+	return v
 }
 
 // setLastState updates the last known state for a corruption (thread-safe)
@@ -1171,13 +1177,12 @@ func (v *VerifierService) getVerificationTimeout(pathID int64) time.Duration {
 	ctx, cancel := context.WithTimeout(context.Background(), verifierQueryTimeout)
 	defer cancel()
 
-	var timeoutHours sql.NullInt64
-	err := v.db.QueryRowContext(ctx, "SELECT verification_timeout_hours FROM scan_paths WHERE id = ?", pathID).Scan(&timeoutHours)
-	if err != nil || !timeoutHours.Valid {
+	path, err := v.scanPaths.GetByID(ctx, pathID)
+	if err != nil || !path.VerificationTimeoutHours.Valid {
 		return defaultTimeout
 	}
 
-	return time.Duration(timeoutHours.Int64) * time.Hour
+	return time.Duration(path.VerificationTimeoutHours.Int64) * time.Hour
 }
 
 // emitPartialReplacement handles the case where only some files were replaced


### PR DESCRIPTION
## Summary

Closes the deferred service-layer scan_paths sites from #199. After this PR, **no production code outside \`internal/repository\` references the scan_paths table by SQL** — every read goes through ScanPathRepository.

| File | Site | Repo method |
|---|---|---|
| integration/path_mapper.go | Reload | ListEnabled |
| services/verifier.go | getVerificationTimeout | GetByID |
| services/scanner.go | getScanPathConfig | GetByID |
| services/scanner.go | refreshScanPathCache | ListEnabled |

## Design notes

- Three services now construct their own \`*ScanPathRepository\` from the \`*sql.DB\` they already take — same pattern that scheduler (Phase 3.4) and notifier (Phase 3.5) established.
- \`ScannerService\` gets an \`initRepositories()\` helper that's idempotent and called both from \`NewScannerService\` and lazily from a private \`scanPathRepo()\` accessor. The lazy path is the small concession that lets ~30 existing scanner_test.go fixtures (which construct \`&ScannerService{}\` directly) keep working unchanged.
- The \`Reload()\` rewrite in path_mapper drops ~20 lines of \`rows.Scan\` boilerplate for the same logic.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] Test schemas updated where they had stale scan_paths shapes:
  - \`integration/path_mapper_test.go\` — full column set
  - \`services/recovery_test.go\` — full column set + rename \`instance_id\` → \`arr_instance_id\` (the test schema had already drifted from production; surfaced by this migration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring to improve maintainability and consistency across scan path configuration handling. No user-facing changes or new functionality in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->