### PR TITLE
feat(repository): introduce EventStore repository — append + replay (Phase 3.14)

### DIFF
--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -2,15 +2,14 @@ package eventbus
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/mescon/Healarr/internal/db"
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -36,6 +35,7 @@ var _ Publisher = (*EventBus)(nil)
 // Events are persisted to the database before being dispatched to subscribers.
 type EventBus struct {
 	db          *sql.DB
+	events      *repository.EventRepository
 	subscribers map[domain.EventType][]chan domain.Event
 	mu          sync.RWMutex
 	stopChan    chan struct{}
@@ -46,6 +46,7 @@ type EventBus struct {
 func NewEventBus(db *sql.DB) *EventBus {
 	return &EventBus{
 		db:          db,
+		events:      repository.NewEventRepository(db),
 		subscribers: make(map[domain.EventType][]chan domain.Event),
 		stopChan:    make(chan struct{}),
 	}
@@ -54,13 +55,7 @@ func NewEventBus(db *sql.DB) *EventBus {
 func (eb *EventBus) Publish(event domain.Event) error {
 	logger.Debugf("EventBus: Publishing event %s (ID: %d, AggregateID: %s)", event.EventType, event.ID, event.AggregateID)
 
-	// 1. Store event in database (source of truth)
-	eventDataJSON, err := json.Marshal(event.EventData)
-	if err != nil {
-		return fmt.Errorf("failed to marshal event data: %w", err)
-	}
-
-	// Set default values if missing
+	// Set default values if missing before persisting
 	if event.CreatedAt.IsZero() {
 		event.CreatedAt = time.Now().UTC() // Use UTC for consistent SQLite date parsing
 	}
@@ -68,20 +63,12 @@ func (eb *EventBus) Publish(event domain.Event) error {
 		event.EventVersion = 1
 	}
 
-	res, err := db.ExecWithRetry(eb.db, `
-        INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at, user_id)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-    `, event.AggregateType, event.AggregateID, event.EventType, eventDataJSON, event.EventVersion, event.CreatedAt, event.UserID)
-
+	// 1. Store event in database (source of truth)
+	id, err := eb.events.Append(event)
 	if err != nil {
 		return fmt.Errorf("failed to persist event: %w", err)
 	}
-
-	// Get the ID of the inserted event
-	id, err := res.LastInsertId()
-	if err == nil {
-		event.ID = id
-	}
+	event.ID = id
 
 	// 2. Publish to in-memory subscribers
 	eb.mu.RLock()

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -1,0 +1,122 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mescon/Healarr/internal/db"
+	"github.com/mescon/Healarr/internal/domain"
+)
+
+// EventRepository owns the events table — the append-only event store that
+// is the system's source of truth. It handles the persist (append) and the
+// replay-on-startup read; higher-level read models (corruption_status,
+// dashboard aggregates) live in their own repositories.
+type EventRepository struct {
+	db *sql.DB
+}
+
+// NewEventRepository returns a repository backed by sqlDB.
+func NewEventRepository(sqlDB *sql.DB) *EventRepository {
+	return &EventRepository{db: sqlDB}
+}
+
+// Append persists an event and returns its new row id.
+//
+// Uses db.ExecWithRetry rather than plain Exec: events are the event-
+// sourcing source of truth, so a write dropped under transient SQLite BUSY
+// would silently lose state history. This matches the retry the eventbus
+// used inline before the repository extraction.
+//
+// Append marshals EventData to JSON and persists exactly the fields it is
+// given — defaulting (CreatedAt, EventVersion) stays with the caller
+// (eventbus), which owns publish policy.
+func (r *EventRepository) Append(e domain.Event) (int64, error) {
+	eventDataJSON, err := json.Marshal(e.EventData)
+	if err != nil {
+		return 0, fmt.Errorf("marshal event data: %w", err)
+	}
+
+	res, err := db.ExecWithRetry(r.db, `
+		INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at, user_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, e.AggregateType, e.AggregateID, e.EventType, eventDataJSON, e.EventVersion, e.CreatedAt, e.UserID)
+	if err != nil {
+		return 0, fmt.Errorf("persist event: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// ListUnprocessed returns events of the given type that have no later event
+// for the same aggregate — i.e. an aggregate whose stream ends at this
+// event. Used by replay-on-startup to re-dispatch events that were
+// persisted but never delivered to in-memory subscribers before a restart.
+// Ordered oldest-first.
+//
+// Rows that fail to scan or whose event_data is unparseable JSON are
+// skipped (not returned, not fatal): a corrupt persisted row can't be
+// replayed regardless, and one bad row must not abort replay of the rest.
+// The skipped count is returned so the caller can log/observe it. Only a
+// query-level or iteration-level failure returns an error.
+func (r *EventRepository) ListUnprocessed(ctx context.Context, eventType domain.EventType) (events []domain.Event, skipped int, err error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT e.id, e.aggregate_type, e.aggregate_id, e.event_type, e.event_data, e.event_version, e.created_at, e.user_id
+		FROM events e
+		WHERE e.event_type = ?
+		AND NOT EXISTS (
+			SELECT 1 FROM events e2
+			WHERE e2.aggregate_id = e.aggregate_id
+			AND e2.created_at > e.created_at
+		)
+		ORDER BY e.created_at ASC
+	`, eventType)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query unprocessed events: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		event, scanErr := scanEventRow(rows)
+		if scanErr != nil {
+			skipped++
+			continue
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, skipped, fmt.Errorf("iterate events: %w", err)
+	}
+	return events, skipped, nil
+}
+
+// scanEventRow scans a full events row into a domain.Event, decoding the
+// JSON event_data and the nullable user_id.
+func scanEventRow(scanner interface {
+	Scan(dest ...interface{}) error
+}) (domain.Event, error) {
+	var event domain.Event
+	var userID sql.NullString
+	var eventDataBytes []byte
+	if err := scanner.Scan(
+		&event.ID, &event.AggregateType, &event.AggregateID, &event.EventType,
+		&eventDataBytes, &event.EventVersion, &event.CreatedAt, &userID,
+	); err != nil {
+		return domain.Event{}, fmt.Errorf("scan event row: %w", err)
+	}
+	if userID.Valid {
+		event.UserID = userID.String
+	}
+	if len(eventDataBytes) > 0 {
+		if err := json.Unmarshal(eventDataBytes, &event.EventData); err != nil {
+			return domain.Event{}, fmt.Errorf("unmarshal event data for %s: %w", event.AggregateID, err)
+		}
+	}
+	return event, nil
+}

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -1,0 +1,134 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/mescon/Healarr/internal/domain"
+)
+
+const eventSchema = `
+CREATE TABLE events (
+	id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	aggregate_type TEXT NOT NULL,
+	aggregate_id   TEXT NOT NULL,
+	event_type     TEXT NOT NULL,
+	event_data     JSON NOT NULL,
+	event_version  INTEGER NOT NULL DEFAULT 1,
+	created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	user_id        TEXT
+);
+`
+
+func newEventTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(eventSchema); err != nil {
+		t.Fatalf("create events schema: %v", err)
+	}
+	return db
+}
+
+func TestEventRepository_Append(t *testing.T) {
+	db := newEventTestDB(t)
+	repo := NewEventRepository(db)
+
+	id, err := repo.Append(domain.Event{
+		AggregateType: "corruption",
+		AggregateID:   "c1",
+		EventType:     domain.CorruptionDetected,
+		EventData:     map[string]interface{}{"file_path": "/a.mkv", "path_id": float64(3)},
+		EventVersion:  1,
+		CreatedAt:     time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if id == 0 {
+		t.Error("Append returned id=0")
+	}
+
+	var aggID, eventType, dataJSON string
+	if err := db.QueryRow(`SELECT aggregate_id, event_type, event_data FROM events WHERE id = ?`, id).
+		Scan(&aggID, &eventType, &dataJSON); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if aggID != "c1" || eventType != string(domain.CorruptionDetected) {
+		t.Errorf("persisted row: agg=%q type=%q", aggID, eventType)
+	}
+	if dataJSON != `{"file_path":"/a.mkv","path_id":3}` {
+		t.Errorf("event_data = %q", dataJSON)
+	}
+}
+
+func TestEventRepository_ListUnprocessed_endOfStreamOnly(t *testing.T) {
+	db := newEventTestDB(t)
+	repo := NewEventRepository(db)
+	ctx := context.Background()
+
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEv := func(aggID string, et domain.EventType, at time.Time) {
+		if _, err := db.Exec(
+			`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at) VALUES ('corruption', ?, ?, '{}', ?)`,
+			aggID, et, at.UTC().Format("2006-01-02 15:04:05.000"),
+		); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// c1: detected then resolved → NOT unprocessed (has a later event).
+	appendEv("c1", domain.CorruptionDetected, base)
+	appendEv("c1", domain.VerificationSuccess, base.Add(time.Minute))
+	// c2: detected only → unprocessed.
+	appendEv("c2", domain.CorruptionDetected, base.Add(time.Hour))
+
+	events, skipped, err := repo.ListUnprocessed(ctx, domain.CorruptionDetected)
+	if err != nil {
+		t.Fatalf("ListUnprocessed: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
+	}
+	if len(events) != 1 || events[0].AggregateID != "c2" {
+		t.Fatalf("got %+v, want only c2", events)
+	}
+	// Verify the round-tripped event data unmarshaled.
+	if events[0].EventType != domain.CorruptionDetected {
+		t.Errorf("event type = %q, want CorruptionDetected", events[0].EventType)
+	}
+}
+
+func TestEventRepository_ListUnprocessed_skipsCorruptData(t *testing.T) {
+	db := newEventTestDB(t)
+	repo := NewEventRepository(db)
+
+	// One valid, one with non-JSON event_data → the corrupt row is skipped,
+	// not fatal (replay must survive a bad persisted row).
+	if _, err := db.Exec(
+		`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data) VALUES
+		 ('corruption', 'good', ?, '{"file_path":"/a"}'),
+		 ('corruption', 'bad',  ?, 'not-json')`,
+		domain.CorruptionDetected, domain.CorruptionDetected,
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	events, skipped, err := repo.ListUnprocessed(context.Background(), domain.CorruptionDetected)
+	if err != nil {
+		t.Fatalf("ListUnprocessed should not error on corrupt row: %v", err)
+	}
+	if skipped != 1 {
+		t.Errorf("skipped = %d, want 1", skipped)
+	}
+	if len(events) != 1 || events[0].AggregateID != "good" {
+		t.Errorf("got %+v, want only the good row", events)
+	}
+}

--- a/internal/services/event_replay.go
+++ b/internal/services/event_replay.go
@@ -1,12 +1,13 @@
 package services
 
 import (
+	"context"
 	"database/sql"
-	"encoding/json"
 
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // EventReplayService replays unprocessed events on startup.
@@ -14,12 +15,13 @@ import (
 // may not have been delivered to in-memory subscribers before a restart.
 type EventReplayService struct {
 	db       *sql.DB
+	events   *repository.EventRepository
 	eventBus *eventbus.EventBus
 }
 
 // NewEventReplayService creates a new event replay service.
 func NewEventReplayService(db *sql.DB, eventBus *eventbus.EventBus) *EventReplayService {
-	return &EventReplayService{db: db, eventBus: eventBus}
+	return &EventReplayService{db: db, events: repository.NewEventRepository(db), eventBus: eventBus}
 }
 
 // ReplayUnprocessedEvents finds CorruptionDetected events that have no subsequent
@@ -27,57 +29,19 @@ func NewEventReplayService(db *sql.DB, eventBus *eventbus.EventBus) *EventReplay
 // This should be called AFTER all services have subscribed to events but BEFORE
 // the recovery service runs.
 func (s *EventReplayService) ReplayUnprocessedEvents() error {
-	// Find CorruptionDetected events with no subsequent events for the same aggregate.
-	// These are events that were persisted but the remediator never processed them
-	// (e.g., due to immediate restart after publishing).
-	query := `
-		SELECT e.id, e.aggregate_type, e.aggregate_id, e.event_type, e.event_data, e.event_version, e.created_at, e.user_id
-		FROM events e
-		WHERE e.event_type = ?
-		AND NOT EXISTS (
-			SELECT 1 FROM events e2
-			WHERE e2.aggregate_id = e.aggregate_id
-			AND e2.created_at > e.created_at
-		)
-		ORDER BY e.created_at ASC
-	`
-
-	rows, err := s.db.Query(query, domain.CorruptionDetected)
+	// Find CorruptionDetected events with no subsequent events for the same
+	// aggregate. These are events that were persisted but the remediator
+	// never processed them (e.g., due to immediate restart after publishing).
+	events, skipped, err := s.events.ListUnprocessed(context.Background(), domain.CorruptionDetected)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	if skipped > 0 {
+		logger.Warnf("Event replay: skipped %d unparseable event row(s)", skipped)
+	}
 
 	var replayed int
-	for rows.Next() {
-		var event domain.Event
-		var userID sql.NullString
-		var eventDataBytes []byte
-		if err := rows.Scan(
-			&event.ID,
-			&event.AggregateType,
-			&event.AggregateID,
-			&event.EventType,
-			&eventDataBytes,
-			&event.EventVersion,
-			&event.CreatedAt,
-			&userID,
-		); err != nil {
-			logger.Warnf("Failed to scan event for replay: %v", err)
-			continue
-		}
-		if userID.Valid {
-			event.UserID = userID.String
-		}
-
-		// Unmarshal event data from JSON
-		if len(eventDataBytes) > 0 {
-			if err := json.Unmarshal(eventDataBytes, &event.EventData); err != nil {
-				logger.Warnf("Failed to unmarshal event data for %s: %v", event.AggregateID, err)
-				continue
-			}
-		}
-
+	for _, event := range events {
 		// Republish to in-memory subscribers (skip DB persist since it already exists)
 		if err := s.eventBus.RepublishToSubscribers(event); err != nil {
 			logger.Warnf("Failed to replay event %s: %v", event.AggregateID, err)
@@ -86,10 +50,6 @@ func (s *EventReplayService) ReplayUnprocessedEvents() error {
 
 		replayed++
 		logger.Infof("Replayed unprocessed event: %s (%s)", event.AggregateID, event.EventType)
-	}
-
-	if err := rows.Err(); err != nil {
-		return err
 	}
 
 	if replayed > 0 {


### PR DESCRIPTION
## Summary

First slice of the event-store migration (the read-model work the audit flagged). Extracts the events-table **append** (the event-sourcing source-of-truth write) and the **replay-on-startup read** into \`EventRepository\`.

| Method | Consumer |
|---|---|
| Append(domain.Event) → id | eventbus.Publish |
| ListUnprocessed(eventType) → (events, skipped, err) | event_replay.ReplayUnprocessedEvents |

## Design notes

- **`Append` uses `db.ExecWithRetry`** — events are the source of truth; a write dropped under transient SQLite BUSY would silently lose state history. Same retry rationale as scans/scan_files writes. Defaulting (`CreatedAt`, `EventVersion`) stays in the eventbus (publish policy); `Append` persists exactly what it's given.
- **`ListUnprocessed` returns a `skipped` count rather than aborting on a corrupt row.** A malformed persisted event can't be replayed regardless, and one bad row must not abort replay of the rest — this preserves the original log-and-continue behavior. The caller logs the skipped count.
- **`eventbus → repository` is acyclic**: `repository` imports only `domain` + `db`, never `eventbus`. eventbus drops its `encoding/json` + `internal/db` imports.
- event_replay's ~40 lines of manual `rows.Scan` + `json.Unmarshal` collapse into one repo call.

## Scope

This is the foundation. Remaining event-store reads — analytical queries in health_monitor / monitor / recovery / verifier / remediator, the scanner's active-corruption lookups, and a few handler counts — are follow-up PRs on top of this.

## Test plan

- [x] \`go test ./...\` — all packages pass (eventbus + services + replay tests)
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`event_test.go\`: Append (round-trips event_data JSON), ListUnprocessed (returns only end-of-stream aggregates), ListUnprocessed skips corrupt-JSON rows (count, non-fatal)
- [x] Existing TestReplayUnprocessedEvents_CorruptedEventData still passes (the skip-corrupt-row behavior is preserved)