### PR TITLE
feat(repository): complete scans write-path migration (Phase 3.12)

### DIFF
--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -5,11 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/mescon/Healarr/internal/db"
 )
 
 // Scan is the read-shape of a row from the scans table. Only the columns
-// used by handler-layer reads are populated; the scanner service uses
-// raw SQL for its lifecycle mutations (its own follow-up PR).
+// used by handler-layer reads are populated.
 type Scan struct {
 	ID               int64
 	Path             string
@@ -176,4 +177,161 @@ func (r *ScanRepository) GetLastCompletedScanByPathID(ctx context.Context, pathI
 		return LastScan{}, fmt.Errorf("query last scan by path: %w", err)
 	}
 	return l, nil
+}
+
+// =============================================================================
+// Write path (scanner lifecycle)
+//
+// These methods own the scans state machine that the scanner service drives.
+// IncrementCorruptions uses db.ExecWithRetry because it fires from parallel
+// per-file scan goroutines and can hit SQLite BUSY; the rest run on the
+// single scan-control path and use plain ExecContext.
+// =============================================================================
+
+// CreateScanParams is the input shape for starting a new scan record.
+type CreateScanParams struct {
+	Path                string
+	PathID              int64
+	TotalFiles          int
+	FileListJSON        string
+	DetectionConfigJSON string
+	AutoRemediate       bool
+	DryRun              bool
+}
+
+// InterruptedScan is the resume-shape for a scan that a prior shutdown left
+// in the 'interrupted' state with a persisted file_list.
+type InterruptedScan struct {
+	ID                  int64
+	PathID              sql.NullInt64
+	Path                string
+	TotalFiles          int
+	CurrentFileIndex    int
+	FileListJSON        string
+	DetectionConfigJSON sql.NullString
+	AutoRemediate       bool
+	DryRun              bool
+}
+
+// Create inserts a new scan row in the 'running' state and returns its id.
+func (r *ScanRepository) Create(ctx context.Context, p CreateScanParams) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO scans (path, path_id, status, files_scanned, corruptions_found, total_files, current_file_index, file_list, detection_config, auto_remediate, dry_run, started_at)
+		VALUES (?, ?, 'running', 0, 0, ?, 0, ?, ?, ?, ?, datetime('now'))
+	`, p.Path, p.PathID, p.TotalFiles, p.FileListJSON, p.DetectionConfigJSON, p.AutoRemediate, p.DryRun)
+	if err != nil {
+		return 0, fmt.Errorf("insert scan: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// SetStatus updates only the status column.
+func (r *ScanRepository) SetStatus(ctx context.Context, scanID int64, status string) error {
+	if _, err := r.db.ExecContext(ctx, `UPDATE scans SET status = ? WHERE id = ?`, status, scanID); err != nil {
+		return fmt.Errorf("set scan status: %w", err)
+	}
+	return nil
+}
+
+// Finalize sets the terminal status, the final files_scanned count, and
+// stamps completed_at to now.
+func (r *ScanRepository) Finalize(ctx context.Context, scanID int64, status string, filesScanned int) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET status = ?, files_scanned = ?, completed_at = datetime('now')
+		WHERE id = ?
+	`, status, filesScanned, scanID)
+	if err != nil {
+		return fmt.Errorf("finalize scan: %w", err)
+	}
+	return nil
+}
+
+// MarkInterrupted records a shutdown-time interruption, saving the file
+// index reached so the scan can resume there.
+func (r *ScanRepository) MarkInterrupted(ctx context.Context, scanID int64, currentFileIndex int) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET status = 'interrupted', current_file_index = ? WHERE id = ?
+	`, currentFileIndex, scanID)
+	if err != nil {
+		return fmt.Errorf("mark scan interrupted: %w", err)
+	}
+	return nil
+}
+
+// MarkPaused records a pause, saving the file index reached.
+func (r *ScanRepository) MarkPaused(ctx context.Context, scanID int64, currentFileIndex int) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET current_file_index = ?, status = 'paused' WHERE id = ?
+	`, currentFileIndex, scanID)
+	if err != nil {
+		return fmt.Errorf("mark scan paused: %w", err)
+	}
+	return nil
+}
+
+// MarkAborted sets the 'aborted' status and an explanatory error_message
+// (used when a mount/filesystem becomes inaccessible mid-scan).
+func (r *ScanRepository) MarkAborted(ctx context.Context, scanID int64, errorMessage string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET status = 'aborted', error_message = ? WHERE id = ?
+	`, errorMessage, scanID)
+	if err != nil {
+		return fmt.Errorf("mark scan aborted: %w", err)
+	}
+	return nil
+}
+
+// UpdateProgress updates the live current_file_index and files_scanned
+// counters during a running scan.
+func (r *ScanRepository) UpdateProgress(ctx context.Context, scanID int64, currentFileIndex, filesScanned int) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET current_file_index = ?, files_scanned = ? WHERE id = ?
+	`, currentFileIndex, filesScanned, scanID)
+	if err != nil {
+		return fmt.Errorf("update scan progress: %w", err)
+	}
+	return nil
+}
+
+// IncrementCorruptions bumps corruptions_found by one. Uses db.ExecWithRetry
+// because it fires from parallel per-file scan goroutines (SQLite BUSY
+// contention); behavior matches the scanner's prior inline call.
+func (r *ScanRepository) IncrementCorruptions(scanID int64) error {
+	if _, err := db.ExecWithRetry(r.db, `UPDATE scans SET corruptions_found = corruptions_found + 1 WHERE id = ?`, scanID); err != nil {
+		return fmt.Errorf("increment corruptions: %w", err)
+	}
+	return nil
+}
+
+// ListInterrupted returns scans left in the 'interrupted' state with a
+// persisted file_list, newest first — the resume queue consumed at startup.
+func (r *ScanRepository) ListInterrupted(ctx context.Context) ([]InterruptedScan, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, path_id, path, total_files, current_file_index, file_list, detection_config, auto_remediate, COALESCE(dry_run, 0)
+		FROM scans
+		WHERE status = 'interrupted' AND file_list IS NOT NULL
+		ORDER BY started_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query interrupted scans: %w", err)
+	}
+	defer rows.Close()
+
+	var out []InterruptedScan
+	for rows.Next() {
+		var s InterruptedScan
+		if err := rows.Scan(&s.ID, &s.PathID, &s.Path, &s.TotalFiles, &s.CurrentFileIndex,
+			&s.FileListJSON, &s.DetectionConfigJSON, &s.AutoRemediate, &s.DryRun); err != nil {
+			return nil, fmt.Errorf("scan interrupted scan row: %w", err)
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate interrupted scans: %w", err)
+	}
+	return out, nil
 }

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -19,6 +19,11 @@ CREATE TABLE scans (
 	corruptions_found  INTEGER DEFAULT 0,
 	total_files        INTEGER DEFAULT 0,
 	current_file_index INTEGER DEFAULT 0,
+	file_list          TEXT,
+	detection_config   TEXT,
+	auto_remediate     INTEGER DEFAULT 0,
+	dry_run            INTEGER DEFAULT 0,
+	error_message      TEXT,
 	started_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	completed_at       TIMESTAMP
 );
@@ -198,5 +203,142 @@ func TestScanRepository_GetLastCompletedScanByPathID(t *testing.T) {
 	// portable across SQLite drivers.
 	if !last.CompletedAt.Valid || last.CompletedAt.String[:10] != "2026-05-05" {
 		t.Errorf("CompletedAt = %+v, want date 2026-05-05", last.CompletedAt)
+	}
+}
+
+func TestScanRepository_Create_andStatusTransitions(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	id, err := repo.Create(ctx, CreateScanParams{
+		Path: "/movies", PathID: 1, TotalFiles: 100,
+		FileListJSON: `["/a.mkv","/b.mkv"]`, DetectionConfigJSON: `{"method":"ffprobe"}`,
+		AutoRemediate: true, DryRun: false,
+	})
+	if err != nil || id == 0 {
+		t.Fatalf("Create = (%d, %v), want (>0, nil)", id, err)
+	}
+
+	got, _ := repo.GetByID(ctx, id)
+	if got.Status != "running" || got.Path != "/movies" {
+		t.Errorf("after Create: %+v, want running /movies", got)
+	}
+
+	if err := repo.SetStatus(ctx, id, "paused"); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	if got, _ := repo.GetByID(ctx, id); got.Status != "paused" {
+		t.Errorf("after SetStatus: status = %q, want paused", got.Status)
+	}
+
+	if err := repo.Finalize(ctx, id, "completed", 100); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, id)
+	if got.Status != "completed" || got.FilesScanned != 100 || !got.CompletedAt.Valid {
+		t.Errorf("after Finalize: %+v, want completed/100/non-null-completed_at", got)
+	}
+}
+
+func TestScanRepository_MarkInterrupted_Paused_Aborted(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	id, _ := repo.Create(ctx, CreateScanParams{Path: "/p", PathID: 1, TotalFiles: 50, FileListJSON: "[]"})
+
+	if err := repo.MarkInterrupted(ctx, id, 17); err != nil {
+		t.Fatalf("MarkInterrupted: %v", err)
+	}
+	var status string
+	var idx int
+	_ = db.QueryRow(`SELECT status, current_file_index FROM scans WHERE id = ?`, id).Scan(&status, &idx)
+	if status != "interrupted" || idx != 17 {
+		t.Errorf("MarkInterrupted: status/idx = %q/%d, want interrupted/17", status, idx)
+	}
+
+	if err := repo.MarkPaused(ctx, id, 23); err != nil {
+		t.Fatalf("MarkPaused: %v", err)
+	}
+	_ = db.QueryRow(`SELECT status, current_file_index FROM scans WHERE id = ?`, id).Scan(&status, &idx)
+	if status != "paused" || idx != 23 {
+		t.Errorf("MarkPaused: status/idx = %q/%d, want paused/23", status, idx)
+	}
+
+	if err := repo.MarkAborted(ctx, id, "mount lost"); err != nil {
+		t.Fatalf("MarkAborted: %v", err)
+	}
+	var errMsg string
+	_ = db.QueryRow(`SELECT status, error_message FROM scans WHERE id = ?`, id).Scan(&status, &errMsg)
+	if status != "aborted" || errMsg != "mount lost" {
+		t.Errorf("MarkAborted: status/msg = %q/%q, want aborted/mount lost", status, errMsg)
+	}
+}
+
+func TestScanRepository_UpdateProgress_andIncrementCorruptions(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+	id, _ := repo.Create(ctx, CreateScanParams{Path: "/p", PathID: 1, TotalFiles: 50, FileListJSON: "[]"})
+
+	if err := repo.UpdateProgress(ctx, id, 30, 28); err != nil {
+		t.Fatalf("UpdateProgress: %v", err)
+	}
+	var idx, scanned int
+	_ = db.QueryRow(`SELECT current_file_index, files_scanned FROM scans WHERE id = ?`, id).Scan(&idx, &scanned)
+	if idx != 30 || scanned != 28 {
+		t.Errorf("UpdateProgress: idx/scanned = %d/%d, want 30/28", idx, scanned)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := repo.IncrementCorruptions(id); err != nil {
+			t.Fatalf("IncrementCorruptions: %v", err)
+		}
+	}
+	var found int
+	_ = db.QueryRow(`SELECT corruptions_found FROM scans WHERE id = ?`, id).Scan(&found)
+	if found != 3 {
+		t.Errorf("corruptions_found = %d, want 3", found)
+	}
+}
+
+func TestScanRepository_ListInterrupted(t *testing.T) {
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// Interrupted with a file_list → should be returned.
+	resumable, _ := repo.Create(ctx, CreateScanParams{
+		Path: "/resumable", PathID: 1, TotalFiles: 10,
+		FileListJSON: `["/x.mkv"]`, DetectionConfigJSON: `{"method":"ffprobe"}`, AutoRemediate: true,
+	})
+	_ = repo.MarkInterrupted(ctx, resumable, 5)
+
+	// Interrupted but file_list IS NULL → excluded.
+	mustExecScan(t, db, `INSERT INTO scans (path, status, file_list) VALUES ('/nofiles', 'interrupted', NULL)`)
+	// Running → excluded.
+	_, _ = repo.Create(ctx, CreateScanParams{Path: "/running", PathID: 1, TotalFiles: 1, FileListJSON: "[]"})
+
+	rows, err := repo.ListInterrupted(ctx)
+	if err != nil {
+		t.Fatalf("ListInterrupted: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Path != "/resumable" {
+		t.Fatalf("ListInterrupted = %+v, want only /resumable", rows)
+	}
+	r := rows[0]
+	if r.CurrentFileIndex != 5 || r.FileListJSON != `["/x.mkv"]` || !r.AutoRemediate {
+		t.Errorf("resume shape wrong: %+v", r)
+	}
+	if !r.DetectionConfigJSON.Valid || r.DetectionConfigJSON.String != `{"method":"ffprobe"}` {
+		t.Errorf("detection_config = %+v", r.DetectionConfigJSON)
+	}
+}
+
+func mustExecScan(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
 	}
 }

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/mescon/Healarr/internal/db"
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
@@ -310,6 +309,7 @@ type ScannerService struct {
 	scanPaths     *repository.ScanPathRepository
 	rescans       *repository.RescanRepository
 	scanFilesRepo *repository.ScanFileRepository
+	scans         *repository.ScanRepository
 	eventBus      *eventbus.EventBus
 	detector      integration.HealthChecker
 	pathMapper    integration.PathMapper
@@ -361,6 +361,9 @@ func (s *ScannerService) initRepositories() {
 	if s.scanFilesRepo == nil {
 		s.scanFilesRepo = repository.NewScanFileRepository(s.db)
 	}
+	if s.scans == nil {
+		s.scans = repository.NewScanRepository(s.db)
+	}
 }
 
 // scanPathRepo returns the lazy-initialized ScanPathRepository.
@@ -379,6 +382,12 @@ func (s *ScannerService) rescanRepo() *repository.RescanRepository {
 func (s *ScannerService) scanFileRepo() *repository.ScanFileRepository {
 	s.initRepositories()
 	return s.scanFilesRepo
+}
+
+// scanRepo returns the lazy-initialized ScanRepository.
+func (s *ScannerService) scanRepo() *repository.ScanRepository {
+	s.initRepositories()
+	return s.scans
 }
 
 // IsFileBeingScanned returns true if the given file is currently being scanned.
@@ -414,10 +423,7 @@ func (s *ScannerService) Shutdown() {
 			logger.Infof("Scanner: saving state for scan %s (file %d/%d)", scanID, filesDone, totalFiles)
 			// Mark as interrupted in database - state is already saved during scanning
 			ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-			_, err := s.db.ExecContext(ctx, `
-				UPDATE scans SET status = 'interrupted', current_file_index = ?
-				WHERE id = ?
-			`, filesDone, scanDBID)
+			err := s.scanRepo().MarkInterrupted(ctx, scanDBID, filesDone)
 			cancel()
 			if err != nil {
 				logger.Errorf("Failed to save scan state for %s: %v", scanID, err)
@@ -454,77 +460,25 @@ func (s *ScannerService) ResumeInterruptedScans() {
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT s.id, s.path_id, s.path, s.total_files, s.current_file_index, s.file_list, s.detection_config, s.auto_remediate, COALESCE(s.dry_run, 0)
-		FROM scans s
-		WHERE s.status = 'interrupted' AND s.file_list IS NOT NULL
-		ORDER BY s.started_at DESC
-	`)
+	scansToResume, err := s.scanRepo().ListInterrupted(ctx)
 	if err != nil {
 		logger.Errorf("Failed to query interrupted scans: %v", err)
 		return
 	}
-	defer rows.Close()
-
-	var scansToResume []struct {
-		scanDBID        int64
-		pathID          int64
-		path            string
-		totalFiles      int
-		currentIndex    int
-		fileListJSON    string
-		detectionConfig string
-		autoRemediate   bool
-		dryRun          bool
-	}
-
-	for rows.Next() {
-		var scan struct {
-			scanDBID        int64
-			pathID          int64
-			path            string
-			totalFiles      int
-			currentIndex    int
-			fileListJSON    string
-			detectionConfig string
-			autoRemediate   bool
-			dryRun          bool
-		}
-		var pathID sql.NullInt64
-		var detectionConfigNull sql.NullString
-
-		if err := rows.Scan(&scan.scanDBID, &pathID, &scan.path, &scan.totalFiles, &scan.currentIndex, &scan.fileListJSON, &detectionConfigNull, &scan.autoRemediate, &scan.dryRun); err != nil {
-			logger.Errorf("Failed to scan interrupted scan row: %v", err)
-			continue
-		}
-		if pathID.Valid {
-			scan.pathID = pathID.Int64
-		}
-		if detectionConfigNull.Valid {
-			scan.detectionConfig = detectionConfigNull.String
-		}
-		scansToResume = append(scansToResume, scan)
-	}
-
-	// Check for iteration errors
-	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating interrupted scans: %v", err)
-		return
-	}
 
 	for _, scan := range scansToResume {
-		logger.Infof("Resuming interrupted scan for %s (starting at file %d/%d)", scan.path, scan.currentIndex, scan.totalFiles)
+		logger.Infof("Resuming interrupted scan for %s (starting at file %d/%d)", scan.Path, scan.CurrentFileIndex, scan.TotalFiles)
 		s.wg.Add(1)
 		cfg := resumeScanConfig{
-			ScanDBID:            scan.scanDBID,
-			PathID:              scan.pathID,
-			LocalPath:           scan.path,
-			TotalFiles:          scan.totalFiles,
-			StartIndex:          scan.currentIndex,
-			FileListJSON:        scan.fileListJSON,
-			DetectionConfigJSON: scan.detectionConfig,
-			AutoRemediate:       scan.autoRemediate,
-			DryRun:              scan.dryRun,
+			ScanDBID:            scan.ID,
+			PathID:              scan.PathID.Int64,
+			LocalPath:           scan.Path,
+			TotalFiles:          scan.TotalFiles,
+			StartIndex:          scan.CurrentFileIndex,
+			FileListJSON:        scan.FileListJSON,
+			DetectionConfigJSON: scan.DetectionConfigJSON.String,
+			AutoRemediate:       scan.AutoRemediate,
+			DryRun:              scan.DryRun,
 		}
 		safego.Run("scanner-resume", func() { s.resumeScan(cfg) })
 	}
@@ -585,7 +539,7 @@ func (s *ScannerService) resumeScan(cfg resumeScanConfig) {
 
 	// Update scan status to running
 	statusCtx, statusCancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-	_, err := s.db.ExecContext(statusCtx, `UPDATE scans SET status = 'running' WHERE id = ?`, cfg.ScanDBID)
+	err := s.scanRepo().SetStatus(statusCtx, cfg.ScanDBID, string(ScanStatusRunning))
 	statusCancel()
 	if err != nil {
 		logger.Errorf("Failed to update scan status: %v", err)
@@ -597,10 +551,7 @@ func (s *ScannerService) resumeScan(cfg resumeScanConfig) {
 			finalStatus = progress.Status
 		}
 		deferCtx, deferCancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-		_, err := s.db.ExecContext(deferCtx, `
-			UPDATE scans SET status = ?, files_scanned = ?, completed_at = datetime('now')
-			WHERE id = ?
-		`, finalStatus, progress.FilesDone, cfg.ScanDBID)
+		err := s.scanRepo().Finalize(deferCtx, cfg.ScanDBID, finalStatus, progress.FilesDone)
 		deferCancel()
 		if err != nil {
 			logger.Errorf("Failed to update scan record: %v", err)
@@ -890,19 +841,17 @@ func (s *ScannerService) recordScanStart(localPath string, pathID int64, files [
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	result, err := s.db.ExecContext(ctx, `
-		INSERT INTO scans (path, path_id, status, files_scanned, corruptions_found, total_files, current_file_index, file_list, detection_config, auto_remediate, dry_run, started_at)
-		VALUES (?, ?, 'running', 0, 0, ?, 0, ?, ?, ?, ?, datetime('now'))
-	`, localPath, pathID, len(files), string(fileListJSON), string(detectionConfigJSON), cfg.AutoRemediate, cfg.DryRun)
-
+	scanDBID, err := s.scanRepo().Create(ctx, repository.CreateScanParams{
+		Path:                localPath,
+		PathID:              pathID,
+		TotalFiles:          len(files),
+		FileListJSON:        string(fileListJSON),
+		DetectionConfigJSON: string(detectionConfigJSON),
+		AutoRemediate:       cfg.AutoRemediate,
+		DryRun:              cfg.DryRun,
+	})
 	if err != nil {
 		logger.Errorf("Failed to record scan start: %v", err)
-		return 0
-	}
-
-	scanDBID, err := result.LastInsertId()
-	if err != nil {
-		logger.Warnf("Failed to get scan ID after insert: %v", err)
 		return 0
 	}
 	return scanDBID
@@ -939,11 +888,7 @@ func (s *ScannerService) finalizeScan(scanID string, progress *ScanProgress, sca
 		}
 		if scanDBID > 0 {
 			ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-			_, err := s.db.ExecContext(ctx, `
-				UPDATE scans
-				SET status = ?, files_scanned = ?, completed_at = datetime('now')
-				WHERE id = ?
-			`, finalStatus, progress.FilesDone, scanDBID)
+			err := s.scanRepo().Finalize(ctx, scanDBID, finalStatus, progress.FilesDone)
 			cancel()
 			if err != nil {
 				logger.Errorf("Failed to update scan record: %v", err)
@@ -1109,7 +1054,7 @@ func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProg
 	// Save current position
 	if scanDBID > 0 {
 		pauseCtx, pauseCancel := context.WithTimeout(ctx, scannerQueryTimeout)
-		if _, err := s.db.ExecContext(pauseCtx, `UPDATE scans SET current_file_index = ?, status = 'paused' WHERE id = ?`, fileIndex, scanDBID); err != nil {
+		if err := s.scanRepo().MarkPaused(pauseCtx, scanDBID, fileIndex); err != nil {
 			logger.Warnf("Failed to update scan pause state for scan %d: %v", scanDBID, err)
 		}
 		pauseCancel()
@@ -1125,7 +1070,7 @@ func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProg
 		s.mu.Unlock()
 		if scanDBID > 0 {
 			resumeCtx, resumeCancel := context.WithTimeout(ctx, scannerQueryTimeout)
-			if _, err := s.db.ExecContext(resumeCtx, `UPDATE scans SET status = 'running' WHERE id = ?`, scanDBID); err != nil {
+			if err := s.scanRepo().SetStatus(resumeCtx, scanDBID, string(ScanStatusRunning)); err != nil {
 				logger.Warnf("Failed to update scan resume state for scan %d: %v", scanDBID, err)
 			}
 			resumeCancel()
@@ -1238,8 +1183,8 @@ func (s *ScannerService) handleRecoverableError(progress *ScanProgress, sfc *sca
 		progress.Status = ScanStatusAborted
 
 		if sfc.scanDBID > 0 {
-			if _, err := s.db.Exec(`UPDATE scans SET status = 'aborted', error_message = ? WHERE id = ?`,
-				"Scan aborted: filesystem/mount became inaccessible", sfc.scanDBID); err != nil {
+			if err := s.scanRepo().MarkAborted(context.Background(), sfc.scanDBID,
+				"Scan aborted: filesystem/mount became inaccessible"); err != nil {
 				logger.Warnf("Failed to update scan abort state for scan %d: %v", sfc.scanDBID, err)
 			}
 		}
@@ -1306,7 +1251,7 @@ func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *Sca
 		}
 
 		// Update corruptions count
-		if _, err := db.ExecWithRetry(s.db, `UPDATE scans SET corruptions_found = corruptions_found + 1 WHERE id = ?`, sfc.scanDBID); err != nil {
+		if err := s.scanRepo().IncrementCorruptions(sfc.scanDBID); err != nil {
 			logger.Warnf("Failed to update corruptions count for scan %d: %v", sfc.scanDBID, err)
 		}
 	}
@@ -1564,7 +1509,7 @@ func (s *ScannerService) markFileProcessed(progress *ScanProgress, fileIndex int
 	if fileIndex%10 == 0 {
 		if scanDBID > 0 {
 			progressCtx, progressCancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-			if _, err := s.db.ExecContext(progressCtx, `UPDATE scans SET current_file_index = ?, files_scanned = ? WHERE id = ?`, fileIndex, filesDone, scanDBID); err != nil {
+			if err := s.scanRepo().UpdateProgress(progressCtx, scanDBID, fileIndex, filesDone); err != nil {
 				logger.Warnf("Failed to save scan progress for scan %d: %v", scanDBID, err)
 			}
 			progressCancel()


### PR DESCRIPTION
## Summary

Migrates the scanner's scans state-machine — 11 SQL sites — onto the \`ScanRepository\` that #204 introduced for the read side. **After this PR, no production code outside \`internal/repository\` references the scans table by SQL.**

| Method | Scanner site |
|---|---|
| Create | recordScanStart |
| SetStatus | resume-to-running (×2) |
| Finalize | runScan defer, finalizeScan |
| MarkInterrupted | Shutdown interrupt-save |
| MarkPaused | pause handler |
| MarkAborted | mount-lost abort |
| UpdateProgress | periodic progress save |
| IncrementCorruptions | per-corruption (db.ExecWithRetry) |
| ListInterrupted | ResumeInterruptedScans |

## Design notes

- **`IncrementCorruptions` uses `db.ExecWithRetry`** — it fires from parallel per-file scan goroutines and must tolerate SQLite BUSY, same as the scanner's prior inline call. The `repository → db` dependency is acyclic (established in #208 / Phase 3.11).
- **`ListInterrupted` returns `[]InterruptedScan`** — a typed value type replacing ~50 lines of manual row-scanning into an anonymous struct with `sql.Null*` juggling.
- `ScannerService` gains a lazy `scanRepo()` accessor (same pattern as `scanPathRepo`/`rescanRepo`/`scanFileRepo`), so the ~30 direct-construction test fixtures need no changes. The `internal/db` import drops out of the scanner entirely.
- The two remaining `s.db` reads in scanner.go (`hasActiveCorruption`, `LoadActiveCorruptionsForPath`) query the **events** table, not scans — they belong to a future event-store repository, out of scope here.

## Test plan

- [x] \`go test ./...\` — all packages pass (scanner integration tests included)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New scan_test.go cases: Create + status transitions, MarkInterrupted/Paused/Aborted, UpdateProgress + IncrementCorruptions, ListInterrupted (returns only interrupted-with-file_list rows, correct resume shape)
- [x] scan_test.go schema extended with file_list/detection_config/auto_remediate/dry_run/error_message columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan state persistence and recovery; interrupted scans can now be resumed from their last checkpoint with retained progress information.
  * Enhanced reliability of scan operations with better handling of pause, abort, and failure states.

* **Tests**
  * Added comprehensive test coverage for scan lifecycle operations and state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->