### PR TITLE
feat(repository): extract scans table reads into typed repository (Phase 3.7)

### DIFF
--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -64,8 +65,8 @@ func (s *RESTServer) getScans(c *gin.Context) {
 	p := ParsePagination(c, cfg)
 
 	// Get total count
-	var total int
-	if err := s.db.QueryRow("SELECT COUNT(*) FROM scans").Scan(&total); err != nil {
+	total, err := s.scans.Count(c.Request.Context())
+	if err != nil {
 		logger.Errorf("Failed to query scans count: %v", err)
 		respondDatabaseError(c, err)
 		return
@@ -81,42 +82,24 @@ func (s *RESTServer) getScans(c *gin.Context) {
 		"corruptions_found": "corruptions_found",
 	}
 	orderByClause := SafeOrderByClause(p.SortBy, p.SortOrder, allowedSortColumns, "started_at", "desc")
-	// Security: orderByClause is validated against allowlist by SafeOrderByClause
-	query := fmt.Sprintf("SELECT id, path, status, files_scanned, corruptions_found, started_at, completed_at FROM scans %s LIMIT ? OFFSET ?", orderByClause) // NOSONAR - validated ORDER BY
-	rows, err := s.db.Query(query, p.Limit, p.Offset)                                                                                                         // NOSONAR
+	rows, err := s.scans.ListPaged(c.Request.Context(), orderByClause, p.Limit, p.Offset)
 	if err != nil {
 		logger.Errorf("Failed to query scans: %v", err)
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	scans := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var id int
-		var path, status, startedAt string
-		var completedAt sql.NullString
-		var filesScanned, corruptionsFound int
-
-		if rows.Scan(&id, &path, &status, &filesScanned, &corruptionsFound, &startedAt, &completedAt) != nil {
-			continue
-		}
-
+	scans := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
 		scans = append(scans, map[string]interface{}{
-			"id":                id,
-			"path":              path,
-			"status":            status,
-			"files_scanned":     filesScanned,
-			"corruptions_found": corruptionsFound,
-			"started_at":        startedAt,
-			"completed_at":      completedAt.String,
+			"id":                row.ID,
+			"path":              row.Path,
+			"status":            row.Status,
+			"files_scanned":     row.FilesScanned,
+			"corruptions_found": row.CorruptionsFound,
+			"started_at":        row.StartedAt,
+			"completed_at":      row.CompletedAt.String,
 		})
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading scan results"})
-		logger.Errorf("Error iterating scans: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -200,10 +183,13 @@ func (s *RESTServer) rescanPath(c *gin.Context) {
 	scanID := c.Param("scan_id")
 
 	// Get the original scan path from the database
-	var path string
-	var status string
-	err := s.db.QueryRow("SELECT path, status FROM scans WHERE id = ?", scanID).Scan(&path, &status)
-	if err == sql.ErrNoRows {
+	scanIDInt, parseErr := strconv.ParseInt(scanID, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan ID"})
+		return
+	}
+	scan, err := s.scans.GetByID(c.Request.Context(), scanIDInt)
+	if errors.Is(err, repository.ErrNotFound) {
 		c.JSON(http.StatusNotFound, gin.H{"error": ErrMsgScanNotFound})
 		return
 	}
@@ -211,9 +197,10 @@ func (s *RESTServer) rescanPath(c *gin.Context) {
 		respondDatabaseError(c, err)
 		return
 	}
+	path := scan.Path
 
 	// Don't allow rescanning a currently running scan
-	if status == "running" {
+	if scan.Status == "running" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Scan is currently running"})
 		return
 	}
@@ -263,14 +250,13 @@ func (s *RESTServer) getScanDetails(c *gin.Context) {
 		InaccessibleFiles int    `json:"inaccessible_files"`
 	}
 
-	var completedAt sql.NullString
-	var pathID sql.NullInt64
-	err := s.db.QueryRow(`
-		SELECT id, path, path_id, status, files_scanned, corruptions_found, started_at, completed_at
-		FROM scans WHERE id = ?
-	`, scanID).Scan(&scan.ID, &scan.Path, &pathID, &scan.Status, &scan.FilesScanned, &scan.CorruptionsFound, &scan.StartedAt, &completedAt)
-
-	if err == sql.ErrNoRows {
+	scanIDInt, parseErr := strconv.ParseInt(scanID, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan ID"})
+		return
+	}
+	row, err := s.scans.GetByID(c.Request.Context(), scanIDInt)
+	if errors.Is(err, repository.ErrNotFound) {
 		c.JSON(http.StatusNotFound, gin.H{"error": ErrMsgScanNotFound})
 		return
 	}
@@ -278,10 +264,15 @@ func (s *RESTServer) getScanDetails(c *gin.Context) {
 		respondDatabaseError(c, err)
 		return
 	}
-
-	scan.CompletedAt = completedAt.String
-	if pathID.Valid {
-		scan.PathID = int(pathID.Int64)
+	scan.ID = int(row.ID)
+	scan.Path = row.Path
+	scan.Status = row.Status
+	scan.FilesScanned = row.FilesScanned
+	scan.CorruptionsFound = row.CorruptionsFound
+	scan.StartedAt = row.StartedAt
+	scan.CompletedAt = row.CompletedAt.String
+	if row.PathID.Valid {
+		scan.PathID = int(row.PathID.Int64)
 	}
 
 	// Get file counts from scan_files table using single GROUP BY query (performance optimization)
@@ -319,9 +310,13 @@ func (s *RESTServer) getScanFiles(c *gin.Context) {
 	p := ParsePagination(c, DefaultPaginationConfig())
 
 	// Verify scan exists
-	var scanExists int
-	err := s.db.QueryRow("SELECT id FROM scans WHERE id = ?", scanID).Scan(&scanExists)
-	if err == sql.ErrNoRows {
+	scanIDInt, parseErr := strconv.ParseInt(scanID, 10, 64)
+	if parseErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid scan ID"})
+		return
+	}
+	exists, err := s.scans.Exists(c.Request.Context(), scanIDInt)
+	if err == nil && !exists {
 		c.JSON(http.StatusNotFound, gin.H{"error": ErrMsgScanNotFound})
 		return
 	}

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -1562,7 +1562,7 @@ func TestRescanPath_PathNotFound(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.POST("/rescan/:path_id", server.rescanPath)
+	r.POST("/rescan/:scan_id", server.rescanPath)
 
 	// Request rescan for non-existent path
 	req, _ := http.NewRequest("POST", "/rescan/9999", nil)
@@ -1589,7 +1589,7 @@ func TestRescanPath_DBError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.POST("/rescan/:path_id", server.rescanPath)
+	r.POST("/rescan/:scan_id", server.rescanPath)
 
 	req, _ := http.NewRequest("POST", "/rescan/1", nil)
 	w := httptest.NewRecorder()

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 func (s *RESTServer) getDashboardStats(c *gin.Context) {
@@ -65,16 +68,14 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	stats.TotalCorruptions = pending + resolved + orphaned + manualIntervention + inProgress + failed
 
 	// All scan stats in a single query
-	if err := s.db.QueryRow(`
-		SELECT
-			COUNT(CASE WHEN status = 'running' THEN 1 END),
-			COUNT(*),
-			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) = date('now') THEN files_scanned END), 0),
-			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) >= date('now', '-7 days') THEN files_scanned END), 0)
-		FROM scans
-	`).Scan(&stats.ActiveScans, &stats.TotalScans, &stats.FilesScannedToday, &stats.FilesScannedWeek); err != nil {
+	if scanStats, err := s.scans.GetScanStats(c.Request.Context()); err != nil {
 		warnings = append(warnings, "failed to query scan stats")
 		logger.Debugf("Failed to query scan stats: %v", err)
+	} else {
+		stats.ActiveScans = scanStats.ActiveScans
+		stats.TotalScans = scanStats.TotalScans
+		stats.FilesScannedToday = scanStats.FilesScannedToday
+		stats.FilesScannedWeek = scanStats.FilesScannedWeek
 	}
 
 	// Query 3: Corruptions detected today (needs events table)
@@ -93,27 +94,20 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	}
 
 	// Query 4: Last completed scan info
-	var lastScanID sql.NullInt64
-	var lastScanTime, lastScanPath sql.NullString
-	if err := s.db.QueryRow(`
-		SELECT id, completed_at, path
-		FROM scans
-		WHERE status = 'completed' AND completed_at IS NOT NULL
-		ORDER BY completed_at DESC
-		LIMIT 1
-	`).Scan(&lastScanID, &lastScanTime, &lastScanPath); err != nil && err != sql.ErrNoRows {
+	last, err := s.scans.GetLastCompletedScan(c.Request.Context())
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		warnings = append(warnings, "failed to query last scan")
 		logger.Debugf("Failed to query last scan: %v", err)
 	}
-	if lastScanID.Valid {
-		id := int(lastScanID.Int64)
+	if last.ID.Valid {
+		id := int(last.ID.Int64)
 		stats.LastScanID = &id
 	}
-	if lastScanTime.Valid {
-		stats.LastScanTime = &lastScanTime.String
+	if last.CompletedAt.Valid {
+		stats.LastScanTime = &last.CompletedAt.String
 	}
-	if lastScanPath.Valid {
-		stats.LastScanPath = &lastScanPath.String
+	if last.Path.Valid {
+		stats.LastScanPath = &last.Path.String
 	}
 
 	// Calculate success rate
@@ -244,7 +238,7 @@ func (s *RESTServer) getPathHealth(c *gin.Context) {
 
 	// For each path, get last scan and corruption stats
 	for i := range paths {
-		paths[i].LastScanID, paths[i].LastScanTime = s.loadPathLastScan(paths[i].PathID)
+		paths[i].LastScanID, paths[i].LastScanTime = s.loadPathLastScan(c.Request.Context(), int64(paths[i].PathID))
 		paths[i].ActiveCorruptions, paths[i].TotalCorruptions, paths[i].ResolvedCount = s.loadPathCorruptionStats(paths[i].PathID)
 		paths[i].Status = determinePathHealthStatus(paths[i])
 	}
@@ -253,28 +247,20 @@ func (s *RESTServer) getPathHealth(c *gin.Context) {
 }
 
 // loadPathLastScan queries the last completed scan for a given path, returning nullable ID and time.
-func (s *RESTServer) loadPathLastScan(pathID int) (*int, *string) {
-	var lastScanID sql.NullInt64
-	var lastScanTime sql.NullString
-	err := s.db.QueryRow(`
-		SELECT id, completed_at
-		FROM scans
-		WHERE path_id = ? AND status = 'completed' AND completed_at IS NOT NULL
-		ORDER BY completed_at DESC
-		LIMIT 1
-	`, pathID).Scan(&lastScanID, &lastScanTime)
+func (s *RESTServer) loadPathLastScan(ctx context.Context, pathID int64) (*int, *string) {
+	last, err := s.scans.GetLastCompletedScanByPathID(ctx, pathID)
 	if err != nil {
 		return nil, nil
 	}
 
 	var idPtr *int
-	if lastScanID.Valid {
-		id := int(lastScanID.Int64)
+	if last.ID.Valid {
+		id := int(last.ID.Int64)
 		idPtr = &id
 	}
 	var timePtr *string
-	if lastScanTime.Valid {
-		timePtr = &lastScanTime.String
+	if last.CompletedAt.Valid {
+		timePtr = &last.CompletedAt.String
 	}
 	return idPtr, timePtr
 }

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -73,6 +73,7 @@ type RESTServer struct {
 	arrInstances   *repository.ArrInstanceRepository
 	scanPaths      *repository.ScanPathRepository
 	schedules      *repository.ScheduleRepository
+	scans          *repository.ScanRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -84,6 +85,7 @@ func (s *RESTServer) initRepositories() {
 	s.arrInstances = repository.NewArrInstanceRepository(s.db)
 	s.scanPaths = repository.NewScanPathRepository(s.db)
 	s.schedules = repository.NewScheduleRepository(s.db)
+	s.scans = repository.NewScanRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -1,0 +1,179 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Scan is the read-shape of a row from the scans table. Only the columns
+// used by handler-layer reads are populated; the scanner service uses
+// raw SQL for its lifecycle mutations (its own follow-up PR).
+type Scan struct {
+	ID               int64
+	Path             string
+	PathID           sql.NullInt64
+	Status           string
+	FilesScanned     int
+	CorruptionsFound int
+	StartedAt        string
+	CompletedAt      sql.NullString
+}
+
+// ScanStats is the aggregate the dashboard renders.
+type ScanStats struct {
+	ActiveScans       int
+	TotalScans        int
+	FilesScannedToday int
+	FilesScannedWeek  int
+}
+
+// LastScan describes the most-recent completed scan (globally, or per path).
+type LastScan struct {
+	ID          sql.NullInt64
+	CompletedAt sql.NullString
+	Path        sql.NullString
+}
+
+// ScanRepository wraps read access to the scans table. Write access from
+// the scanner service is intentionally not migrated here yet — those
+// methods are state-machine transitions tied tightly to scan lifecycle
+// and want a richer API than per-query Update methods.
+type ScanRepository struct {
+	db *sql.DB
+}
+
+// NewScanRepository returns a repository backed by db.
+func NewScanRepository(db *sql.DB) *ScanRepository {
+	return &ScanRepository{db: db}
+}
+
+// Count returns the total number of rows in the scans table.
+func (r *ScanRepository) Count(ctx context.Context) (int, error) {
+	var n int
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM scans`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count scans: %w", err)
+	}
+	return n, nil
+}
+
+// ListPaged returns a page of scans, ordered by the given orderByClause.
+//
+// IMPORTANT: orderByClause is interpolated directly into the SQL. The
+// caller MUST pass an allowlist-validated clause (i.e. the output of
+// api.SafeOrderByClause); this method does no further validation. The
+// alternative — parsing the clause inside the repo — would duplicate
+// the allowlist that the handler already enforces.
+func (r *ScanRepository) ListPaged(ctx context.Context, orderByClause string, limit, offset int) ([]Scan, error) {
+	query := fmt.Sprintf( //nolint:gosec // orderByClause is allowlist-validated by caller; see method doc
+		`SELECT id, path, status, files_scanned, corruptions_found, started_at, completed_at FROM scans %s LIMIT ? OFFSET ?`,
+		orderByClause,
+	)
+	rows, err := r.db.QueryContext(ctx, query, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query scans page: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Scan
+	for rows.Next() {
+		var s Scan
+		if err := rows.Scan(&s.ID, &s.Path, &s.Status, &s.FilesScanned, &s.CorruptionsFound, &s.StartedAt, &s.CompletedAt); err != nil {
+			return nil, fmt.Errorf("scan scans row: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scans: %w", err)
+	}
+	return out, nil
+}
+
+// GetByID returns the row matching id, or ErrNotFound.
+func (r *ScanRepository) GetByID(ctx context.Context, id int64) (Scan, error) {
+	var s Scan
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id, path, path_id, status, files_scanned, corruptions_found, started_at, completed_at
+		FROM scans WHERE id = ?
+	`, id).Scan(&s.ID, &s.Path, &s.PathID, &s.Status, &s.FilesScanned, &s.CorruptionsFound, &s.StartedAt, &s.CompletedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Scan{}, ErrNotFound
+	}
+	if err != nil {
+		return Scan{}, fmt.Errorf("get scan: %w", err)
+	}
+	return s, nil
+}
+
+// Exists returns true if a scans row with the given id exists.
+func (r *ScanRepository) Exists(ctx context.Context, id int64) (bool, error) {
+	var found int64
+	err := r.db.QueryRowContext(ctx, `SELECT id FROM scans WHERE id = ?`, id).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check scan exists: %w", err)
+	}
+	return true, nil
+}
+
+// GetScanStats returns the dashboard aggregates over the scans table —
+// active count, total count, files scanned today and over the last week.
+func (r *ScanRepository) GetScanStats(ctx context.Context) (ScanStats, error) {
+	var s ScanStats
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(CASE WHEN status = 'running' THEN 1 END),
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) = date('now') THEN files_scanned END), 0),
+			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) >= date('now', '-7 days') THEN files_scanned END), 0)
+		FROM scans
+	`).Scan(&s.ActiveScans, &s.TotalScans, &s.FilesScannedToday, &s.FilesScannedWeek)
+	if err != nil {
+		return ScanStats{}, fmt.Errorf("query scan stats: %w", err)
+	}
+	return s, nil
+}
+
+// GetLastCompletedScan returns the most recent completed scan globally.
+// Returns ErrNotFound when no completed scan exists.
+func (r *ScanRepository) GetLastCompletedScan(ctx context.Context) (LastScan, error) {
+	var l LastScan
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id, completed_at, path
+		FROM scans
+		WHERE status = 'completed' AND completed_at IS NOT NULL
+		ORDER BY completed_at DESC
+		LIMIT 1
+	`).Scan(&l.ID, &l.CompletedAt, &l.Path)
+	if errors.Is(err, sql.ErrNoRows) {
+		return LastScan{}, ErrNotFound
+	}
+	if err != nil {
+		return LastScan{}, fmt.Errorf("query last completed scan: %w", err)
+	}
+	return l, nil
+}
+
+// GetLastCompletedScanByPathID returns the most recent completed scan
+// for a specific scan_path. Path is left zero-valued (the caller usually
+// knows the path already). Returns ErrNotFound when none exists.
+func (r *ScanRepository) GetLastCompletedScanByPathID(ctx context.Context, pathID int64) (LastScan, error) {
+	var l LastScan
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id, completed_at
+		FROM scans
+		WHERE path_id = ? AND status = 'completed' AND completed_at IS NOT NULL
+		ORDER BY completed_at DESC
+		LIMIT 1
+	`, pathID).Scan(&l.ID, &l.CompletedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return LastScan{}, ErrNotFound
+	}
+	if err != nil {
+		return LastScan{}, fmt.Errorf("query last scan by path: %w", err)
+	}
+	return l, nil
+}

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -1,0 +1,202 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const scanSchema = `
+CREATE TABLE scans (
+	id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+	path               TEXT NOT NULL,
+	path_id            INTEGER,
+	status             TEXT NOT NULL,
+	files_scanned      INTEGER DEFAULT 0,
+	corruptions_found  INTEGER DEFAULT 0,
+	total_files        INTEGER DEFAULT 0,
+	current_file_index INTEGER DEFAULT 0,
+	started_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	completed_at       TIMESTAMP
+);
+`
+
+func newScanTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(scanSchema); err != nil {
+		t.Fatalf("create scan schema: %v", err)
+	}
+	return db
+}
+
+// seedScan inserts a scans row directly for test setup. Returns the new id.
+func seedScan(t *testing.T, db *sql.DB, path, status string, files, corruptions int, completedAt string) int64 {
+	t.Helper()
+	var res sql.Result
+	var err error
+	if completedAt == "" {
+		res, err = db.Exec(
+			`INSERT INTO scans (path, status, files_scanned, corruptions_found) VALUES (?, ?, ?, ?)`,
+			path, status, files, corruptions)
+	} else {
+		res, err = db.Exec(
+			`INSERT INTO scans (path, status, files_scanned, corruptions_found, completed_at) VALUES (?, ?, ?, ?, ?)`,
+			path, status, files, corruptions, completedAt)
+	}
+	if err != nil {
+		t.Fatalf("seed scan: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestScanRepository_Count(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	if n, _ := repo.Count(context.Background()); n != 0 {
+		t.Errorf("Count empty = %d, want 0", n)
+	}
+	seedScan(t, db, "/a", "completed", 10, 1, "2026-05-01 00:00:00")
+	seedScan(t, db, "/b", "running", 5, 0, "")
+	if n, _ := repo.Count(context.Background()); n != 2 {
+		t.Errorf("Count = %d, want 2", n)
+	}
+}
+
+func TestScanRepository_GetByID(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	id := seedScan(t, db, "/path", "completed", 100, 3, "2026-05-01 00:00:00")
+
+	got, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Path != "/path" || got.Status != "completed" || got.FilesScanned != 100 || got.CorruptionsFound != 3 {
+		t.Errorf("unexpected row: %+v", got)
+	}
+}
+
+func TestScanRepository_GetByID_notFound(t *testing.T) {
+	repo := NewScanRepository(newScanTestDB(t))
+	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByID = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanRepository_Exists(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	id := seedScan(t, db, "/p", "completed", 1, 0, "")
+
+	if ok, err := repo.Exists(context.Background(), id); err != nil || !ok {
+		t.Errorf("Exists existing = (%v, %v), want (true, nil)", ok, err)
+	}
+	if ok, err := repo.Exists(context.Background(), 999); err != nil || ok {
+		t.Errorf("Exists missing = (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
+func TestScanRepository_ListPaged(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	for i := 0; i < 5; i++ {
+		seedScan(t, db, "/p", "completed", i*10, 0, "")
+	}
+
+	rows, err := repo.ListPaged(context.Background(), "ORDER BY id ASC", 3, 0)
+	if err != nil || len(rows) != 3 {
+		t.Fatalf("ListPaged page 1 = (%d, %v), want (3, nil)", len(rows), err)
+	}
+
+	rows, err = repo.ListPaged(context.Background(), "ORDER BY id ASC", 3, 3)
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("ListPaged page 2 = (%d, %v), want (2, nil)", len(rows), err)
+	}
+}
+
+func TestScanRepository_GetScanStats(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	// Seed some scans with timestamps that fall in today/this-week ranges.
+	if _, err := db.Exec(
+		`INSERT INTO scans (path, status, files_scanned, started_at) VALUES
+		 ('/a', 'running',   10, datetime('now')),
+		 ('/b', 'completed', 20, datetime('now')),
+		 ('/c', 'completed', 30, datetime('now', '-3 days')),
+		 ('/d', 'completed', 40, datetime('now', '-10 days'))`,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	stats, err := repo.GetScanStats(context.Background())
+	if err != nil {
+		t.Fatalf("GetScanStats: %v", err)
+	}
+	if stats.ActiveScans != 1 || stats.TotalScans != 4 {
+		t.Errorf("active/total = %d/%d, want 1/4", stats.ActiveScans, stats.TotalScans)
+	}
+	if stats.FilesScannedToday != 30 {
+		t.Errorf("today = %d, want 30 (10 + 20)", stats.FilesScannedToday)
+	}
+	if stats.FilesScannedWeek != 60 {
+		t.Errorf("week = %d, want 60 (10 + 20 + 30)", stats.FilesScannedWeek)
+	}
+}
+
+func TestScanRepository_GetLastCompletedScan(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	seedScan(t, db, "/older", "completed", 0, 0, "2026-05-01 00:00:00")
+	seedScan(t, db, "/newer", "completed", 0, 0, "2026-05-10 00:00:00")
+	seedScan(t, db, "/running", "running", 0, 0, "")
+
+	last, err := repo.GetLastCompletedScan(context.Background())
+	if err != nil {
+		t.Fatalf("GetLastCompletedScan: %v", err)
+	}
+	if !last.Path.Valid || last.Path.String != "/newer" {
+		t.Errorf("Path = %+v, want /newer", last.Path)
+	}
+}
+
+func TestScanRepository_GetLastCompletedScan_empty(t *testing.T) {
+	repo := NewScanRepository(newScanTestDB(t))
+	if _, err := repo.GetLastCompletedScan(context.Background()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("empty DB = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanRepository_GetLastCompletedScanByPathID(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	// Two paths, two completed scans each — the per-path query should pick
+	// the newer one for the queried path, not the global newest.
+	if _, err := db.Exec(`
+		INSERT INTO scans (path, path_id, status, completed_at) VALUES
+		('/a', 1, 'completed', '2026-05-01 00:00:00'),
+		('/a', 1, 'completed', '2026-05-05 00:00:00'),
+		('/b', 2, 'completed', '2026-05-10 00:00:00')
+	`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	last, err := repo.GetLastCompletedScanByPathID(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetLastCompletedScanByPathID: %v", err)
+	}
+	// modernc.org/sqlite normalizes timestamps to RFC3339-ish form
+	// (2026-05-05T00:00:00Z); just check the date portion to keep the test
+	// portable across SQLite drivers.
+	if !last.CompletedAt.Valid || last.CompletedAt.String[:10] != "2026-05-05" {
+		t.Errorf("CompletedAt = %+v, want date 2026-05-05", last.CompletedAt)
+	}
+}


### PR DESCRIPTION
## Summary

Seventh Phase 3 PR. Migrates **handler-layer reads** of the scans table — 5 sites in handlers_scans.go + 3 in handlers_stats.go — to ScanRepository.

| Method | Site |
|---|---|
| Count | handlers_scans.go (paginated list) |
| ListPaged | handlers_scans.go (paginated list) |
| GetByID | handlers_scans.go (rescanPath, getScanDetails) |
| Exists | handlers_scans.go (getScanFiles) |
| GetScanStats | handlers_stats.go (dashboard) |
| GetLastCompletedScan | handlers_stats.go (dashboard) |
| GetLastCompletedScanByPathID | handlers_stats.go (path-health) |

**Deferred:** scanner.go write sites (status transitions, files_scanned increments, etc.) — those are state-machine transitions tied to scan lifecycle and want a richer API than per-query Update methods. Their own follow-up.

## Design notes

- \`ListPaged(orderByClause string, ...)\` takes a **pre-validated** ORDER BY clause as input. Validation belongs to the handler (\`SafeOrderByClause\` already enforces an allowlist); pushing the parser into the repo would duplicate that allowlist. The method documents the contract and carries a \`gosec nolint\` for the \`fmt.Sprintf\`.
- \`GetScanStats\` consolidates the \`COUNT(CASE WHEN ...)\` + \`substr(started_at, 1, 10) = date('now')\` aggregate into one repo call. The dashboard handler now reads the typed \`ScanStats\` value and assigns fields.
- \`loadPathLastScan\` gains a \`context.Context\` argument and takes \`int64\` to match the repo. Caller passes \`c.Request.Context()\`.
- Three \`TestRescanPath_*\` fixtures had stale route patterns (\`:path_id\` where production uses \`:scan_id\`). The old code accidentally worked because \`c.Param(\"scan_id\")\" returned \`\"\"\` → \`sql.ErrNoRows\" → 404. With explicit \`strconv.ParseInt\` returning 400 on empty, the misconfiguration surfaces. Routes updated.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`internal/repository/scan_test.go\` covers Count, GetByID hit/miss, Exists hit/miss, ListPaged (two pages), GetScanStats (today/week buckets), GetLastCompletedScan (global newest), GetLastCompletedScanByPathID (per-path newest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling and validation across scan-related endpoints with proper responses for invalid scan identifiers and improved consistency in error messaging across dashboard and scan operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->