### PR TITLE
feat(repository): finish arr_instances migration via arr-client (Phase 3.13)

### DIFF
--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // ArrType is the typed enum of supported *arr application kinds. Using a
@@ -142,6 +143,7 @@ func (r *RateLimiter) Wait(ctx context.Context) error {
 // HTTPArrClient implements ArrClient for communicating with Sonarr/Radarr APIs.
 type HTTPArrClient struct {
 	db              *sql.DB
+	arrInstances    *repository.ArrInstanceRepository
 	httpClient      *http.Client
 	rateLimiter     *RateLimiter
 	circuitBreakers *CircuitBreakerRegistry
@@ -151,13 +153,37 @@ type HTTPArrClient struct {
 func NewArrClient(db *sql.DB) *HTTPArrClient {
 	cfg := config.Get()
 	return &HTTPArrClient{
-		db: db,
+		db:           db,
+		arrInstances: repository.NewArrInstanceRepository(db),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 		rateLimiter:     NewRateLimiter(cfg.ArrRateLimitRPS, cfg.ArrRateLimitBurst),
 		circuitBreakers: NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig()),
 	}
+}
+
+// arrInstanceFromRepo converts a repository.ArrInstance (raw persisted
+// shape, encrypted api_key, string type) into the integration ArrInstance
+// the client uses (decrypted api_key, typed ArrType). ParseArrType is the
+// boundary validation: an unknown type string (e.g. a manual SQL insert
+// with a typo) surfaces as an error here rather than downstream.
+func arrInstanceFromRepo(row repository.ArrInstance) (ArrInstance, error) {
+	arrType, err := ParseArrType(row.Type)
+	if err != nil {
+		return ArrInstance{}, fmt.Errorf("instance %d has invalid type %q: %w", row.ID, row.Type, err)
+	}
+	decryptedKey, err := crypto.Decrypt(row.EncryptedAPIKey)
+	if err != nil {
+		return ArrInstance{}, fmt.Errorf("failed to decrypt API key for instance %d: %w", row.ID, err)
+	}
+	return ArrInstance{
+		ID:     row.ID,
+		Name:   row.Name,
+		Type:   arrType,
+		URL:    row.URL,
+		APIKey: decryptedKey,
+	}, nil
 }
 
 // GetCircuitBreakerStats returns statistics for all circuit breakers.
@@ -296,48 +322,34 @@ func normalizedPathLength(rootPath string) int {
 }
 
 func (c *HTTPArrClient) getInstanceForPath(arrPath string) (*ArrInstance, error) {
-	rows, err := c.db.Query("SELECT i.id, i.name, i.type, i.url, i.api_key, sp.arr_path FROM arr_instances i JOIN scan_paths sp ON sp.arr_instance_id = i.id WHERE i.enabled = 1")
+	rows, err := c.arrInstances.ListEnabledWithScanPaths(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query instances: %w", err)
 	}
-	defer rows.Close()
 
 	var bestMatch *ArrInstance
 	var longestPrefixLen int
 
-	for rows.Next() {
-		var i ArrInstance
-		var rootPath string
-		var encryptedKey string
-		if err := rows.Scan(&i.ID, &i.Name, &i.Type, &i.URL, &encryptedKey, &rootPath); err != nil {
-			// ArrType.Scan rejects unknown DB values here. Logging at Errorf
-			// surfaces the bad row (typically a manual SQL insert with a
-			// typo'd type) rather than silently producing "no instance
-			// found" downstream.
-			logger.Errorf("getInstanceForPath: skipping unscannable row: %v", err)
+	for _, row := range rows {
+		if !isValidPathMatch(row.ArrPath, arrPath) {
 			continue
 		}
 
-		decryptedKey, err := crypto.Decrypt(encryptedKey)
+		instance, err := arrInstanceFromRepo(row.ArrInstance)
 		if err != nil {
-			logger.Errorf("Failed to decrypt API key for instance %d: %v", i.ID, err)
-			continue
-		}
-		i.APIKey = decryptedKey
-
-		if !isValidPathMatch(rootPath, arrPath) {
+			// Surfaces a bad row (typically a manual SQL insert with a
+			// typo'd type, or an undecryptable key) rather than silently
+			// producing "no instance found" downstream.
+			logger.Errorf("getInstanceForPath: skipping invalid instance: %v", err)
 			continue
 		}
 
-		pathLen := normalizedPathLength(rootPath)
+		pathLen := normalizedPathLength(row.ArrPath)
 		if pathLen > longestPrefixLen {
 			longestPrefixLen = pathLen
-			bestMatch = &i
+			matched := instance
+			bestMatch = &matched
 		}
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating instances for path: %w", err)
 	}
 
 	if bestMatch == nil {
@@ -1109,50 +1121,35 @@ func (c *HTTPArrClient) TriggerSearch(mediaID int64, path string, episodeIDs []i
 
 // getAllInstancesInternal returns all enabled *arr instances (internal use)
 func (c *HTTPArrClient) getAllInstancesInternal() ([]*ArrInstance, error) {
-	rows, err := c.db.Query("SELECT id, name, type, url, api_key FROM arr_instances WHERE enabled = 1")
+	rows, err := c.arrInstances.ListEnabled(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query instances: %w", err)
 	}
-	defer rows.Close()
 
 	var instances []*ArrInstance
-	for rows.Next() {
-		var i ArrInstance
-		var encryptedKey string
-		if rows.Scan(&i.ID, &i.Name, &i.Type, &i.URL, &encryptedKey) != nil {
-			continue
-		}
-		decryptedKey, err := crypto.Decrypt(encryptedKey)
+	for _, row := range rows {
+		instance, err := arrInstanceFromRepo(row)
 		if err != nil {
-			logger.Errorf("Failed to decrypt API key for instance %d: %v", i.ID, err)
+			logger.Errorf("getAllInstancesInternal: skipping invalid instance: %v", err)
 			continue
 		}
-		i.APIKey = decryptedKey
-		instances = append(instances, &i)
+		matched := instance
+		instances = append(instances, &matched)
 	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating instances: %w", err)
-	}
-
 	return instances, nil
 }
 
 // getInstanceByIDInternal returns a specific *arr instance by ID (internal use)
 func (c *HTTPArrClient) getInstanceByIDInternal(id int64) (*ArrInstance, error) {
-	var i ArrInstance
-	var encryptedKey string
-	err := c.db.QueryRow("SELECT id, name, type, url, api_key FROM arr_instances WHERE id = ?", id).
-		Scan(&i.ID, &i.Name, &i.Type, &i.URL, &encryptedKey)
+	row, err := c.arrInstances.GetByID(context.Background(), id)
 	if err != nil {
 		return nil, err
 	}
-	decryptedKey, err := crypto.Decrypt(encryptedKey)
+	instance, err := arrInstanceFromRepo(row)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt API key: %w", err)
+		return nil, err
 	}
-	i.APIKey = decryptedKey
-	return &i, nil
+	return &instance, nil
 }
 
 // GetQueue retrieves the download queue for an *arr instance

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -44,7 +44,8 @@ func newTestDB(t *testing.T) *testDB {
 			type TEXT NOT NULL,
 			url TEXT NOT NULL,
 			api_key TEXT NOT NULL,
-			enabled INTEGER DEFAULT 1
+			enabled INTEGER DEFAULT 1,
+			webhook_secret TEXT
 		);
 		CREATE TABLE IF NOT EXISTS scan_paths (
 			id INTEGER PRIMARY KEY,

--- a/internal/repository/arr_instance.go
+++ b/internal/repository/arr_instance.go
@@ -145,6 +145,44 @@ func (r *ArrInstanceRepository) ListEnabled(ctx context.Context) ([]ArrInstance,
 	return instances, nil
 }
 
+// ArrInstanceWithScanPath pairs an enabled instance with the arr_path of
+// one of its scan_paths (the JOIN produces one row per (instance, path)).
+// Only the columns the arr-client path-matching logic needs are populated
+// — EncryptedWebhookSecret/Enabled are left zero-valued.
+type ArrInstanceWithScanPath struct {
+	ArrInstance
+	ArrPath string
+}
+
+// ListEnabledWithScanPaths returns enabled instances joined with each of
+// their scan_paths' arr_path. Used by the arr-client to resolve which
+// instance owns a given *arr-side path via longest-prefix matching.
+func (r *ArrInstanceRepository) ListEnabledWithScanPaths(ctx context.Context) ([]ArrInstanceWithScanPath, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT i.id, i.name, i.type, i.url, i.api_key, sp.arr_path
+		FROM arr_instances i
+		JOIN scan_paths sp ON sp.arr_instance_id = i.id
+		WHERE i.enabled = 1
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query enabled arr_instances with scan paths: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ArrInstanceWithScanPath
+	for rows.Next() {
+		var row ArrInstanceWithScanPath
+		if err := rows.Scan(&row.ID, &row.Name, &row.Type, &row.URL, &row.EncryptedAPIKey, &row.ArrPath); err != nil {
+			return nil, fmt.Errorf("scan arr_instance+scan_path row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate arr_instances with scan paths: %w", err)
+	}
+	return out, nil
+}
+
 // GetByID returns the row matching id, or ErrNotFound.
 func (r *ArrInstanceRepository) GetByID(ctx context.Context, id int64) (ArrInstance, error) {
 	var inst ArrInstance

--- a/internal/repository/arr_instance_test.go
+++ b/internal/repository/arr_instance_test.go
@@ -20,6 +20,12 @@ CREATE TABLE arr_instances (
 	webhook_secret TEXT,
 	created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+CREATE TABLE scan_paths (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	local_path      TEXT NOT NULL,
+	arr_path        TEXT NOT NULL,
+	arr_instance_id INTEGER
+);
 `
 
 func newArrInstanceTestDB(t *testing.T) *sql.DB {
@@ -150,6 +156,62 @@ func TestArrInstanceRepository_ListAll_andListEnabled(t *testing.T) {
 		if !inst.Enabled {
 			t.Errorf("ListEnabled returned disabled row: %+v", inst)
 		}
+	}
+}
+
+func TestArrInstanceRepository_ListEnabledWithScanPaths(t *testing.T) {
+	db := newArrInstanceTestDB(t)
+	repo := NewArrInstanceRepository(db)
+	ctx := context.Background()
+
+	enabledID, err := repo.Create(ctx, CreateArrInstanceParams{
+		Name: "sonarr", Type: "sonarr", URL: "http://s", EncryptedAPIKey: "enc-k", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("Create enabled: %v", err)
+	}
+	disabledID, err := repo.Create(ctx, CreateArrInstanceParams{
+		Name: "radarr", Type: "radarr", URL: "http://r", EncryptedAPIKey: "enc-k", Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("Create disabled: %v", err)
+	}
+
+	// Enabled instance with two scan paths → two joined rows.
+	mustExecArr(t, db, `INSERT INTO scan_paths (local_path, arr_path, arr_instance_id) VALUES ('/m', '/data/movies', ?)`, enabledID)
+	mustExecArr(t, db, `INSERT INTO scan_paths (local_path, arr_path, arr_instance_id) VALUES ('/t', '/data/tv', ?)`, enabledID)
+	// Disabled instance's scan path → excluded (WHERE i.enabled = 1).
+	mustExecArr(t, db, `INSERT INTO scan_paths (local_path, arr_path, arr_instance_id) VALUES ('/x', '/data/x', ?)`, disabledID)
+	// Orphan scan path (no instance) → excluded by the INNER JOIN.
+	mustExecArr(t, db, `INSERT INTO scan_paths (local_path, arr_path, arr_instance_id) VALUES ('/o', '/data/o', 999)`)
+
+	rows, err := repo.ListEnabledWithScanPaths(ctx)
+	if err != nil {
+		t.Fatalf("ListEnabledWithScanPaths: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (both paths of the enabled instance)", len(rows))
+	}
+
+	arrPaths := map[string]bool{}
+	for _, r := range rows {
+		if r.ID != enabledID {
+			t.Errorf("row references instance %d, want enabled %d", r.ID, enabledID)
+		}
+		if r.EncryptedAPIKey != "enc-k" {
+			t.Errorf("EncryptedAPIKey = %q, want enc-k", r.EncryptedAPIKey)
+		}
+		arrPaths[r.ArrPath] = true
+	}
+	if !arrPaths["/data/movies"] || !arrPaths["/data/tv"] {
+		t.Errorf("arr_paths = %v, want both /data/movies and /data/tv", arrPaths)
+	}
+}
+
+func mustExecArr(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the 3 deferred integration-package \`arr_instances\` SQL sites from #198. **After this PR, no production code outside \`internal/repository\` references the arr_instances table by SQL.**

The #198 deferral cited an import-cycle risk (integration owns the \`ArrType\` enum). That risk never materialized: \`ArrInstanceRepository\` uses a plain \`string\` Type field, so \`internal/repository\` imports nothing from \`internal/integration\`. The dependency added here — \`integration → repository\` — is therefore acyclic.

| Method | arr-client site |
|---|---|
| ListEnabledWithScanPaths | getInstanceForPath (instance⋈scan_path join) |
| ListEnabled | getAllInstancesInternal |
| GetByID | getInstanceByIDInternal |

## Design notes

- New \`arrInstanceFromRepo\` helper converts \`repository.ArrInstance\` (encrypted key, string type) → \`integration.ArrInstance\` (decrypted key, typed \`ArrType\`). \`ParseArrType\` does the boundary validation the inline \`ArrType.Scan\` used to do — an unknown type string surfaces as a logged error, not a silent miss.
- \`getInstanceForPath\` now filters by path **before** converting, so a malformed row only matters if it actually matches the requested path — marginally more robust than the prior scan-then-skip.
- \`ListEnabledWithScanPaths\` + \`ArrInstanceWithScanPath\` value type encapsulate the instances⋈scan_paths JOIN.

## Test plan

- [x] \`go test ./...\` — all packages pass (integration suite included)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] \`grep\` confirms zero arr_instances raw SQL outside internal/repository
- [x] arr_client_test.go schema gains \`webhook_secret\` (ListEnabled/GetByID select it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for instance data access and management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->