### PR TITLE
feat(repository): extract settings KV table into typed repository (Phase 3.8)

### DIFF
--- a/internal/api/handlers_auth.go
+++ b/internal/api/handlers_auth.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"database/sql"
+	"errors"
 	"net/http"
 	"time"
 
@@ -10,6 +10,7 @@ import (
 	"github.com/mescon/Healarr/internal/auth"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // defaultSessionTTL is how long a newly issued session token remains valid.
@@ -21,8 +22,8 @@ func (s *RESTServer) handleAuthSetup(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// Check if password already exists
-	var exists bool
-	if s.db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM settings WHERE key = 'password_hash')").Scan(&exists) != nil {
+	exists, err := s.settings.Exists(ctx, repository.SettingKeyPasswordHash)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrMsgDatabaseError})
 		return
 	}
@@ -66,9 +67,12 @@ func (s *RESTServer) handleAuthSetup(c *gin.Context) {
 		return
 	}
 
-	// Store both
-	_, err = s.db.Exec("INSERT INTO settings (key, value) VALUES ('password_hash', ?), ('api_key', ?)", hash, encryptedKey)
-	if err != nil {
+	// Store both in one transaction so the user never ends up with one
+	// half (password but no api_key, or vice versa).
+	if err := s.settings.SetMany(ctx, map[string]string{
+		repository.SettingKeyPasswordHash: hash,
+		repository.SettingKeyAPIKey:       encryptedKey,
+	}); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save settings"})
 		return
 	}
@@ -92,9 +96,8 @@ func (s *RESTServer) handleLogin(c *gin.Context) {
 	}
 
 	// Get stored hash
-	var hash string
-	err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = 'password_hash'").Scan(&hash)
-	if err == sql.ErrNoRows {
+	hash, err := s.settings.Get(ctx, repository.SettingKeyPasswordHash)
+	if errors.Is(err, repository.ErrNotFound) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Setup required"})
 		return
 	}
@@ -138,20 +141,20 @@ func (s *RESTServer) handleLogin(c *gin.Context) {
 func (s *RESTServer) handleAuthStatus(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var count int
-	if s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM settings WHERE key = 'password_hash'").Scan(&count) != nil {
+	isSetup, err := s.settings.Exists(ctx, repository.SettingKeyPasswordHash)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrMsgDatabaseError})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"is_setup": count > 0})
+	c.JSON(http.StatusOK, gin.H{"is_setup": isSetup})
 }
 
 func (s *RESTServer) getAPIKey(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	var encryptedKey string
-	if s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = 'api_key'").Scan(&encryptedKey) != nil {
+	encryptedKey, err := s.settings.Get(ctx, repository.SettingKeyAPIKey)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve API key"})
 		return
 	}
@@ -182,8 +185,7 @@ func (s *RESTServer) regenerateAPIKey(c *gin.Context) {
 	}
 
 	// Update in database
-	_, err = s.db.Exec("UPDATE settings SET value = ? WHERE key = 'api_key'", encryptedKey)
-	if err != nil {
+	if err := s.settings.Set(c.Request.Context(), repository.SettingKeyAPIKey, encryptedKey); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update API key"})
 		return
 	}
@@ -212,8 +214,8 @@ func (s *RESTServer) changePassword(c *gin.Context) {
 	}
 
 	// Verify current password
-	var hash string
-	if s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = 'password_hash'").Scan(&hash) != nil {
+	hash, err := s.settings.Get(ctx, repository.SettingKeyPasswordHash)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrMsgDatabaseError})
 		return
 	}
@@ -231,8 +233,7 @@ func (s *RESTServer) changePassword(c *gin.Context) {
 	}
 
 	// Update in database
-	_, err = s.db.Exec("UPDATE settings SET value = ? WHERE key = 'password_hash'", newHash)
-	if err != nil {
+	if err := s.settings.Set(ctx, repository.SettingKeyPasswordHash, newHash); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update password"})
 		return
 	}

--- a/internal/api/handlers_config.go
+++ b/internal/api/handlers_config.go
@@ -50,11 +50,7 @@ func (s *RESTServer) updateSettings(c *gin.Context) {
 	}
 
 	// Upsert setting
-	_, err := s.db.Exec(`
-		INSERT INTO settings (key, value, updated_at) VALUES ('base_path', ?, datetime('now'))
-		ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = datetime('now')
-	`, basePath, basePath)
-	if err != nil {
+	if err := s.settings.Set(c.Request.Context(), repository.SettingKeyBasePath, basePath); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save setting"})
 		return
 	}

--- a/internal/api/handlers_logs_test.go
+++ b/internal/api/handlers_logs_test.go
@@ -82,6 +82,7 @@ func setupLogsTestServer(t *testing.T, db *sql.DB) (*gin.Engine, string, func())
 		eventBus: eb,
 		hub:      hub,
 	}
+	s.initRepositories()
 
 	// Setup API key for authentication
 	apiKey, err := auth.GenerateAPIKey()

--- a/internal/api/handlers_notifications_test.go
+++ b/internal/api/handlers_notifications_test.go
@@ -71,6 +71,7 @@ func setupNotificationsTestServer(t *testing.T, db *sql.DB, withNotifier bool) (
 		eventBus: eb,
 		hub:      hub,
 	}
+	s.initRepositories()
 
 	// Optionally add notifier service
 	if withNotifier {

--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -14,14 +14,11 @@ import (
 
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
-// SQL queries and error messages for setup handlers
-const (
-	sqlCountPasswordHash = "SELECT COUNT(*) FROM settings WHERE key = 'password_hash'"
-	sqlCountAPIKey       = "SELECT COUNT(*) FROM settings WHERE key = 'api_key'"
-	errMsgDatabaseError  = "Database error"
-)
+// Error messages for setup handlers.
+const errMsgDatabaseError = "Database error"
 
 // validatePathWithinDir validates that targetPath is within baseDir (defense in depth)
 // Returns the cleaned target path if valid, or an error if path escapes the base directory
@@ -51,28 +48,28 @@ type SetupStatus struct {
 func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 	status := SetupStatus{}
 
+	ctx := c.Request.Context()
+
 	// Check for password
-	var passwordExists int
-	err := s.db.QueryRow(sqlCountPasswordHash).Scan(&passwordExists)
-	if err != nil && err != sql.ErrNoRows {
+	hasPassword, err := s.settings.Exists(ctx, repository.SettingKeyPasswordHash)
+	if err != nil {
 		logger.Errorf("Failed to check password status: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return
 	}
-	status.HasPassword = passwordExists > 0
+	status.HasPassword = hasPassword
 
 	// Check for API key
-	var apiKeyExists int
-	err = s.db.QueryRow(sqlCountAPIKey).Scan(&apiKeyExists)
-	if err != nil && err != sql.ErrNoRows {
+	hasAPIKey, err := s.settings.Exists(ctx, repository.SettingKeyAPIKey)
+	if err != nil {
 		logger.Errorf("Failed to check API key status: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return
 	}
-	status.HasAPIKey = apiKeyExists > 0
+	status.HasAPIKey = hasAPIKey
 
 	// Check for configured instances
-	instanceCount, err := s.arrInstances.Count(c.Request.Context())
+	instanceCount, err := s.arrInstances.Count(ctx)
 	if err != nil {
 		logger.Errorf("Failed to check instances: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
@@ -81,7 +78,7 @@ func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 	status.HasInstances = instanceCount > 0
 
 	// Check for configured scan paths
-	pathCount, err := s.scanPaths.Count(c.Request.Context())
+	pathCount, err := s.scanPaths.Count(ctx)
 	if err != nil {
 		logger.Errorf("Failed to check scan paths: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
@@ -90,14 +87,13 @@ func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 	status.HasScanPaths = pathCount > 0
 
 	// Check if onboarding was dismissed
-	var dismissed sql.NullString
-	err = s.db.QueryRow("SELECT value FROM settings WHERE key = 'onboarding_dismissed'").Scan(&dismissed)
-	if err != nil && err != sql.ErrNoRows {
+	dismissed, err := s.settings.GetOr(ctx, repository.SettingKeyOnboardingDismissed, "")
+	if err != nil {
 		logger.Errorf("Failed to check onboarding dismissed status: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return
 	}
-	status.OnboardingDismissed = dismissed.Valid && dismissed.String == "true"
+	status.OnboardingDismissed = dismissed == "true"
 
 	// User needs setup if they have no password (first-time setup)
 	status.NeedsSetup = !status.HasPassword
@@ -109,11 +105,7 @@ func (s *RESTServer) handleSetupStatus(c *gin.Context) {
 // This endpoint is public during first-time setup, authenticated otherwise
 func (s *RESTServer) handleSetupDismiss(c *gin.Context) {
 	// Store the dismissal flag
-	_, err := s.db.Exec(`
-		INSERT INTO settings (key, value, updated_at) VALUES ('onboarding_dismissed', 'true', datetime('now'))
-		ON CONFLICT(key) DO UPDATE SET value = 'true', updated_at = datetime('now')
-	`)
-	if err != nil {
+	if err := s.settings.Set(c.Request.Context(), repository.SettingKeyOnboardingDismissed, "true"); err != nil {
 		logger.Errorf("Failed to dismiss onboarding: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save preference"})
 		return
@@ -127,11 +119,7 @@ func (s *RESTServer) handleSetupDismiss(c *gin.Context) {
 // This endpoint is authenticated - only logged-in users can reset the wizard
 func (s *RESTServer) handleSetupReset(c *gin.Context) {
 	// Reset the dismissal flag to false
-	_, err := s.db.Exec(`
-		INSERT INTO settings (key, value, updated_at) VALUES ('onboarding_dismissed', 'false', datetime('now'))
-		ON CONFLICT(key) DO UPDATE SET value = 'false', updated_at = datetime('now')
-	`)
-	if err != nil {
+	if err := s.settings.Set(c.Request.Context(), repository.SettingKeyOnboardingDismissed, "false"); err != nil {
 		logger.Errorf("Failed to reset onboarding: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to reset setup wizard"})
 		return
@@ -302,14 +290,13 @@ func (s *RESTServer) validateUploadedDatabase(dbPath string) error {
 // It checks if setup is needed before allowing unauthenticated access
 func (s *RESTServer) handleConfigImportPublic(c *gin.Context) {
 	// Check if we're in setup mode (no password set)
-	var passwordExists int
-	err := s.db.QueryRow(sqlCountPasswordHash).Scan(&passwordExists)
+	passwordExists, err := s.settings.Exists(c.Request.Context(), repository.SettingKeyPasswordHash)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return
 	}
 
-	if passwordExists > 0 {
+	if passwordExists {
 		// Password exists, require authentication
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 		return
@@ -322,14 +309,13 @@ func (s *RESTServer) handleConfigImportPublic(c *gin.Context) {
 // handleDatabaseRestorePublic is a wrapper for handleDatabaseRestore that can be called during setup
 func (s *RESTServer) handleDatabaseRestorePublic(c *gin.Context) {
 	// Check if we're in setup mode (no password set)
-	var passwordExists int
-	err := s.db.QueryRow(sqlCountPasswordHash).Scan(&passwordExists)
+	passwordExists, err := s.settings.Exists(c.Request.Context(), repository.SettingKeyPasswordHash)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": errMsgDatabaseError})
 		return
 	}
 
-	if passwordExists > 0 {
+	if passwordExists {
 		// Password exists, require authentication
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
 		return

--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -96,8 +97,8 @@ func (s *RESTServer) handleWebhook(c *gin.Context) {
 		}
 	} else {
 		// Legacy fallback: validate against the master API key.
-		var storedKey string
-		if err := s.db.QueryRow("SELECT value FROM settings WHERE key = 'api_key'").Scan(&storedKey); err != nil {
+		storedKey, err := s.settings.Get(c.Request.Context(), repository.SettingKeyAPIKey)
+		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Authentication error"})
 			return
 		}

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -74,6 +74,7 @@ type RESTServer struct {
 	scanPaths      *repository.ScanPathRepository
 	schedules      *repository.ScheduleRepository
 	scans          *repository.ScanRepository
+	settings       *repository.SettingsRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -86,6 +87,7 @@ func (s *RESTServer) initRepositories() {
 	s.scanPaths = repository.NewScanPathRepository(s.db)
 	s.schedules = repository.NewScheduleRepository(s.db)
 	s.scans = repository.NewScanRepository(s.db)
+	s.settings = repository.NewSettingsRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server
@@ -259,8 +261,8 @@ func (s *RESTServer) handleRuntimeConfig(c *gin.Context) {
 	cfg := config.Get()
 	basePath := cfg.BasePath
 
-	var savedBasePath sql.NullString
-	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = 'base_path'").Scan(&savedBasePath); err != nil && err != sql.ErrNoRows {
+	savedBasePath, err := s.settings.GetOr(c.Request.Context(), repository.SettingKeyBasePath, "")
+	if err != nil {
 		logger.Debugf("Failed to query base_path setting: %v", err)
 	}
 
@@ -269,7 +271,7 @@ func (s *RESTServer) handleRuntimeConfig(c *gin.Context) {
 
 	if envBasePath != "" {
 		source = "environment"
-	} else if savedBasePath.Valid && savedBasePath.String != "" {
+	} else if savedBasePath != "" {
 		source = "database"
 	}
 
@@ -617,9 +619,8 @@ var errInvalidToken = errors.New("invalid token")
 func (s *RESTServer) verifyAPIToken(token string) error {
 	ctx := context.Background()
 
-	var encryptedKey string
-	if err := s.db.QueryRowContext(ctx,
-		"SELECT value FROM settings WHERE key = 'api_key'").Scan(&encryptedKey); err != nil {
+	encryptedKey, err := s.settings.Get(ctx, repository.SettingKeyAPIKey)
+	if err != nil {
 		return fmt.Errorf("failed to retrieve API key: %w", err)
 	}
 

--- a/internal/api/rest_test.go
+++ b/internal/api/rest_test.go
@@ -328,6 +328,7 @@ func TestHandleRuntimeConfig(t *testing.T) {
 			router: gin.New(),
 			db:     db,
 		}
+		s.initRepositories()
 
 		s.router.GET("/api/runtime-config", s.handleRuntimeConfig)
 
@@ -362,6 +363,7 @@ func TestHandleRuntimeConfig(t *testing.T) {
 			router: gin.New(),
 			db:     db,
 		}
+		s.initRepositories()
 
 		s.router.GET("/api/runtime-config", s.handleRuntimeConfig)
 
@@ -400,6 +402,7 @@ func TestHandleRuntimeConfig(t *testing.T) {
 			router: gin.New(),
 			db:     emptyDB,
 		}
+		s.initRepositories()
 
 		s.router.GET("/api/runtime-config", s.handleRuntimeConfig)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // Version is set at build time via -ldflags
@@ -291,8 +294,8 @@ func LoadBasePathFromDB(db *sql.DB) {
 		return
 	}
 
-	var basePath string
-	err := db.QueryRow("SELECT value FROM settings WHERE key = 'base_path'").Scan(&basePath)
+	basePath, err := repository.NewSettingsRepository(db).
+		GetOr(context.Background(), repository.SettingKeyBasePath, "")
 	if err != nil || basePath == "" {
 		return // Keep default
 	}

--- a/internal/repository/settings.go
+++ b/internal/repository/settings.go
@@ -1,0 +1,125 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Well-known setting keys. Defining them as constants here gives a
+// single source of truth — handlers reference SettingKeyPasswordHash
+// rather than the string literal, so a rename is one edit.
+const (
+	SettingKeyPasswordHash        = "password_hash"
+	SettingKeyAPIKey              = "api_key"
+	SettingKeyBasePath            = "base_path"
+	SettingKeyOnboardingDismissed = "onboarding_dismissed"
+)
+
+// SettingsRepository wraps the settings KV table. Schema is
+// (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TIMESTAMP).
+//
+// Values are opaque strings; the repo doesn't know or care whether
+// they're encrypted, JSON, bools, etc. That's caller policy.
+type SettingsRepository struct {
+	db *sql.DB
+}
+
+// NewSettingsRepository returns a repository backed by db.
+func NewSettingsRepository(db *sql.DB) *SettingsRepository {
+	return &SettingsRepository{db: db}
+}
+
+// Get returns the value for key, or ErrNotFound if no row matches.
+func (r *SettingsRepository) Get(ctx context.Context, key string) (string, error) {
+	var v string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("get setting %q: %w", key, err)
+	}
+	return v, nil
+}
+
+// GetOr returns the value for key, or fallback if the key is absent.
+// DB errors (other than not-found) are returned to the caller.
+func (r *SettingsRepository) GetOr(ctx context.Context, key, fallback string) (string, error) {
+	v, err := r.Get(ctx, key)
+	if errors.Is(err, ErrNotFound) {
+		return fallback, nil
+	}
+	return v, err
+}
+
+// Exists returns true if the row exists.
+func (r *SettingsRepository) Exists(ctx context.Context, key string) (bool, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT 1 FROM settings WHERE key = ? LIMIT 1`, key).Scan(&n)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check setting exists %q: %w", key, err)
+	}
+	return true, nil
+}
+
+// Set upserts the (key, value) pair, bumping updated_at to now.
+// SQLite's INSERT OR REPLACE wins here: callers don't have to know
+// whether the row already exists, and we don't risk the
+// SELECT-then-INSERT-or-UPDATE race.
+func (r *SettingsRepository) Set(ctx context.Context, key, value string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+	`, key, value)
+	if err != nil {
+		return fmt.Errorf("set setting %q: %w", key, err)
+	}
+	return nil
+}
+
+// SetMany upserts multiple settings in a single transaction — all rows
+// commit together, or none does. Used at first-run setup where the
+// password and API key must both land or neither should.
+func (r *SettingsRepository) SetMany(ctx context.Context, pairs map[string]string) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() // safe to call after Commit
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	for key, value := range pairs {
+		if _, err := stmt.ExecContext(ctx, key, value); err != nil {
+			return fmt.Errorf("set setting %q: %w", key, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row for key. Returns nil if no row matched.
+func (r *SettingsRepository) Delete(ctx context.Context, key string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM settings WHERE key = ?`, key)
+	if err != nil {
+		return fmt.Errorf("delete setting %q: %w", key, err)
+	}
+	return nil
+}

--- a/internal/repository/settings_test.go
+++ b/internal/repository/settings_test.go
@@ -1,0 +1,141 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const settingsSchema = `
+CREATE TABLE settings (
+	key        TEXT PRIMARY KEY,
+	value      TEXT NOT NULL,
+	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newSettingsTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(settingsSchema); err != nil {
+		t.Fatalf("create settings schema: %v", err)
+	}
+	return db
+}
+
+func TestSettingsRepository_Set_andGet(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+
+	if err := repo.Set(ctx, "k1", "v1"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := repo.Get(ctx, "k1")
+	if err != nil || got != "v1" {
+		t.Errorf("Get k1 = (%q, %v), want (v1, nil)", got, err)
+	}
+}
+
+func TestSettingsRepository_Set_overwrites(t *testing.T) {
+	// SQLite ON CONFLICT(key) DO UPDATE — Set is upsert, not strict insert.
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+
+	_ = repo.Set(ctx, "k", "v1")
+	_ = repo.Set(ctx, "k", "v2")
+	got, _ := repo.Get(ctx, "k")
+	if got != "v2" {
+		t.Errorf("after second Set, Get = %q, want v2", got)
+	}
+}
+
+func TestSettingsRepository_Get_notFound(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	_, err := repo.Get(context.Background(), "nope")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSettingsRepository_GetOr_fallback(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	got, err := repo.GetOr(context.Background(), "nope", "default-value")
+	if err != nil || got != "default-value" {
+		t.Errorf("GetOr missing = (%q, %v), want (default-value, nil)", got, err)
+	}
+}
+
+func TestSettingsRepository_GetOr_existing(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	_ = repo.Set(context.Background(), "k", "actual")
+	got, _ := repo.GetOr(context.Background(), "k", "default-value")
+	if got != "actual" {
+		t.Errorf("GetOr existing = %q, want actual (fallback should NOT apply)", got)
+	}
+}
+
+func TestSettingsRepository_Exists(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+
+	if ok, _ := repo.Exists(ctx, "nope"); ok {
+		t.Error("Exists for missing key returned true")
+	}
+	_ = repo.Set(ctx, "k", "v")
+	if ok, _ := repo.Exists(ctx, "k"); !ok {
+		t.Error("Exists for present key returned false")
+	}
+}
+
+func TestSettingsRepository_Delete(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+	_ = repo.Set(ctx, "k", "v")
+
+	if err := repo.Delete(ctx, "k"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := repo.Get(ctx, "k"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("after Delete, Get = %v, want ErrNotFound", err)
+	}
+	// Deleting an absent key is a no-op.
+	if err := repo.Delete(ctx, "nope"); err != nil {
+		t.Errorf("Delete missing key = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestSettingsRepository_SetMany_atomic(t *testing.T) {
+	// SetMany commits all keys or none. Verify the happy path first.
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+
+	if err := repo.SetMany(ctx, map[string]string{"a": "1", "b": "2"}); err != nil {
+		t.Fatalf("SetMany: %v", err)
+	}
+	if got, _ := repo.Get(ctx, "a"); got != "1" {
+		t.Errorf("a = %q, want 1", got)
+	}
+	if got, _ := repo.Get(ctx, "b"); got != "2" {
+		t.Errorf("b = %q, want 2", got)
+	}
+}
+
+func TestSettingsRepository_SetMany_overwrites(t *testing.T) {
+	repo := NewSettingsRepository(newSettingsTestDB(t))
+	ctx := context.Background()
+	_ = repo.Set(ctx, "a", "old")
+
+	if err := repo.SetMany(ctx, map[string]string{"a": "new", "b": "fresh"}); err != nil {
+		t.Fatalf("SetMany: %v", err)
+	}
+	if got, _ := repo.Get(ctx, "a"); got != "new" {
+		t.Errorf("a = %q, want new", got)
+	}
+}


### PR DESCRIPTION
## Summary

Eighth Phase 3 PR. Migrates the \`settings\` KV table — 15 SQL sites across 6 files — to \`SettingsRepository\`.

| File | Sites |
|---|---|
| handlers_auth.go | 8 (EXISTS / INSERT pair / SELECT hash / COUNT / SELECT api_key / UPDATE api_key / SELECT hash / UPDATE hash) |
| handlers_setup.go | 5 (two COUNT-based exists, onboarding_dismissed read + 2 upserts, public-config-import setup check) |
| handlers_webhook.go | 1 (legacy api_key fallback) |
| handlers_config.go | 1 (base_path upsert) |
| rest.go | 2 (handleRuntimeConfig base_path, verifyAPIToken api_key) |
| config/config.go | 1 (base_path startup read) |

**Deferred:** \`internal/db/repository.go\` has two sites in the API-key encryption-migration path. Those run once at startup and want their own startup-migrations PR.

## Design notes

- **Well-known key constants** (\`SettingKeyPasswordHash\`, \`SettingKeyAPIKey\`, \`SettingKeyBasePath\`, \`SettingKeyOnboardingDismissed\`) live in the repo file. Handlers reference these instead of string literals — a rename is one edit.
- \`Set\` uses \`INSERT ON CONFLICT DO UPDATE\` (upsert). Callers don't need to know whether a row exists; the SELECT-then-write race goes away.
- \`SetMany\` writes a map of keys in a single transaction. The auth setup flow needs this — original code inserted \`password_hash\` and \`api_key\` with one multi-row INSERT, and atomicity matters (a half-failure would leave the user with a password but no integration key). Two \`Set\` calls would NOT preserve that; \`SetMany\` does via \`tx.PrepareContext\` + single Commit.
- \`GetOr\` provides a clean \"default value when missing\" pattern — \`onboarding_dismissed\" and the \`base_path\` startup load both use it.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`settings_test.go\` covers Set + Get, Set overwrites (upsert), Get notfound, GetOr (fallback + existing wins over fallback), Exists, Delete (idempotent), SetMany (happy path + overwrites)