### PR TITLE
feat(repository): extract pending_rescans into typed repository (Phase 3.10)

### DIFF
--- a/internal/repository/rescan.go
+++ b/internal/repository/rescan.go
@@ -1,0 +1,139 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// PendingRescan is a row from the pending_rescans retry queue that's
+// ready to be retried.
+type PendingRescan struct {
+	ID         int64
+	FilePath   string
+	PathID     sql.NullInt64
+	RetryCount int
+	MaxRetries int
+}
+
+// RescanStats is the pending/abandoned/resolved breakdown of the queue.
+type RescanStats struct {
+	Pending   int
+	Abandoned int
+	Resolved  int
+}
+
+// RescanRepository wraps the pending_rescans table — the queue of files
+// that hit a recoverable (infrastructure) error during scanning and are
+// awaiting a backoff-scheduled retry.
+type RescanRepository struct {
+	db *sql.DB
+}
+
+// NewRescanRepository returns a repository backed by db.
+func NewRescanRepository(db *sql.DB) *RescanRepository {
+	return &RescanRepository{db: db}
+}
+
+// Queue inserts (or, on file_path conflict, re-queues) a file for rescan.
+//
+// The next_retry_at expression encodes exponential backoff directly in
+// SQL: 5 minutes initially, doubling each retry via a bit-shift, capped
+// at 5 * 2^5 = 160 minutes. That schedule is persistence policy, so it
+// lives here rather than being computed in Go and passed in.
+func (r *RescanRepository) Queue(ctx context.Context, filePath string, pathID int64, errorType, errorMessage string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO pending_rescans (file_path, path_id, error_type, error_message, next_retry_at)
+		VALUES (?, ?, ?, ?, datetime('now', '+5 minutes'))
+		ON CONFLICT(file_path) DO UPDATE SET
+			retry_count = retry_count + 1,
+			last_attempt_at = CURRENT_TIMESTAMP,
+			error_type = excluded.error_type,
+			error_message = excluded.error_message,
+			next_retry_at = datetime('now', '+' || (5 * (1 << MIN(retry_count, 5))) || ' minutes')
+	`, filePath, pathID, errorType, errorMessage)
+	if err != nil {
+		return fmt.Errorf("queue rescan: %w", err)
+	}
+	return nil
+}
+
+// ListReady returns up to limit pending rescans whose next_retry_at has
+// passed and that haven't exhausted their retries, oldest-due first.
+func (r *RescanRepository) ListReady(ctx context.Context, limit int) ([]PendingRescan, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, file_path, path_id, retry_count, max_retries
+		FROM pending_rescans
+		WHERE status = 'pending'
+		AND next_retry_at <= datetime('now')
+		AND retry_count < max_retries
+		ORDER BY next_retry_at ASC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query ready rescans: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PendingRescan
+	for rows.Next() {
+		var f PendingRescan
+		if err := rows.Scan(&f.ID, &f.FilePath, &f.PathID, &f.RetryCount, &f.MaxRetries); err != nil {
+			return nil, fmt.Errorf("scan pending rescan row: %w", err)
+		}
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending rescans: %w", err)
+	}
+	return out, nil
+}
+
+// MarkResolved closes a queue entry with the given status ("resolved" or
+// "abandoned") and resolution detail.
+func (r *RescanRepository) MarkResolved(ctx context.Context, id int64, status, resolution string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE pending_rescans
+		SET status = ?, resolved_at = CURRENT_TIMESTAMP, resolution = ?
+		WHERE id = ?
+	`, status, resolution, id)
+	if err != nil {
+		return fmt.Errorf("mark rescan resolved: %w", err)
+	}
+	return nil
+}
+
+// BumpRetry increments the retry counter and reschedules the next attempt
+// using the same exponential-backoff schedule as Queue (note the +1 in the
+// shift: this row's retry_count is about to be incremented).
+func (r *RescanRepository) BumpRetry(ctx context.Context, id int64, errorType, errorMessage string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE pending_rescans
+		SET retry_count = retry_count + 1,
+		    last_attempt_at = CURRENT_TIMESTAMP,
+		    error_type = ?,
+		    error_message = ?,
+		    next_retry_at = datetime('now', '+' || (5 * (1 << MIN(retry_count + 1, 5))) || ' minutes')
+		WHERE id = ?
+	`, errorType, errorMessage, id)
+	if err != nil {
+		return fmt.Errorf("bump rescan retry: %w", err)
+	}
+	return nil
+}
+
+// Stats returns the pending/abandoned/resolved counts for the queue.
+func (r *RescanRepository) Stats(ctx context.Context) (RescanStats, error) {
+	var s RescanStats
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'abandoned' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END), 0)
+		FROM pending_rescans
+	`).Scan(&s.Pending, &s.Abandoned, &s.Resolved)
+	if err != nil {
+		return RescanStats{}, fmt.Errorf("query rescan stats: %w", err)
+	}
+	return s, nil
+}

--- a/internal/repository/rescan_test.go
+++ b/internal/repository/rescan_test.go
@@ -1,0 +1,176 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const rescanSchema = `
+CREATE TABLE pending_rescans (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	file_path       TEXT NOT NULL UNIQUE,
+	path_id         INTEGER,
+	error_type      TEXT NOT NULL,
+	error_message   TEXT,
+	retry_count     INTEGER DEFAULT 0,
+	max_retries     INTEGER DEFAULT 5,
+	first_seen_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	last_attempt_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	next_retry_at   TIMESTAMP,
+	status          TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'resolved', 'abandoned')),
+	resolved_at     TIMESTAMP,
+	resolution      TEXT
+);
+`
+
+func newRescanTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(rescanSchema); err != nil {
+		t.Fatalf("create pending_rescans schema: %v", err)
+	}
+	return db
+}
+
+func TestRescanRepository_Queue_insertsAndReQueues(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	ctx := context.Background()
+
+	if err := repo.Queue(ctx, "/a.mkv", 1, "MountLost", "mount gone"); err != nil {
+		t.Fatalf("Queue: %v", err)
+	}
+
+	// Re-queueing the same file_path bumps retry_count via ON CONFLICT.
+	if err := repo.Queue(ctx, "/a.mkv", 1, "Timeout", "slow"); err != nil {
+		t.Fatalf("Queue (conflict): %v", err)
+	}
+
+	var retryCount int
+	var errType string
+	if err := db.QueryRow(`SELECT retry_count, error_type FROM pending_rescans WHERE file_path = ?`, "/a.mkv").
+		Scan(&retryCount, &errType); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if retryCount != 1 {
+		t.Errorf("retry_count = %d, want 1 after one conflict", retryCount)
+	}
+	if errType != "Timeout" {
+		t.Errorf("error_type = %q, want Timeout (latest wins)", errType)
+	}
+}
+
+func TestRescanRepository_ListReady(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	ctx := context.Background()
+
+	// Ready: pending, due in the past, under max_retries.
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+		VALUES ('/ready.mkv', 'MountLost', 0, 5, 'pending', datetime('now', '-1 minute'))`)
+	// Not due yet.
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+		VALUES ('/future.mkv', 'MountLost', 0, 5, 'pending', datetime('now', '+1 hour'))`)
+	// Exhausted retries.
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+		VALUES ('/exhausted.mkv', 'MountLost', 5, 5, 'pending', datetime('now', '-1 minute'))`)
+	// Already resolved.
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+		VALUES ('/done.mkv', 'MountLost', 0, 5, 'resolved', datetime('now', '-1 minute'))`)
+
+	ready, err := repo.ListReady(ctx, 50)
+	if err != nil {
+		t.Fatalf("ListReady: %v", err)
+	}
+	if len(ready) != 1 || ready[0].FilePath != "/ready.mkv" {
+		t.Errorf("ListReady = %+v, want only /ready.mkv", ready)
+	}
+}
+
+func TestRescanRepository_ListReady_respectsLimit(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	for _, p := range []string{"/a", "/b", "/c"} {
+		mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+			VALUES (?, 'MountLost', 0, 5, 'pending', datetime('now', '-1 minute'))`, p)
+	}
+	ready, err := repo.ListReady(context.Background(), 2)
+	if err != nil || len(ready) != 2 {
+		t.Fatalf("ListReady(limit=2) = (%d, %v), want (2, nil)", len(ready), err)
+	}
+}
+
+func TestRescanRepository_MarkResolved(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	ctx := context.Background()
+	_ = repo.Queue(ctx, "/a.mkv", 1, "MountLost", "gone")
+	var id int64
+	_ = db.QueryRow(`SELECT id FROM pending_rescans WHERE file_path = ?`, "/a.mkv").Scan(&id)
+
+	if err := repo.MarkResolved(ctx, id, "abandoned", "max retries"); err != nil {
+		t.Fatalf("MarkResolved: %v", err)
+	}
+	var status, resolution string
+	_ = db.QueryRow(`SELECT status, resolution FROM pending_rescans WHERE id = ?`, id).Scan(&status, &resolution)
+	if status != "abandoned" || resolution != "max retries" {
+		t.Errorf("status/resolution = %q/%q, want abandoned/max retries", status, resolution)
+	}
+
+	// Resolved entries are excluded from ListReady.
+	ready, _ := repo.ListReady(ctx, 50)
+	if len(ready) != 0 {
+		t.Errorf("resolved entry still in ListReady: %+v", ready)
+	}
+}
+
+func TestRescanRepository_BumpRetry(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	ctx := context.Background()
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, retry_count, max_retries, status, next_retry_at)
+		VALUES ('/a.mkv', 'MountLost', 0, 5, 'pending', datetime('now', '-1 minute'))`)
+	var id int64
+	_ = db.QueryRow(`SELECT id FROM pending_rescans WHERE file_path = ?`, "/a.mkv").Scan(&id)
+
+	if err := repo.BumpRetry(ctx, id, "Timeout", "still slow"); err != nil {
+		t.Fatalf("BumpRetry: %v", err)
+	}
+	var retryCount int
+	var errType string
+	_ = db.QueryRow(`SELECT retry_count, error_type FROM pending_rescans WHERE id = ?`, id).Scan(&retryCount, &errType)
+	if retryCount != 1 || errType != "Timeout" {
+		t.Errorf("retry_count/error_type = %d/%q, want 1/Timeout", retryCount, errType)
+	}
+}
+
+func TestRescanRepository_Stats(t *testing.T) {
+	db := newRescanTestDB(t)
+	repo := NewRescanRepository(db)
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, status) VALUES ('/p1', 'X', 'pending')`)
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, status) VALUES ('/p2', 'X', 'pending')`)
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, status) VALUES ('/a1', 'X', 'abandoned')`)
+	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, status) VALUES ('/r1', 'X', 'resolved')`)
+
+	stats, err := repo.Stats(context.Background())
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if stats.Pending != 2 || stats.Abandoned != 1 || stats.Resolved != 1 {
+		t.Errorf("stats = %+v, want pending=2 abandoned=1 resolved=1", stats)
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -308,6 +308,7 @@ type Scanner interface {
 type ScannerService struct {
 	db          *sql.DB
 	scanPaths   *repository.ScanPathRepository
+	rescans     *repository.RescanRepository
 	eventBus    *eventbus.EventBus
 	detector    integration.HealthChecker
 	pathMapper  integration.PathMapper
@@ -347,8 +348,14 @@ func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.H
 // that construct &ScannerService{} directly don't need a fixture update
 // just to satisfy a new repo field.
 func (s *ScannerService) initRepositories() {
-	if s.scanPaths == nil && s.db != nil {
+	if s.db == nil {
+		return
+	}
+	if s.scanPaths == nil {
 		s.scanPaths = repository.NewScanPathRepository(s.db)
+	}
+	if s.rescans == nil {
+		s.rescans = repository.NewRescanRepository(s.db)
 	}
 }
 
@@ -356,6 +363,12 @@ func (s *ScannerService) initRepositories() {
 func (s *ScannerService) scanPathRepo() *repository.ScanPathRepository {
 	s.initRepositories()
 	return s.scanPaths
+}
+
+// rescanRepo returns the lazy-initialized RescanRepository.
+func (s *ScannerService) rescanRepo() *repository.RescanRepository {
+	s.initRepositories()
+	return s.rescans
 }
 
 // IsFileBeingScanned returns true if the given file is currently being scanned.
@@ -1876,18 +1889,7 @@ func (s *ScannerService) queueForRescan(filePath string, pathID int64, errorType
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO pending_rescans (file_path, path_id, error_type, error_message, next_retry_at)
-		VALUES (?, ?, ?, ?, datetime('now', '+5 minutes'))
-		ON CONFLICT(file_path) DO UPDATE SET
-			retry_count = retry_count + 1,
-			last_attempt_at = CURRENT_TIMESTAMP,
-			error_type = excluded.error_type,
-			error_message = excluded.error_message,
-			next_retry_at = datetime('now', '+' || (5 * (1 << MIN(retry_count, 5))) || ' minutes')
-	`, filePath, pathID, errorType, errorMessage)
-
-	if err != nil {
+	if err := s.rescanRepo().Queue(ctx, filePath, pathID, errorType, errorMessage); err != nil {
 		logger.Errorf("Failed to queue file for rescan: %s: %v", filePath, err)
 	} else {
 		logger.Debugf("Queued for rescan: %s", filePath)
@@ -1933,35 +1935,26 @@ func (s *ScannerService) loadPendingRescanFiles() ([]pendingRescanFile, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, file_path, path_id, retry_count, max_retries
-		FROM pending_rescans
-		WHERE status = 'pending'
-		AND next_retry_at <= datetime('now')
-		AND retry_count < max_retries
-		ORDER BY next_retry_at ASC
-		LIMIT 50
-	`)
+	rows, err := s.rescanRepo().ListReady(ctx, 50)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var files []pendingRescanFile
-	for rows.Next() {
-		var f pendingRescanFile
-		var pathID sql.NullInt64
-		if err := rows.Scan(&f.ID, &f.FilePath, &pathID, &f.RetryCount, &f.MaxRetries); err != nil {
-			logger.Errorf("Failed to scan pending rescan row: %v", err)
-			continue
+	files := make([]pendingRescanFile, 0, len(rows))
+	for _, row := range rows {
+		f := pendingRescanFile{
+			ID:         row.ID,
+			FilePath:   row.FilePath,
+			RetryCount: row.RetryCount,
+			MaxRetries: row.MaxRetries,
 		}
-		if pathID.Valid {
-			f.PathID = pathID.Int64
+		if row.PathID.Valid {
+			f.PathID = row.PathID.Int64
 		}
 		files = append(files, f)
 	}
 
-	return files, rows.Err()
+	return files, nil
 }
 
 // markRescanResolved marks a pending rescan as resolved with the given resolution
@@ -1975,11 +1968,7 @@ func (s *ScannerService) markRescanResolved(id int64, resolution string) {
 		status = "abandoned"
 	}
 
-	if _, err := s.db.ExecContext(ctx, `
-		UPDATE pending_rescans
-		SET status = ?, resolved_at = CURRENT_TIMESTAMP, resolution = ?
-		WHERE id = ?
-	`, status, resolution, id); err != nil {
+	if err := s.rescanRepo().MarkResolved(ctx, id, status, resolution); err != nil {
 		logger.Warnf("Failed to mark pending rescan %d as %s: %v", id, resolution, err)
 	}
 }
@@ -1989,15 +1978,7 @@ func (s *ScannerService) updateRescanRetry(f pendingRescanFile, healthErr *integ
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	if _, err := s.db.ExecContext(ctx, `
-		UPDATE pending_rescans
-		SET retry_count = retry_count + 1,
-		    last_attempt_at = CURRENT_TIMESTAMP,
-		    error_type = ?,
-		    error_message = ?,
-		    next_retry_at = datetime('now', '+' || (5 * (1 << MIN(retry_count + 1, 5))) || ' minutes')
-		WHERE id = ?
-	`, healthErr.Type, healthErr.Message, f.ID); err != nil {
+	if err := s.rescanRepo().BumpRetry(ctx, f.ID, healthErr.Type, healthErr.Message); err != nil {
 		logger.Warnf("Failed to update pending rescan %d retry state: %v", f.ID, err)
 	}
 
@@ -2086,12 +2067,9 @@ func (s *ScannerService) GetPendingRescanStats() (pending, abandoned, resolved i
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	err = s.db.QueryRowContext(ctx, `
-		SELECT
-			COALESCE(SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'abandoned' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END), 0)
-		FROM pending_rescans
-	`).Scan(&pending, &abandoned, &resolved)
-	return
+	stats, err := s.rescanRepo().Stats(ctx)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return stats.Pending, stats.Abandoned, stats.Resolved, nil
 }


### PR DESCRIPTION
## Summary

Migrates the scanner's \`pending_rescans\` retry-queue SQL — 5 sites — to \`RescanRepository\`. This is the cleanest slice of the scanner write-path: a self-contained queue table with **no concurrency-retry (\`ExecWithRetry\`) entanglement**, unlike the scans state-machine writes which I'm deferring to a follow-up.

| Method | Scanner site |
|---|---|
| Queue | queueForRescan (upsert + backoff) |
| ListReady | loadPendingRescanFiles |
| MarkResolved | markRescanResolved |
| BumpRetry | updateRescanRetry |
| Stats | GetPendingRescanStats |

## Design notes

- The exponential-backoff schedule (\`datetime('now', '+' || (5 * (1 << MIN(retry_count, 5))) || ' minutes')\` — 5min doubling to a 160min cap) is **persistence policy**, so the SQL lives in the repo verbatim. The scanner just calls \`Queue\`/\`BumpRetry\` and the schedule emerges.
- \`BumpRetry\` keeps the \`+1\` in the bit-shift (the row's \`retry_count\` is about to increment, so the *next* delay must reflect the post-increment count) — preserving the exact original behavior.
- \`ScannerService\` gains a lazy \`rescanRepo()\` accessor alongside the existing \`scanPathRepo()\` — same pattern, so the ~30 test fixtures that build \`&ScannerService{}\` directly need no changes.

## Deferred (own follow-ups)

- **scans state-machine writes** — status transitions intertwined with \`db.ExecWithRetry\` concurrency handling; want careful treatment of the retry semantics.
- **scan_files result inserts** — the 6 INSERT sites with varying column sets.

## Test plan

- [x] \`go test ./...\` — all packages pass (scanner integration tests included)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`rescan_test.go\` covers Queue (insert + ON CONFLICT re-queue with latest-error-wins), ListReady (filters not-due / exhausted / resolved; respects limit), MarkResolved (+ exclusion from ListReady), BumpRetry, Stats