### PR TITLE
feat(repository): extract scan_files into typed repository (Phase 3.11)

### DIFF
--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -276,27 +275,14 @@ func (s *RESTServer) getScanDetails(c *gin.Context) {
 	}
 
 	// Get file counts from scan_files table using single GROUP BY query (performance optimization)
-	rows, err := s.db.Query("SELECT status, COUNT(*) FROM scan_files WHERE scan_id = ? GROUP BY status", scanID)
+	counts, err := s.scanFiles.CountByStatus(c.Request.Context(), scanIDInt)
 	if err != nil {
 		logger.Debugf("Failed to query file counts: %v", err)
 	} else {
-		defer rows.Close()
-		for rows.Next() {
-			var status string
-			var count int
-			if rows.Scan(&status, &count) == nil {
-				switch status {
-				case "healthy":
-					scan.HealthyFiles = count
-				case "corrupt":
-					scan.CorruptFiles = count
-				case "skipped":
-					scan.SkippedFiles = count
-				case "inaccessible":
-					scan.InaccessibleFiles = count
-				}
-			}
-		}
+		scan.HealthyFiles = counts["healthy"]
+		scan.CorruptFiles = counts["corrupt"]
+		scan.SkippedFiles = counts["skipped"]
+		scan.InaccessibleFiles = counts["inaccessible"]
 	}
 
 	c.JSON(http.StatusOK, scan)
@@ -321,68 +307,31 @@ func (s *RESTServer) getScanFiles(c *gin.Context) {
 		return
 	}
 
-	// Build query with optional status filter
-	whereClause := "WHERE scan_id = ?"
-	args := []interface{}{scanID}
-
-	if statusFilter != "all" {
-		whereClause += " AND status = ?"
-		args = append(args, statusFilter)
-	}
-
-	// Get total count
-	// Security: whereClause contains only fixed strings with ? placeholders, user values are in args
-	var total int
-	countQuery := "SELECT COUNT(*) FROM scan_files " + whereClause // NOSONAR - parameterized query
-	err = s.db.QueryRow(countQuery, args...).Scan(&total)
+	// Get total count (optionally filtered by status)
+	total, err := s.scanFiles.CountForScan(c.Request.Context(), scanIDInt, statusFilter)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
 
 	// Get paginated data
-	// Security: whereClause uses ? placeholders, ORDER BY is fixed/hardcoded
-	query := fmt.Sprintf(`
-		SELECT id, file_path, status, corruption_type, error_details, file_size, scanned_at
-		FROM scan_files %s
-		ORDER BY status DESC, file_path ASC
-		LIMIT ? OFFSET ?
-	`, whereClause) // NOSONAR - parameterized query with fixed ORDER BY
-	args = append(args, p.Limit, p.Offset)
-
-	rows, err := s.db.Query(query, args...) // NOSONAR
+	rows, err := s.scanFiles.ListForScan(c.Request.Context(), scanIDInt, statusFilter, p.Limit, p.Offset)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	files := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var id int
-		var filePath, status, scannedAt string
-		var corruptionType, errorDetails sql.NullString
-		var fileSize sql.NullInt64
-
-		if rows.Scan(&id, &filePath, &status, &corruptionType, &errorDetails, &fileSize, &scannedAt) != nil {
-			continue
-		}
-
+	files := make([]map[string]interface{}, 0, len(rows))
+	for _, row := range rows {
 		files = append(files, map[string]interface{}{
-			"id":              id,
-			"file_path":       filePath,
-			"status":          status,
-			"corruption_type": corruptionType.String,
-			"error_details":   errorDetails.String,
-			"file_size":       fileSize.Int64,
-			"scanned_at":      scannedAt,
+			"id":              row.ID,
+			"file_path":       row.FilePath,
+			"status":          row.Status,
+			"corruption_type": row.CorruptionType.String,
+			"error_details":   row.ErrorDetails.String,
+			"file_size":       row.FileSize.Int64,
+			"scanned_at":      row.ScannedAt,
 		})
-	}
-
-	if err := rows.Err(); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error reading scan files"})
-		logger.Errorf("Error iterating scan files: %v", err)
-		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -76,6 +76,7 @@ type RESTServer struct {
 	scans          *repository.ScanRepository
 	settings       *repository.SettingsRepository
 	corruptions    *repository.CorruptionRepository
+	scanFiles      *repository.ScanFileRepository
 }
 
 // initRepositories populates the domain repository fields from s.db. Called
@@ -90,6 +91,7 @@ func (s *RESTServer) initRepositories() {
 	s.scans = repository.NewScanRepository(s.db)
 	s.settings = repository.NewSettingsRepository(s.db)
 	s.corruptions = repository.NewCorruptionRepository(s.db)
+	s.scanFiles = repository.NewScanFileRepository(s.db)
 }
 
 // ServerDeps contains all dependencies required for the REST server

--- a/internal/repository/scan_file.go
+++ b/internal/repository/scan_file.go
@@ -1,0 +1,145 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/mescon/Healarr/internal/db"
+)
+
+// ScanFile is a row from the scan_files table (the per-file outcome of a scan).
+type ScanFile struct {
+	ID             int64
+	FilePath       string
+	Status         string
+	CorruptionType sql.NullString
+	ErrorDetails   sql.NullString
+	FileSize       sql.NullInt64
+	ScannedAt      string
+}
+
+// ScanFileRecord is the write shape for a per-file scan result. Empty
+// CorruptionType / ErrorDetails are stored as SQL NULL — that unifies the
+// healthy-file insert (which sets neither) with the corrupt/skipped/
+// inaccessible inserts (which set both) behind one statement.
+type ScanFileRecord struct {
+	FilePath       string
+	Status         string
+	CorruptionType string
+	ErrorDetails   string
+	FileSize       int64
+}
+
+// ScanFileRepository wraps the scan_files table.
+type ScanFileRepository struct {
+	db *sql.DB
+}
+
+// NewScanFileRepository returns a repository backed by sqlDB.
+func NewScanFileRepository(sqlDB *sql.DB) *ScanFileRepository {
+	return &ScanFileRepository{db: sqlDB}
+}
+
+// Record inserts a per-file scan result for the given scan.
+//
+// Uses db.ExecWithRetry because these inserts fire from parallel per-file
+// scan goroutines and can hit SQLite BUSY under contention; the retry
+// wrapper is the same one the scanner used inline before this migration,
+// so concurrency behavior is unchanged.
+func (r *ScanFileRepository) Record(ctx context.Context, scanID int64, rec ScanFileRecord) error {
+	_ = ctx // retry wrapper operates on the pool; ctx reserved for a future ExecContext variant
+	var corruptionType, errorDetails interface{}
+	if rec.CorruptionType != "" {
+		corruptionType = rec.CorruptionType
+	}
+	if rec.ErrorDetails != "" {
+		errorDetails = rec.ErrorDetails
+	}
+	_, err := db.ExecWithRetry(r.db, `
+		INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, scanID, rec.FilePath, rec.Status, corruptionType, errorDetails, rec.FileSize)
+	if err != nil {
+		return fmt.Errorf("record scan file: %w", err)
+	}
+	return nil
+}
+
+// CountByStatus returns a status → count map for a scan (the scan-detail
+// screen's healthy/corrupt/skipped/inaccessible breakdown).
+func (r *ScanFileRepository) CountByStatus(ctx context.Context, scanID int64) (map[string]int, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT status, COUNT(*) FROM scan_files WHERE scan_id = ? GROUP BY status`, scanID)
+	if err != nil {
+		return nil, fmt.Errorf("count scan files by status: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			return nil, fmt.Errorf("scan status-count row: %w", err)
+		}
+		counts[status] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate status counts: %w", err)
+	}
+	return counts, nil
+}
+
+// CountForScan returns the number of scan_files rows for a scan, optionally
+// filtered to a single status. A statusFilter of "" or "all" counts every row.
+func (r *ScanFileRepository) CountForScan(ctx context.Context, scanID int64, statusFilter string) (int, error) {
+	var n int
+	var err error
+	if statusFilter == "" || statusFilter == "all" {
+		err = r.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM scan_files WHERE scan_id = ?`, scanID).Scan(&n)
+	} else {
+		err = r.db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM scan_files WHERE scan_id = ? AND status = ?`, scanID, statusFilter).Scan(&n)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("count scan files: %w", err)
+	}
+	return n, nil
+}
+
+// ListForScan returns a page of scan_files for a scan, optionally filtered
+// to a single status, ordered by status DESC then file_path ASC. A
+// statusFilter of "" or "all" returns every status.
+func (r *ScanFileRepository) ListForScan(ctx context.Context, scanID int64, statusFilter string, limit, offset int) ([]ScanFile, error) {
+	var rows *sql.Rows
+	var err error
+	const tail = ` ORDER BY status DESC, file_path ASC LIMIT ? OFFSET ?`
+	if statusFilter == "" || statusFilter == "all" {
+		rows, err = r.db.QueryContext(ctx,
+			`SELECT id, file_path, status, corruption_type, error_details, file_size, scanned_at
+			 FROM scan_files WHERE scan_id = ?`+tail, scanID, limit, offset)
+	} else {
+		rows, err = r.db.QueryContext(ctx,
+			`SELECT id, file_path, status, corruption_type, error_details, file_size, scanned_at
+			 FROM scan_files WHERE scan_id = ? AND status = ?`+tail, scanID, statusFilter, limit, offset)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query scan files: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ScanFile
+	for rows.Next() {
+		var f ScanFile
+		if err := rows.Scan(&f.ID, &f.FilePath, &f.Status, &f.CorruptionType, &f.ErrorDetails, &f.FileSize, &f.ScannedAt); err != nil {
+			return nil, fmt.Errorf("scan scan_files row: %w", err)
+		}
+		out = append(out, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate scan files: %w", err)
+	}
+	return out, nil
+}

--- a/internal/repository/scan_file_test.go
+++ b/internal/repository/scan_file_test.go
@@ -1,0 +1,159 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const scanFileSchema = `
+CREATE TABLE scan_files (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	scan_id         INTEGER NOT NULL,
+	file_path       TEXT NOT NULL,
+	status          TEXT NOT NULL CHECK (status IN ('healthy', 'corrupt', 'error', 'inaccessible', 'skipped')),
+	corruption_type TEXT,
+	error_details   TEXT,
+	file_size       INTEGER,
+	scanned_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+func newScanFileTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(scanFileSchema); err != nil {
+		t.Fatalf("create scan_files schema: %v", err)
+	}
+	return db
+}
+
+func TestScanFileRepository_Record_healthyStoresNullOptionals(t *testing.T) {
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+
+	// Healthy file: no corruption_type / error_details → should be NULL.
+	if err := repo.Record(context.Background(), 1, ScanFileRecord{
+		FilePath: "/a.mkv", Status: "healthy", FileSize: 123,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var ct, ed sql.NullString
+	var size sql.NullInt64
+	if err := db.QueryRow(`SELECT corruption_type, error_details, file_size FROM scan_files WHERE scan_id = 1`).
+		Scan(&ct, &ed, &size); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if ct.Valid || ed.Valid {
+		t.Errorf("healthy record stored non-NULL optionals: ct=%+v ed=%+v", ct, ed)
+	}
+	if !size.Valid || size.Int64 != 123 {
+		t.Errorf("file_size = %+v, want 123", size)
+	}
+}
+
+func TestScanFileRepository_Record_corruptStoresDetails(t *testing.T) {
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+
+	if err := repo.Record(context.Background(), 1, ScanFileRecord{
+		FilePath: "/b.mkv", Status: "corrupt", CorruptionType: "CorruptHeader",
+		ErrorDetails: "bad ebml", FileSize: 999,
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var ct, ed string
+	if err := db.QueryRow(`SELECT corruption_type, error_details FROM scan_files WHERE scan_id = 1`).
+		Scan(&ct, &ed); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if ct != "CorruptHeader" || ed != "bad ebml" {
+		t.Errorf("ct/ed = %q/%q, want CorruptHeader/bad ebml", ct, ed)
+	}
+}
+
+func TestScanFileRepository_CountByStatus(t *testing.T) {
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+	ctx := context.Background()
+
+	for _, rec := range []ScanFileRecord{
+		{FilePath: "/1", Status: "healthy"},
+		{FilePath: "/2", Status: "healthy"},
+		{FilePath: "/3", Status: "corrupt", CorruptionType: "X"},
+		{FilePath: "/4", Status: "skipped", CorruptionType: "Y"},
+	} {
+		if err := repo.Record(ctx, 1, rec); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+	// A different scan — must not bleed into scan 1's counts.
+	_ = repo.Record(ctx, 2, ScanFileRecord{FilePath: "/other", Status: "corrupt", CorruptionType: "Z"})
+
+	counts, err := repo.CountByStatus(ctx, 1)
+	if err != nil {
+		t.Fatalf("CountByStatus: %v", err)
+	}
+	if counts["healthy"] != 2 || counts["corrupt"] != 1 || counts["skipped"] != 1 {
+		t.Errorf("counts = %+v, want healthy=2 corrupt=1 skipped=1", counts)
+	}
+}
+
+func TestScanFileRepository_CountForScan_andListForScan(t *testing.T) {
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+	ctx := context.Background()
+	for _, rec := range []ScanFileRecord{
+		{FilePath: "/h1", Status: "healthy"},
+		{FilePath: "/h2", Status: "healthy"},
+		{FilePath: "/c1", Status: "corrupt", CorruptionType: "X"},
+	} {
+		_ = repo.Record(ctx, 1, rec)
+	}
+
+	// "all" filter.
+	total, err := repo.CountForScan(ctx, 1, "all")
+	if err != nil || total != 3 {
+		t.Fatalf("CountForScan all = (%d, %v), want (3, nil)", total, err)
+	}
+	rows, err := repo.ListForScan(ctx, 1, "all", 10, 0)
+	if err != nil || len(rows) != 3 {
+		t.Fatalf("ListForScan all = (%d, %v), want (3, nil)", len(rows), err)
+	}
+
+	// Status filter.
+	total, err = repo.CountForScan(ctx, 1, "corrupt")
+	if err != nil || total != 1 {
+		t.Fatalf("CountForScan corrupt = (%d, %v), want (1, nil)", total, err)
+	}
+	rows, err = repo.ListForScan(ctx, 1, "corrupt", 10, 0)
+	if err != nil || len(rows) != 1 || rows[0].FilePath != "/c1" {
+		t.Fatalf("ListForScan corrupt = %+v (err %v), want only /c1", rows, err)
+	}
+}
+
+func TestScanFileRepository_ListForScan_pagination(t *testing.T) {
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+	ctx := context.Background()
+	for _, p := range []string{"/a", "/b", "/c", "/d", "/e"} {
+		_ = repo.Record(ctx, 1, ScanFileRecord{FilePath: p, Status: "healthy"})
+	}
+
+	page1, err := repo.ListForScan(ctx, 1, "all", 2, 0)
+	if err != nil || len(page1) != 2 {
+		t.Fatalf("page1 = (%d, %v), want (2, nil)", len(page1), err)
+	}
+	page3, err := repo.ListForScan(ctx, 1, "all", 2, 4)
+	if err != nil || len(page3) != 1 {
+		t.Fatalf("page3 = (%d, %v), want (1, nil)", len(page3), err)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -306,14 +306,15 @@ type Scanner interface {
 
 // ScannerService manages file scanning operations for corruption detection.
 type ScannerService struct {
-	db          *sql.DB
-	scanPaths   *repository.ScanPathRepository
-	rescans     *repository.RescanRepository
-	eventBus    *eventbus.EventBus
-	detector    integration.HealthChecker
-	pathMapper  integration.PathMapper
-	activeScans map[string]*ScanProgress
-	mu          sync.Mutex
+	db            *sql.DB
+	scanPaths     *repository.ScanPathRepository
+	rescans       *repository.RescanRepository
+	scanFilesRepo *repository.ScanFileRepository
+	eventBus      *eventbus.EventBus
+	detector      integration.HealthChecker
+	pathMapper    integration.PathMapper
+	activeScans   map[string]*ScanProgress
+	mu            sync.Mutex
 	// filesInProgress tracks individual files currently being scanned to prevent race conditions
 	filesInProgress map[string]bool
 	filesMu         sync.Mutex
@@ -357,6 +358,9 @@ func (s *ScannerService) initRepositories() {
 	if s.rescans == nil {
 		s.rescans = repository.NewRescanRepository(s.db)
 	}
+	if s.scanFilesRepo == nil {
+		s.scanFilesRepo = repository.NewScanFileRepository(s.db)
+	}
 }
 
 // scanPathRepo returns the lazy-initialized ScanPathRepository.
@@ -369,6 +373,12 @@ func (s *ScannerService) scanPathRepo() *repository.ScanPathRepository {
 func (s *ScannerService) rescanRepo() *repository.RescanRepository {
 	s.initRepositories()
 	return s.rescans
+}
+
+// scanFileRepo returns the lazy-initialized ScanFileRepository.
+func (s *ScannerService) scanFileRepo() *repository.ScanFileRepository {
+	s.initRepositories()
+	return s.scanFilesRepo
 }
 
 // IsFileBeingScanned returns true if the given file is currently being scanned.
@@ -1142,10 +1152,13 @@ func (s *ScannerService) shouldSkipRecentlyModified(sfc *scanFileContext) bool {
 		logger.Infof("Skipping recently modified file (mtime %v ago): %s",
 			time.Since(sfc.fileMtime).Round(time.Second), sfc.filePath)
 		if sfc.scanDBID > 0 {
-			if _, err := db.ExecWithRetry(s.db, `
-				INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-				VALUES (?, ?, 'skipped', 'RecentlyModified', 'File modified within last 2 minutes - likely still being written', ?)
-			`, sfc.scanDBID, sfc.filePath, sfc.fileSize); err != nil {
+			if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+				FilePath:       sfc.filePath,
+				Status:         "skipped",
+				CorruptionType: "RecentlyModified",
+				ErrorDetails:   "File modified within last 2 minutes - likely still being written",
+				FileSize:       sfc.fileSize,
+			}); err != nil {
 				logger.Debugf("Failed to record skipped file (recently modified): %v", err)
 			}
 		}
@@ -1162,10 +1175,13 @@ func (s *ScannerService) shouldSkipChangingSize(sfc *scanFileContext) bool {
 		if info2.Size() != sfc.fileSize {
 			logger.Infof("Skipping file with changing size (download in progress?): %s", sfc.filePath)
 			if sfc.scanDBID > 0 {
-				if _, err := db.ExecWithRetry(s.db, `
-					INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-					VALUES (?, ?, 'skipped', 'SizeChanging', 'File size changed during scan - active download/copy', ?)
-				`, sfc.scanDBID, sfc.filePath, sfc.fileSize); err != nil {
+				if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+					FilePath:       sfc.filePath,
+					Status:         "skipped",
+					CorruptionType: "SizeChanging",
+					ErrorDetails:   "File size changed during scan - active download/copy",
+					FileSize:       sfc.fileSize,
+				}); err != nil {
 					// scan_files rows drive the UI scan-detail screen; losing
 					// writes silently produces empty scan reports. Log loud.
 					logger.Errorf("Failed to record skipped file (size changing): %v", err)
@@ -1180,10 +1196,11 @@ func (s *ScannerService) shouldSkipChangingSize(sfc *scanFileContext) bool {
 // recordHealthyFile records a healthy file in the scan_files table.
 func (s *ScannerService) recordHealthyFile(sfc *scanFileContext) {
 	if sfc.scanDBID > 0 {
-		_, err := db.ExecWithRetry(s.db, `
-			INSERT INTO scan_files (scan_id, file_path, status, file_size)
-			VALUES (?, ?, 'healthy', ?)
-		`, sfc.scanDBID, sfc.filePath, sfc.fileSize)
+		err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+			FilePath: sfc.filePath,
+			Status:   "healthy",
+			FileSize: sfc.fileSize,
+		})
 		if err != nil {
 			// scan_files rows drive the UI scan-detail screen; losing writes
 			// silently produces "0 healthy, 0 corrupt" reports.
@@ -1200,10 +1217,13 @@ func (s *ScannerService) handleRecoverableError(progress *ScanProgress, sfc *sca
 
 	// Record as "inaccessible" not "corrupt"
 	if sfc.scanDBID > 0 {
-		_, err := db.ExecWithRetry(s.db, `
-			INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-			VALUES (?, ?, 'inaccessible', ?, ?, ?)
-		`, sfc.scanDBID, sfc.filePath, healthErr.Type, healthErr.Message, sfc.fileSize)
+		err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+			FilePath:       sfc.filePath,
+			Status:         "inaccessible",
+			CorruptionType: healthErr.Type,
+			ErrorDetails:   healthErr.Message,
+			FileSize:       sfc.fileSize,
+		})
 		if err != nil {
 			logger.Errorf("Failed to record inaccessible file: %v", err)
 		}
@@ -1259,10 +1279,13 @@ func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *Sca
 	if hasActive {
 		logger.Infof("Skipping duplicate corruption for file already being processed: %s", sfc.filePath)
 		if sfc.scanDBID > 0 {
-			if _, err := db.ExecWithRetry(s.db, `
-				INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-				VALUES (?, ?, 'skipped', 'AlreadyProcessing', 'File already has active corruption record', ?)
-			`, sfc.scanDBID, sfc.filePath, sfc.fileSize); err != nil {
+			if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+				FilePath:       sfc.filePath,
+				Status:         "skipped",
+				CorruptionType: "AlreadyProcessing",
+				ErrorDetails:   "File already has active corruption record",
+				FileSize:       sfc.fileSize,
+			}); err != nil {
 				logger.Debugf("Failed to record skipped file (already processing): %v", err)
 			}
 		}
@@ -1271,10 +1294,13 @@ func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *Sca
 
 	// Record corrupt file
 	if sfc.scanDBID > 0 {
-		_, err := db.ExecWithRetry(s.db, `
-			INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-			VALUES (?, ?, 'corrupt', ?, ?, ?)
-		`, sfc.scanDBID, sfc.filePath, healthErr.Type, healthErr.Message, sfc.fileSize)
+		err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+			FilePath:       sfc.filePath,
+			Status:         "corrupt",
+			CorruptionType: healthErr.Type,
+			ErrorDetails:   healthErr.Message,
+			FileSize:       sfc.fileSize,
+		})
 		if err != nil {
 			logger.Debugf("Failed to record corrupt file: %v", err)
 		}


### PR DESCRIPTION
## Summary

Migrates the \`scan_files\` table — 6 INSERT sites in scanner.go + 3 read sites in handlers_scans.go — to \`ScanFileRepository\`.

| Method | Site |
|---|---|
| Record | scanner.go × 6 (healthy / corrupt / inaccessible / 3× skipped) |
| CountByStatus | handlers_scans.go getScanDetails (GROUP BY breakdown) |
| CountForScan + ListForScan | handlers_scans.go getScanFiles (paginated list) |

## Design notes

- **One `Record` method for 6 inserts.** They varied only by status string and which optional columns (`corruption_type`, `error_details`) were set. `ScanFileRecord` with empty-→-NULL optionals produces rows identical to the old 4-col (healthy) and 6-col variants.
- **`Record` calls `db.ExecWithRetry`** — the same SQLite-BUSY retry wrapper the scanner used inline. These inserts fire from parallel per-file scan goroutines, so the retry is load-bearing. Preserving it means `internal/repository` imports `internal/db`; that direction is **acyclic** (the db package doesn't import repository — its own settings-migration sites were deliberately left un-migrated to keep it that way).
- \`ScannerService.scanFilesRepo\` field is named to avoid colliding with the existing \`scanFiles()\` method; reached via a lazy \`scanFileRepo()\` accessor (same pattern as \`scanPathRepo\`/\`rescanRepo\`), so the ~30 direct-construction test fixtures need no changes.
- \`database/sql\` drops out of handlers_scans.go.

## Deferred

Scanner write-path remaining: the **scans state-machine** transitions (create / status / progress / finalize), several using `db.ExecWithRetry` — own follow-up.

## Test plan

- [x] \`go test ./...\` — all packages pass (scanner integration tests included)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`scan_file_test.go\` covers Record (healthy → NULL optionals; corrupt → stored details), CountByStatus (per-scan isolation), CountForScan + ListForScan (all + status filter), pagination