### PR TITLE
feat(repository): extract corruption read-model into typed repository (Phase 3.9)

### DIFF
--- a/internal/api/handlers_corruptions.go
+++ b/internal/api/handlers_corruptions.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -93,7 +92,6 @@ func (s *RESTServer) getCorruptions(c *gin.Context) {
 	pathIDFilter := c.Query("path_id")
 
 	// Build query
-	baseQuery := "FROM corruption_status"
 	whereClauses := []string{}
 	args := []interface{}{}
 
@@ -116,11 +114,11 @@ func (s *RESTServer) getCorruptions(c *gin.Context) {
 		whereClause = " WHERE " + strings.Join(whereClauses, " AND ")
 	}
 
-	// Get total count with filter
-	// Security: whereClause contains only fixed strings with ? placeholders, user values are in args
-	var total int
-	countQuery := "SELECT COUNT(*) " + baseQuery + whereClause // NOSONAR - uses parameterized query with args
-	if err := s.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+	// Get total count with filter.
+	// whereClause contains only fixed fragments with ? placeholders; user
+	// values are passed via args. See CorruptionRepository.CountFiltered.
+	total, err := s.corruptions.CountFiltered(ctx, whereClause, args...)
+	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
@@ -136,56 +134,35 @@ func (s *RESTServer) getCorruptions(c *gin.Context) {
 	}
 	orderByClause := SafeOrderByClause(p.SortBy, p.SortOrder, allowedSortColumns, "last_updated_at", "desc")
 
-	// Security: whereClause uses ? placeholders, orderByClause is validated against allowlist
-	query := fmt.Sprintf("SELECT corruption_id, current_state, retry_count, file_path, path_id, last_error, detected_at, last_updated_at, corruption_type %s%s %s LIMIT ? OFFSET ?", baseQuery, whereClause, orderByClause) // NOSONAR - parameterized query + validated ORDER BY
-	args = append(args, p.Limit, p.Offset)
-
-	rows, err := s.db.QueryContext(ctx, query, args...) // NOSONAR
+	rows, err := s.corruptions.ListFiltered(ctx, whereClause, orderByClause, p.Limit, p.Offset, args...)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	corruptions := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var id, state, filePath string
-		var pathID sql.NullInt64
-		var lastError, corruptionType sql.NullString
-		var retryCount int
-		var detectedAt, lastUpdatedAt string
-
-		if rows.Scan(&id, &state, &retryCount, &filePath, &pathID, &lastError, &detectedAt, &lastUpdatedAt, &corruptionType) != nil {
-			continue
-		}
-
+	corruptions := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
 		corruption := map[string]interface{}{
-			"id":              id,
-			"state":           state,
-			"retry_count":     retryCount,
-			"file_path":       filePath,
-			"last_error":      lastError.String,
-			"detected_at":     detectedAt,
-			"last_updated_at": lastUpdatedAt,
-			"corruption_type": corruptionType.String,
+			"id":              row.CorruptionID,
+			"state":           row.CurrentState,
+			"retry_count":     row.RetryCount,
+			"file_path":       row.FilePath,
+			"last_error":      row.LastError.String,
+			"detected_at":     row.DetectedAt,
+			"last_updated_at": row.LastUpdatedAt,
+			"corruption_type": row.CorruptionType.String,
 		}
-		if pathID.Valid {
-			corruption["path_id"] = pathID.Int64
+		if row.PathID.Valid {
+			corruption["path_id"] = row.PathID.Int64
 		}
 
 		// Fetch enriched data from event_data (file_size from CorruptionDetected, media info from SearchCompleted)
-		enriched := s.getEnrichedCorruptionData(ctx, id)
+		enriched := s.getEnrichedCorruptionData(ctx, row.CorruptionID)
 		for k, v := range enriched {
 			corruption[k] = v
 		}
 
 		corruptions = append(corruptions, corruption)
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading corruptions"})
-		logger.Errorf("Error iterating corruptions: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -216,16 +193,12 @@ func (s *RESTServer) fetchEventData(ctx context.Context, corruptionID, eventType
 	if order != "ASC" && order != "DESC" {
 		order = "DESC"
 	}
-	var eventData sql.NullString
-	query := fmt.Sprintf(`SELECT event_data FROM events WHERE aggregate_id = ? AND event_type = ? ORDER BY created_at %s LIMIT 1`, order) // NOSONAR - order is validated above
-	if s.db.QueryRowContext(ctx, query, corruptionID, eventType).Scan(&eventData) != nil {
-		return nil
-	}
-	if !eventData.Valid {
+	raw, err := s.corruptions.LatestEventData(ctx, corruptionID, eventType, order)
+	if err != nil {
 		return nil
 	}
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(eventData.String), &data); err != nil {
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
 		logger.Debugf("Failed to unmarshal %s event data for %s: %v", eventType, corruptionID, err)
 		return nil
 	}
@@ -339,38 +312,28 @@ func (s *RESTServer) getRemediations(c *gin.Context) {
 	p := ParsePagination(c, DefaultPaginationConfig())
 
 	// Get total count
-	var total int
-	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM corruption_status WHERE current_state = ?", string(domain.VerificationSuccess)).Scan(&total); err != nil {
+	resolvedState := string(domain.VerificationSuccess)
+	total, err := s.corruptions.CountByState(ctx, resolvedState)
+	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
 
 	// Get paginated data
-	rows, err := s.db.QueryContext(ctx, "SELECT corruption_id, file_path, last_updated_at FROM corruption_status WHERE current_state = ? ORDER BY last_updated_at DESC LIMIT ? OFFSET ?", string(domain.VerificationSuccess), p.Limit, p.Offset)
+	rows, err := s.corruptions.ListByState(ctx, resolvedState, p.Limit, p.Offset)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	remediations := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var id, filePath, completedAt string
-		if rows.Scan(&id, &filePath, &completedAt) != nil {
-			continue
-		}
+	remediations := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
 		remediations = append(remediations, map[string]interface{}{
-			"id":           id,
-			"file_path":    filePath,
+			"id":           row.CorruptionID,
+			"file_path":    row.FilePath,
 			"status":       "resolved",
-			"completed_at": completedAt,
+			"completed_at": row.LastUpdatedAt,
 		})
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading remediations"})
-		logger.Errorf("Error iterating remediations: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -385,39 +348,26 @@ func (s *RESTServer) getCorruptionHistory(c *gin.Context) {
 	defer cancel()
 
 	id := c.Param("id")
-	rows, err := s.db.QueryContext(ctx, "SELECT event_type, event_data, created_at FROM events WHERE aggregate_id = ? ORDER BY created_at ASC", id)
+	events, err := s.corruptions.ListEvents(ctx, id)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	history := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var eventType, createdAt string
-		var eventData []byte // event_data is JSON stored as text/blob
-		if rows.Scan(&eventType, &eventData, &createdAt) != nil {
-			continue
-		}
-
+	history := make([]map[string]interface{}, 0, len(events))
+	for _, ev := range events {
 		var data map[string]interface{}
-		if len(eventData) > 0 {
-			if err := json.Unmarshal(eventData, &data); err != nil {
+		if len(ev.EventData) > 0 {
+			if err := json.Unmarshal(ev.EventData, &data); err != nil {
 				logger.Debugf("Failed to unmarshal event data: %v", err)
 			}
 		}
 
 		history = append(history, map[string]interface{}{
-			"event_type": eventType,
+			"event_type": ev.EventType,
 			"data":       data,
-			"timestamp":  createdAt,
+			"timestamp":  ev.CreatedAt,
 		})
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading history"})
-		logger.Errorf("Error iterating corruption history: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, history)
@@ -444,17 +394,8 @@ func (s *RESTServer) retryCorruptions(c *gin.Context) {
 
 	retried := 0
 	for _, id := range req.IDs {
-		var filePath sql.NullString
-		var pathID sql.NullInt64
-		err := s.db.QueryRowContext(ctx, `
-			SELECT
-				json_extract(event_data, '$.file_path'),
-				json_extract(event_data, '$.path_id')
-			FROM events
-			WHERE aggregate_id = ? AND event_type = 'CorruptionDetected'
-			LIMIT 1
-		`, id).Scan(&filePath, &pathID)
-		if err != nil || !filePath.Valid || filePath.String == "" {
+		filePath, pathID, err := s.corruptions.CorruptionDetectedFileInfo(ctx, id)
+		if err != nil {
 			logger.Errorf("Failed to get file_path for corruption %s: %v", id, err)
 			continue
 		}
@@ -464,7 +405,7 @@ func (s *RESTServer) retryCorruptions(c *gin.Context) {
 			AggregateType: "corruption",
 			EventType:     domain.RetryScheduled,
 			EventData: map[string]interface{}{
-				"file_path":      filePath.String,
+				"file_path":      filePath,
 				"path_id":        pathID.Int64,
 				"auto_remediate": true,
 				"manual_retry":   true,
@@ -538,14 +479,9 @@ func (s *RESTServer) deleteCorruptions(c *gin.Context) {
 
 	deleted := 0
 	for _, id := range req.IDs {
-		result, err := s.db.ExecContext(ctx, `DELETE FROM events WHERE aggregate_id = ?`, id)
+		rows, err := s.corruptions.DeleteEvents(ctx, id)
 		if err != nil {
 			logger.Errorf("Failed to delete events for corruption %s: %v", id, err)
-			continue
-		}
-		rows, rowsErr := result.RowsAffected()
-		if rowsErr != nil {
-			logger.Debugf("Failed to get rows affected for corruption %s: %v", id, rowsErr)
 			continue
 		}
 		if rows > 0 {

--- a/internal/api/handlers_corruptions_test.go
+++ b/internal/api/handlers_corruptions_test.go
@@ -136,7 +136,7 @@ func createCorruptionsTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	return &RESTServer{
+	srv := &RESTServer{
 		router:     r,
 		db:         db,
 		eventBus:   eb,
@@ -146,6 +146,8 @@ func createCorruptionsTestServer(t *testing.T, db *sql.DB, eb *eventbus.EventBus
 		hub:        NewWebSocketHub(eb),
 		startTime:  time.Now(),
 	}
+	srv.initRepositories()
+	return srv
 }
 
 func TestGetCorruptions_EmptyDB(t *testing.T) {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -75,6 +75,7 @@ type RESTServer struct {
 	schedules      *repository.ScheduleRepository
 	scans          *repository.ScanRepository
 	settings       *repository.SettingsRepository
+	corruptions    *repository.CorruptionRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -88,6 +89,7 @@ func (s *RESTServer) initRepositories() {
 	s.schedules = repository.NewScheduleRepository(s.db)
 	s.scans = repository.NewScanRepository(s.db)
 	s.settings = repository.NewSettingsRepository(s.db)
+	s.corruptions = repository.NewCorruptionRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -1,0 +1,236 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// CorruptionStatus is a row from the corruption_status view — the
+// event-sourced projection that derives each corruption aggregate's
+// current state from its append-only event stream.
+type CorruptionStatus struct {
+	CorruptionID   string
+	CurrentState   string
+	RetryCount     int
+	FilePath       string
+	PathID         sql.NullInt64
+	LastError      sql.NullString
+	CorruptionType sql.NullString
+	DetectedAt     string
+	LastUpdatedAt  string
+}
+
+// ResolvedCorruption is the trimmed shape the remediations list needs.
+type ResolvedCorruption struct {
+	CorruptionID  string
+	FilePath      string
+	LastUpdatedAt string
+}
+
+// CorruptionEvent is one row of an aggregate's event history.
+type CorruptionEvent struct {
+	EventType string
+	EventData []byte // raw JSON; caller unmarshals
+	CreatedAt string
+}
+
+// CorruptionRepository wraps reads against the corruption_status view and
+// the corruption-aggregate rows of the events table, plus the event
+// deletion used by the "delete corruption" action.
+type CorruptionRepository struct {
+	db *sql.DB
+}
+
+// NewCorruptionRepository returns a repository backed by db.
+func NewCorruptionRepository(db *sql.DB) *CorruptionRepository {
+	return &CorruptionRepository{db: db}
+}
+
+// corruptionStatusColumns is the SELECT list matching CorruptionStatus.
+const corruptionStatusColumns = `corruption_id, current_state, retry_count, file_path, path_id, last_error, detected_at, last_updated_at, corruption_type`
+
+func scanCorruptionStatusRow(scanner interface {
+	Scan(dest ...interface{}) error
+}, cs *CorruptionStatus) error {
+	return scanner.Scan(
+		&cs.CorruptionID, &cs.CurrentState, &cs.RetryCount, &cs.FilePath,
+		&cs.PathID, &cs.LastError, &cs.DetectedAt, &cs.LastUpdatedAt, &cs.CorruptionType,
+	)
+}
+
+// CountFiltered returns the number of corruption_status rows matching the
+// given WHERE clause.
+//
+// IMPORTANT: whereClause is interpolated directly into the SQL. The caller
+// MUST build it from fixed fragments + ? placeholders (the handler's
+// statusFilterClauses map and a parameterized path_id predicate); user
+// input belongs in args, never in whereClause. This mirrors
+// ScanRepository.ListPaged's contract.
+func (r *CorruptionRepository) CountFiltered(ctx context.Context, whereClause string, args ...interface{}) (int, error) {
+	query := "SELECT COUNT(*) FROM corruption_status" + whereClause //nolint:gosec // whereClause is fixed fragments; values in args. See method doc.
+	var n int
+	if err := r.db.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count corruptions: %w", err)
+	}
+	return n, nil
+}
+
+// ListFiltered returns corruption_status rows matching whereClause, sorted
+// by orderByClause (allowlist-validated by the caller), paginated.
+//
+// The final two positional args are LIMIT and OFFSET; they are appended
+// after the caller-supplied filter args. Same SQL-injection contract as
+// CountFiltered + the orderByClause contract from ScanRepository.
+func (r *CorruptionRepository) ListFiltered(ctx context.Context, whereClause, orderByClause string, limit, offset int, args ...interface{}) ([]CorruptionStatus, error) {
+	query := fmt.Sprintf( //nolint:gosec // whereClause/orderByClause are caller-validated; values in args. See method doc.
+		"SELECT %s FROM corruption_status%s %s LIMIT ? OFFSET ?",
+		corruptionStatusColumns, whereClause, orderByClause,
+	)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query corruptions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []CorruptionStatus
+	for rows.Next() {
+		var cs CorruptionStatus
+		if err := scanCorruptionStatusRow(rows, &cs); err != nil {
+			return nil, fmt.Errorf("scan corruption row: %w", err)
+		}
+		out = append(out, cs)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate corruptions: %w", err)
+	}
+	return out, nil
+}
+
+// CountByState returns the number of corruption_status rows in the given state.
+func (r *CorruptionRepository) CountByState(ctx context.Context, state string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM corruption_status WHERE current_state = ?`, state).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count corruptions by state: %w", err)
+	}
+	return n, nil
+}
+
+// ListByState returns the trimmed resolved-corruption shape for rows in the
+// given state, ordered by last_updated_at DESC, paginated.
+func (r *CorruptionRepository) ListByState(ctx context.Context, state string, limit, offset int) ([]ResolvedCorruption, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT corruption_id, file_path, last_updated_at FROM corruption_status
+		 WHERE current_state = ? ORDER BY last_updated_at DESC LIMIT ? OFFSET ?`,
+		state, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query corruptions by state: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]ResolvedCorruption, 0)
+	for rows.Next() {
+		var rc ResolvedCorruption
+		if err := rows.Scan(&rc.CorruptionID, &rc.FilePath, &rc.LastUpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan resolved corruption row: %w", err)
+		}
+		out = append(out, rc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate resolved corruptions: %w", err)
+	}
+	return out, nil
+}
+
+// LatestEventData returns the raw event_data JSON for the most recent (or
+// oldest, per order) event of the given type for an aggregate. order must
+// be "ASC" or "DESC"; any other value defaults to "DESC". Returns
+// ErrNotFound when no such event exists or its event_data is NULL.
+func (r *CorruptionRepository) LatestEventData(ctx context.Context, aggregateID, eventType, order string) (string, error) {
+	if order != "ASC" && order != "DESC" {
+		order = "DESC"
+	}
+	query := fmt.Sprintf( //nolint:gosec // order is constrained to ASC/DESC above
+		`SELECT event_data FROM events WHERE aggregate_id = ? AND event_type = ? ORDER BY created_at %s LIMIT 1`,
+		order,
+	)
+	var data sql.NullString
+	err := r.db.QueryRowContext(ctx, query, aggregateID, eventType).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("query latest event data: %w", err)
+	}
+	if !data.Valid {
+		return "", ErrNotFound
+	}
+	return data.String, nil
+}
+
+// ListEvents returns the full event history for an aggregate, oldest first.
+func (r *CorruptionRepository) ListEvents(ctx context.Context, aggregateID string) ([]CorruptionEvent, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT event_type, event_data, created_at FROM events WHERE aggregate_id = ? ORDER BY created_at ASC`,
+		aggregateID)
+	if err != nil {
+		return nil, fmt.Errorf("query event history: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]CorruptionEvent, 0)
+	for rows.Next() {
+		var e CorruptionEvent
+		if err := rows.Scan(&e.EventType, &e.EventData, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan event row: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate events: %w", err)
+	}
+	return out, nil
+}
+
+// CorruptionDetectedFileInfo extracts file_path and path_id from the
+// aggregate's CorruptionDetected event. Returns ErrNotFound if there is
+// no such event or it has no file_path.
+func (r *CorruptionRepository) CorruptionDetectedFileInfo(ctx context.Context, aggregateID string) (filePath string, pathID sql.NullInt64, err error) {
+	var fp sql.NullString
+	err = r.db.QueryRowContext(ctx, `
+		SELECT
+			json_extract(event_data, '$.file_path'),
+			json_extract(event_data, '$.path_id')
+		FROM events
+		WHERE aggregate_id = ? AND event_type = 'CorruptionDetected'
+		LIMIT 1
+	`, aggregateID).Scan(&fp, &pathID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", sql.NullInt64{}, ErrNotFound
+	}
+	if err != nil {
+		return "", sql.NullInt64{}, fmt.Errorf("query corruption file info: %w", err)
+	}
+	if !fp.Valid || fp.String == "" {
+		return "", sql.NullInt64{}, ErrNotFound
+	}
+	return fp.String, pathID, nil
+}
+
+// DeleteEvents removes all events for an aggregate and returns the row count.
+func (r *CorruptionRepository) DeleteEvents(ctx context.Context, aggregateID string) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM events WHERE aggregate_id = ?`, aggregateID)
+	if err != nil {
+		return 0, fmt.Errorf("delete corruption events: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -1,0 +1,216 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// corruptionSchema mirrors the production events table + corruption_status
+// view (001_schema.sql) so the repo's view queries exercise real SQL.
+const corruptionSchema = `
+CREATE TABLE events (
+	id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	aggregate_type TEXT NOT NULL,
+	aggregate_id   TEXT NOT NULL,
+	event_type     TEXT NOT NULL,
+	event_data     JSON NOT NULL,
+	event_version  INTEGER NOT NULL DEFAULT 1,
+	created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	user_id        TEXT
+);
+CREATE VIEW corruption_status AS
+SELECT
+	aggregate_id as corruption_id,
+	(SELECT event_type FROM events e2 WHERE e2.aggregate_id = e.aggregate_id ORDER BY id DESC LIMIT 1) as current_state,
+	(SELECT COUNT(*) FROM events e3 WHERE e3.aggregate_id = e.aggregate_id AND e3.event_type LIKE '%Failed') as retry_count,
+	(SELECT json_extract(event_data, '$.file_path') FROM events e4 WHERE e4.aggregate_id = e.aggregate_id AND e4.event_type = 'CorruptionDetected' LIMIT 1) as file_path,
+	(SELECT json_extract(event_data, '$.path_id') FROM events e7 WHERE e7.aggregate_id = e.aggregate_id AND e7.event_type = 'CorruptionDetected' LIMIT 1) as path_id,
+	(SELECT json_extract(event_data, '$.error') FROM events e5 WHERE e5.aggregate_id = e.aggregate_id ORDER BY id DESC LIMIT 1) as last_error,
+	(SELECT json_extract(event_data, '$.corruption_type') FROM events e6 WHERE e6.aggregate_id = e.aggregate_id AND e6.event_type = 'CorruptionDetected' LIMIT 1) as corruption_type,
+	MIN(created_at) as detected_at,
+	MAX(created_at) as last_updated_at
+FROM events e
+WHERE aggregate_type = 'corruption'
+GROUP BY aggregate_id;
+`
+
+func newCorruptionTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(corruptionSchema); err != nil {
+		t.Fatalf("create corruption schema: %v", err)
+	}
+	return db
+}
+
+// appendEvent inserts an event row with an explicit created_at so test
+// ordering is deterministic (SQLite CURRENT_TIMESTAMP has 1s granularity).
+func appendEvent(t *testing.T, db *sql.DB, aggregateID, eventType, eventData string, createdAt time.Time) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at) VALUES ('corruption', ?, ?, ?, ?)`,
+		aggregateID, eventType, eventData, createdAt.UTC().Format("2006-01-02 15:04:05"),
+	)
+	if err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+}
+
+// seedCorruption writes a detected→resolved (or custom final) corruption.
+func seedCorruption(t *testing.T, db *sql.DB, id, filePath, finalState string, base time.Time) {
+	t.Helper()
+	appendEvent(t, db, id, "CorruptionDetected",
+		`{"file_path":"`+filePath+`","path_id":1,"corruption_type":"CorruptHeader"}`, base)
+	if finalState != "CorruptionDetected" {
+		appendEvent(t, db, id, finalState, `{}`, base.Add(time.Minute))
+	}
+}
+
+func TestCorruptionRepository_CountFiltered_andListFiltered(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedCorruption(t, db, "c1", "/a.mkv", "VerificationSuccess", base)
+	seedCorruption(t, db, "c2", "/b.mkv", "CorruptionDetected", base.Add(time.Hour))
+
+	// No filter — both aggregates.
+	total, err := repo.CountFiltered(context.Background(), "")
+	if err != nil || total != 2 {
+		t.Fatalf("CountFiltered no filter = (%d, %v), want (2, nil)", total, err)
+	}
+
+	// Filter to pending only.
+	where := " WHERE current_state = ?"
+	total, err = repo.CountFiltered(context.Background(), where, "CorruptionDetected")
+	if err != nil || total != 1 {
+		t.Fatalf("CountFiltered pending = (%d, %v), want (1, nil)", total, err)
+	}
+
+	rows, err := repo.ListFiltered(context.Background(), where, "ORDER BY last_updated_at DESC", 10, 0, "CorruptionDetected")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("ListFiltered = (%d, %v), want (1, nil)", len(rows), err)
+	}
+	if rows[0].CorruptionID != "c2" || rows[0].FilePath != "/b.mkv" {
+		t.Errorf("unexpected row: %+v", rows[0])
+	}
+}
+
+func TestCorruptionRepository_CountByState_andListByState(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedCorruption(t, db, "c1", "/a.mkv", "VerificationSuccess", base)
+	seedCorruption(t, db, "c2", "/b.mkv", "VerificationSuccess", base.Add(time.Hour))
+	seedCorruption(t, db, "c3", "/c.mkv", "CorruptionDetected", base.Add(2*time.Hour))
+
+	n, err := repo.CountByState(context.Background(), "VerificationSuccess")
+	if err != nil || n != 2 {
+		t.Fatalf("CountByState = (%d, %v), want (2, nil)", n, err)
+	}
+
+	rows, err := repo.ListByState(context.Background(), "VerificationSuccess", 10, 0)
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("ListByState = (%d, %v), want (2, nil)", len(rows), err)
+	}
+	// Ordered by last_updated_at DESC → c2 first.
+	if rows[0].CorruptionID != "c2" {
+		t.Errorf("ListByState order: got %s first, want c2", rows[0].CorruptionID)
+	}
+}
+
+func TestCorruptionRepository_LatestEventData(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEvent(t, db, "c1", "DownloadProgress", `{"percent":10}`, base)
+	appendEvent(t, db, "c1", "DownloadProgress", `{"percent":90}`, base.Add(time.Minute))
+
+	// DESC → newest (90).
+	raw, err := repo.LatestEventData(context.Background(), "c1", "DownloadProgress", "DESC")
+	if err != nil || raw != `{"percent":90}` {
+		t.Errorf("LatestEventData DESC = (%q, %v), want newest", raw, err)
+	}
+
+	// ASC → oldest (10).
+	raw, err = repo.LatestEventData(context.Background(), "c1", "DownloadProgress", "ASC")
+	if err != nil || raw != `{"percent":10}` {
+		t.Errorf("LatestEventData ASC = (%q, %v), want oldest", raw, err)
+	}
+
+	// Missing event type.
+	if _, err := repo.LatestEventData(context.Background(), "c1", "Nonexistent", "DESC"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("LatestEventData missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCorruptionRepository_ListEvents(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEvent(t, db, "c1", "CorruptionDetected", `{"file_path":"/a.mkv"}`, base)
+	appendEvent(t, db, "c1", "DeletionCompleted", `{}`, base.Add(time.Minute))
+	appendEvent(t, db, "c1", "VerificationSuccess", `{}`, base.Add(2*time.Minute))
+
+	events, err := repo.ListEvents(context.Background(), "c1")
+	if err != nil || len(events) != 3 {
+		t.Fatalf("ListEvents = (%d, %v), want (3, nil)", len(events), err)
+	}
+	// Oldest first.
+	if events[0].EventType != "CorruptionDetected" || events[2].EventType != "VerificationSuccess" {
+		t.Errorf("unexpected event order: %s ... %s", events[0].EventType, events[2].EventType)
+	}
+}
+
+func TestCorruptionRepository_CorruptionDetectedFileInfo(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEvent(t, db, "c1", "CorruptionDetected", `{"file_path":"/movies/x.mkv","path_id":42}`, base)
+
+	fp, pathID, err := repo.CorruptionDetectedFileInfo(context.Background(), "c1")
+	if err != nil {
+		t.Fatalf("CorruptionDetectedFileInfo: %v", err)
+	}
+	if fp != "/movies/x.mkv" {
+		t.Errorf("file_path = %q, want /movies/x.mkv", fp)
+	}
+	if !pathID.Valid || pathID.Int64 != 42 {
+		t.Errorf("path_id = %+v, want 42", pathID)
+	}
+
+	// Aggregate with no CorruptionDetected event.
+	appendEvent(t, db, "c2", "DownloadProgress", `{"percent":1}`, base)
+	if _, _, err := repo.CorruptionDetectedFileInfo(context.Background(), "c2"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing detected event = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCorruptionRepository_DeleteEvents(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEvent(t, db, "c1", "CorruptionDetected", `{"file_path":"/a"}`, base)
+	appendEvent(t, db, "c1", "VerificationSuccess", `{}`, base.Add(time.Minute))
+
+	n, err := repo.DeleteEvents(context.Background(), "c1")
+	if err != nil {
+		t.Fatalf("DeleteEvents: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("DeleteEvents removed %d, want 2", n)
+	}
+
+	events, _ := repo.ListEvents(context.Background(), "c1")
+	if len(events) != 0 {
+		t.Errorf("after delete, ListEvents returned %d rows", len(events))
+	}
+}


### PR DESCRIPTION
## Summary

Ninth Phase 3 PR. Migrates the corruption handlers' 8 SQL sites — reads against the event-sourced \`corruption_status\` view and the corruption-aggregate rows of the \`events\` table — to \`CorruptionRepository\`.

| Method | Handler site |
|---|---|
| CountFiltered / ListFiltered | getCorruptions (dynamic status filter) |
| CountByState / ListByState | resolved-remediations list |
| LatestEventData | fetchEventData (enrichment) |
| ListEvents | getCorruptionHistory |
| CorruptionDetectedFileInfo | retryCorruptions (json_extract) |
| DeleteEvents | deleteCorruptions |

## Design notes

- \`corruption_status\` is a **view** over the append-only \`events\` table — each aggregate's current state is a correlated subquery. The repo owns both the projection reads and the corruption-aggregate event reads.
- \`CountFiltered\`/\`ListFiltered\` take a **pre-built** \`whereClause\` + \`args\`. The \`statusFilterClauses\` map (UI filter → SQL fragment) and the \`path_id\` predicate stay in the handler — that's presentation policy. The repo interpolates only caller-validated fragments; user values bind via \`args\`. Same contract as \`ScanRepository.ListPaged\`, documented on both methods with a \`gosec nolint\`.
- \`LatestEventData\` clamps \`order\` to ASC/DESC and returns \`ErrNotFound\` for missing or NULL \`event_data\`.
- \`CorruptionDetectedFileInfo\` wraps the \`json_extract($.file_path, $.path_id)\` lookup, returning \`ErrNotFound\` when the aggregate has no CorruptionDetected event.
- \`database/sql\` import drops out of the handler — no more \`sql.Null*\` scanning. The JSON-enrichment + dynamic-filter logic (presentation concern) stays in the handler.

After this PR the corruption handlers hold **zero raw SQL**.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`corruption_test.go\` builds the real events table + corruption_status view and covers CountFiltered/ListFiltered (no-filter + state-filter), CountByState/ListByState (ordering), LatestEventData (ASC/DESC/missing), ListEvents (ordering), CorruptionDetectedFileInfo (hit + missing), DeleteEvents