### PR TITLE
feat(repository): migrate corruption read-model queries (Phase 3.15)

### DIFF
--- a/internal/api/handlers_health.go
+++ b/internal/api/handlers_health.go
@@ -149,8 +149,8 @@ func (s *RESTServer) handleHealth(c *gin.Context) {
 	arrHealth := s.checkArrInstancesHealth(ctx)
 
 	// Get pending corruptions count
-	var pending int
-	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM corruption_status WHERE current_state = 'CorruptionDetected'").Scan(&pending); err != nil {
+	pending, err := s.corruptions.CountByState(ctx, "CorruptionDetected")
+	if err != nil {
 		logger.Debugf("Failed to query pending corruptions: %v", err)
 	}
 

--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"net/http"
 
@@ -38,34 +37,25 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	var warnings []string
 
 	// All corruption stats in a single query
-	var resolved, orphaned, inProgress, manualIntervention, pending, failed, ignored int
-	if err := s.db.QueryRow(`
-		SELECT
-			COUNT(DISTINCT CASE WHEN current_state = 'VerificationSuccess' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'MaxRetriesReached' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state IN ('SearchStarted', 'SearchQueued', 'RemediationQueued',
-				'DownloadStarted', 'DownloadProgress', 'SearchCompleted', 'DeletionCompleted', 'FileDetected')
-				THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state IN ('ImportBlocked', 'ManuallyRemoved') THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionDetected' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state LIKE '%Failed' AND current_state != 'MaxRetriesReached' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionIgnored' THEN corruption_id END)
-		FROM corruption_status
-	`).Scan(&resolved, &orphaned, &inProgress, &manualIntervention, &pending, &failed, &ignored); err != nil {
+	counts, err := s.corruptions.StateCounts(c.Request.Context())
+	if err != nil {
 		warnings = append(warnings, "failed to query corruption stats")
 		logger.Debugf("Failed to query corruption stats: %v", err)
 	}
+	resolved, inProgress := counts.Resolved, counts.InProgress
+	orphaned := counts.Orphaned
 
-	stats.ResolvedCorruptions = resolved
-	stats.OrphanedCorruptions = orphaned
-	stats.InProgressCorruptions = inProgress
-	stats.ManualInterventionCorruptions = manualIntervention
-	stats.PendingCorruptions = pending
-	stats.FailedCorruptions = failed
-	stats.IgnoredCorruptions = ignored
-	stats.SuccessfulRemediations = resolved
+	stats.ResolvedCorruptions = counts.Resolved
+	stats.OrphanedCorruptions = counts.Orphaned
+	stats.InProgressCorruptions = counts.InProgress
+	stats.ManualInterventionCorruptions = counts.ManualIntervention
+	stats.PendingCorruptions = counts.Pending
+	stats.FailedCorruptions = counts.Failed
+	stats.IgnoredCorruptions = counts.Ignored
+	stats.SuccessfulRemediations = counts.Resolved
 	// Total excludes ignored - they're not part of active remediation
-	stats.TotalCorruptions = pending + resolved + orphaned + manualIntervention + inProgress + failed
+	stats.TotalCorruptions = counts.Pending + counts.Resolved + counts.Orphaned +
+		counts.ManualIntervention + counts.InProgress + counts.Failed
 
 	// All scan stats in a single query
 	if scanStats, err := s.scans.GetScanStats(c.Request.Context()); err != nil {
@@ -79,18 +69,11 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	}
 
 	// Query 3: Corruptions detected today (needs events table)
-	if err := s.db.QueryRow(`
-		SELECT COUNT(*) FROM events e
-		WHERE e.event_type = 'CorruptionDetected'
-		AND substr(e.created_at, 1, 10) = date('now')
-		AND NOT EXISTS (
-			SELECT 1 FROM corruption_status cs
-			WHERE cs.corruption_id = e.aggregate_id
-			AND cs.current_state = 'CorruptionIgnored'
-		)
-	`).Scan(&stats.CorruptionsToday); err != nil {
+	if today, err := s.corruptions.CountDetectedToday(c.Request.Context()); err != nil {
 		warnings = append(warnings, "failed to query corruptions today")
 		logger.Debugf("Failed to query corruptions today: %v", err)
+	} else {
+		stats.CorruptionsToday = today
 	}
 
 	// Query 4: Last completed scan info
@@ -127,74 +110,40 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 func (s *RESTServer) getStatsHistory(c *gin.Context) {
 	// Group by date for the last 30 days
 	// Use substr to extract YYYY-MM-DD from Go's time.Time format
-	rows, err := s.db.Query(`
-		SELECT substr(created_at, 1, 10) as date, COUNT(*) as count
-		FROM events
-		WHERE event_type = 'CorruptionDetected'
-		AND substr(created_at, 1, 10) >= date('now', '-30 days')
-		GROUP BY substr(created_at, 1, 10)
-		ORDER BY date ASC
-	`)
+	days, err := s.corruptions.CountDetectedByDay(c.Request.Context(), 30)
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	stats := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var date string
-		var count int
-		if rows.Scan(&date, &count) != nil {
-			continue
-		}
+	stats := make([]map[string]interface{}, 0, len(days))
+	for _, d := range days {
 		stats = append(stats, map[string]interface{}{
-			"date":  date,
-			"count": count,
+			"date":  d.Date,
+			"count": d.Count,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		respondDatabaseError(c, err)
-		return
 	}
 	c.JSON(http.StatusOK, stats)
 }
 
 func (s *RESTServer) getStatsTypes(c *gin.Context) {
 	// Group by corruption type
-	rows, err := s.db.Query(`
-		SELECT json_extract(event_data, '$.corruption_type') as type, COUNT(*) as count
-		FROM events
-		WHERE event_type = 'CorruptionDetected'
-		GROUP BY type
-	`)
+	types, err := s.corruptions.CountByCorruptionType(c.Request.Context())
 	if err != nil {
 		respondDatabaseError(c, err)
 		return
 	}
-	defer rows.Close()
 
-	stats := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		var corruptionType sql.NullString
-		var count int
-		if rows.Scan(&corruptionType, &count) != nil {
-			continue
+	stats := make([]map[string]interface{}, 0, len(types))
+	for _, t := range types {
+		typeName := t.Type
+		if typeName == "" {
+			typeName = "Unknown"
 		}
-
-		typeName := "Unknown"
-		if corruptionType.Valid {
-			typeName = corruptionType.String
-		}
-
 		stats = append(stats, map[string]interface{}{
 			"type":  typeName,
-			"count": count,
+			"count": t.Count,
 		})
-	}
-	if err := rows.Err(); err != nil {
-		respondDatabaseError(c, err)
-		return
 	}
 	c.JSON(http.StatusOK, stats)
 }
@@ -239,7 +188,7 @@ func (s *RESTServer) getPathHealth(c *gin.Context) {
 	// For each path, get last scan and corruption stats
 	for i := range paths {
 		paths[i].LastScanID, paths[i].LastScanTime = s.loadPathLastScan(c.Request.Context(), int64(paths[i].PathID))
-		paths[i].ActiveCorruptions, paths[i].TotalCorruptions, paths[i].ResolvedCount = s.loadPathCorruptionStats(paths[i].PathID)
+		paths[i].ActiveCorruptions, paths[i].TotalCorruptions, paths[i].ResolvedCount = s.loadPathCorruptionStats(c.Request.Context(), int64(paths[i].PathID))
 		paths[i].Status = determinePathHealthStatus(paths[i])
 	}
 
@@ -266,15 +215,8 @@ func (s *RESTServer) loadPathLastScan(ctx context.Context, pathID int64) (*int, 
 }
 
 // loadPathCorruptionStats queries active, total, and resolved corruption counts for a given path.
-func (s *RESTServer) loadPathCorruptionStats(pathID int) (active, total, resolved int) {
-	err := s.db.QueryRow(`
-		SELECT
-			COUNT(DISTINCT CASE WHEN current_state NOT IN ('VerificationSuccess', 'MaxRetriesReached', 'CorruptionIgnored') THEN corruption_id END),
-			COUNT(DISTINCT corruption_id),
-			COUNT(DISTINCT CASE WHEN current_state = 'VerificationSuccess' THEN corruption_id END)
-		FROM corruption_status
-		WHERE path_id = ?
-	`, pathID).Scan(&active, &total, &resolved)
+func (s *RESTServer) loadPathCorruptionStats(ctx context.Context, pathID int64) (active, total, resolved int) {
+	active, total, resolved, err := s.corruptions.PathCorruptionStats(ctx, pathID)
 	if err != nil {
 		return 0, 0, 0
 	}

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -234,3 +234,215 @@ func (r *CorruptionRepository) DeleteEvents(ctx context.Context, aggregateID str
 	}
 	return n, nil
 }
+
+// =============================================================================
+// Dashboard / stats read-model aggregates
+// =============================================================================
+
+// CorruptionStateCounts is the dashboard breakdown of corruptions by lifecycle
+// bucket, derived from the corruption_status view's current_state.
+type CorruptionStateCounts struct {
+	Resolved           int
+	Orphaned           int
+	InProgress         int
+	ManualIntervention int
+	Pending            int
+	Failed             int
+	Ignored            int
+}
+
+// DayCount is a (date, count) pair for time-series stats.
+type DayCount struct {
+	Date  string
+	Count int
+}
+
+// TypeCount is a (corruption_type, count) pair.
+type TypeCount struct {
+	Type  string
+	Count int
+}
+
+// StateCounts returns the dashboard breakdown of corruptions by lifecycle
+// bucket in a single pass over corruption_status.
+func (r *CorruptionRepository) StateCounts(ctx context.Context) (CorruptionStateCounts, error) {
+	var c CorruptionStateCounts
+	err := r.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(DISTINCT CASE WHEN current_state = 'VerificationSuccess' THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state = 'MaxRetriesReached' THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ('SearchStarted', 'SearchQueued', 'RemediationQueued',
+				'DownloadStarted', 'DownloadProgress', 'SearchCompleted', 'DeletionCompleted', 'FileDetected')
+				THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ('ImportBlocked', 'ManuallyRemoved') THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionDetected' THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state LIKE '%Failed' AND current_state != 'MaxRetriesReached' THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionIgnored' THEN corruption_id END)
+		FROM corruption_status
+	`).Scan(&c.Resolved, &c.Orphaned, &c.InProgress, &c.ManualIntervention, &c.Pending, &c.Failed, &c.Ignored)
+	if err != nil {
+		return CorruptionStateCounts{}, fmt.Errorf("query corruption state counts: %w", err)
+	}
+	return c, nil
+}
+
+// CountDetectedToday returns the number of CorruptionDetected events created
+// today, excluding aggregates the user has ignored.
+func (r *CorruptionRepository) CountDetectedToday(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events e
+		WHERE e.event_type = 'CorruptionDetected'
+		AND substr(e.created_at, 1, 10) = date('now')
+		AND NOT EXISTS (
+			SELECT 1 FROM corruption_status cs
+			WHERE cs.corruption_id = e.aggregate_id
+			AND cs.current_state = 'CorruptionIgnored'
+		)
+	`).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count corruptions today: %w", err)
+	}
+	return n, nil
+}
+
+// CountDetectedByDay returns daily CorruptionDetected counts over the last
+// `days` days, oldest day first.
+func (r *CorruptionRepository) CountDetectedByDay(ctx context.Context, days int) ([]DayCount, error) {
+	// The cutoff is a literal like '-30 days' that SQLite's date() understands.
+	cutoff := fmt.Sprintf("-%d days", days)
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT substr(created_at, 1, 10) as date, COUNT(*) as count
+		FROM events
+		WHERE event_type = 'CorruptionDetected'
+		AND substr(created_at, 1, 10) >= date('now', ?)
+		GROUP BY substr(created_at, 1, 10)
+		ORDER BY date ASC
+	`, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("query corruptions by day: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]DayCount, 0)
+	for rows.Next() {
+		var d DayCount
+		if err := rows.Scan(&d.Date, &d.Count); err != nil {
+			return nil, fmt.Errorf("scan day-count row: %w", err)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate day counts: %w", err)
+	}
+	return out, nil
+}
+
+// CountByCorruptionType returns CorruptionDetected counts grouped by the
+// corruption_type field of the event data. A NULL type is reported as "".
+func (r *CorruptionRepository) CountByCorruptionType(ctx context.Context) ([]TypeCount, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT json_extract(event_data, '$.corruption_type') as type, COUNT(*) as count
+		FROM events
+		WHERE event_type = 'CorruptionDetected'
+		GROUP BY type
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query corruptions by type: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]TypeCount, 0)
+	for rows.Next() {
+		var typeName sql.NullString
+		var count int
+		if err := rows.Scan(&typeName, &count); err != nil {
+			return nil, fmt.Errorf("scan type-count row: %w", err)
+		}
+		out = append(out, TypeCount{Type: typeName.String, Count: count})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate type counts: %w", err)
+	}
+	return out, nil
+}
+
+// PathCorruptionStats returns active, total, and resolved corruption counts
+// for a single scan path.
+func (r *CorruptionRepository) PathCorruptionStats(ctx context.Context, pathID int64) (active, total, resolved int, err error) {
+	err = r.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(DISTINCT CASE WHEN current_state NOT IN ('VerificationSuccess', 'MaxRetriesReached', 'CorruptionIgnored') THEN corruption_id END),
+			COUNT(DISTINCT corruption_id),
+			COUNT(DISTINCT CASE WHEN current_state = 'VerificationSuccess' THEN corruption_id END)
+		FROM corruption_status
+		WHERE path_id = ?
+	`, pathID).Scan(&active, &total, &resolved)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("query path corruption stats: %w", err)
+	}
+	return active, total, resolved, nil
+}
+
+// =============================================================================
+// Active-corruption lookups (scanner dedup)
+// =============================================================================
+
+// HasActive reports whether the given file has an unresolved CorruptionDetected
+// event within the last 7 days — used by the scanner to skip files already
+// being remediated. "Active" means a CorruptionDetected with no subsequent
+// VerificationSuccess or MaxRetriesReached for the same aggregate.
+func (r *CorruptionRepository) HasActive(ctx context.Context, filePath string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events e1
+		WHERE e1.event_type = 'CorruptionDetected'
+		AND json_extract(e1.event_data, '$.file_path') = ?
+		AND e1.created_at > datetime('now', '-7 days')
+		AND NOT EXISTS (
+			SELECT 1 FROM events e2
+			WHERE e2.aggregate_id = e1.aggregate_id
+			AND e2.event_type IN ('VerificationSuccess', 'MaxRetriesReached')
+		)
+	`, filePath).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check active corruption: %w", err)
+	}
+	return count > 0, nil
+}
+
+// ListActiveFilePathsUnderRoot returns the set of file paths under rootPath
+// that have an active corruption (same definition as HasActive). Returned as
+// a set so the scanner can do O(1) lookups while walking a path — avoids the
+// N+1 HasActive query per file.
+func (r *CorruptionRepository) ListActiveFilePathsUnderRoot(ctx context.Context, rootPath string) (map[string]bool, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT DISTINCT json_extract(e1.event_data, '$.file_path') as file_path
+		FROM events e1
+		WHERE e1.event_type = 'CorruptionDetected'
+		AND json_extract(e1.event_data, '$.file_path') LIKE ? || '%'
+		AND e1.created_at > datetime('now', '-7 days')
+		AND NOT EXISTS (
+			SELECT 1 FROM events e2
+			WHERE e2.aggregate_id = e1.aggregate_id
+			AND e2.event_type IN ('VerificationSuccess', 'MaxRetriesReached')
+		)
+	`, rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("query active corruptions under root: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]bool)
+	for rows.Next() {
+		var filePath string
+		if err := rows.Scan(&filePath); err != nil {
+			return nil, fmt.Errorf("scan active-corruption file_path: %w", err)
+		}
+		result[filePath] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate active corruptions under root: %w", err)
+	}
+	return result, nil
+}

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -214,3 +214,158 @@ func TestCorruptionRepository_DeleteEvents(t *testing.T) {
 		t.Errorf("after delete, ListEvents returned %d rows", len(events))
 	}
 }
+
+func TestCorruptionRepository_StateCounts(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedCorruption(t, db, "resolved1", "/a", "VerificationSuccess", base)
+	seedCorruption(t, db, "orphan1", "/b", "MaxRetriesReached", base)
+	seedCorruption(t, db, "pending1", "/c", "CorruptionDetected", base)
+	seedCorruption(t, db, "pending2", "/d", "CorruptionDetected", base)
+	seedCorruption(t, db, "ignored1", "/e", "CorruptionIgnored", base)
+	seedCorruption(t, db, "failed1", "/f", "DeletionFailed", base)
+
+	c, err := repo.StateCounts(context.Background())
+	if err != nil {
+		t.Fatalf("StateCounts: %v", err)
+	}
+	if c.Resolved != 1 || c.Orphaned != 1 || c.Pending != 2 || c.Ignored != 1 || c.Failed != 1 {
+		t.Errorf("unexpected counts: %+v", c)
+	}
+}
+
+func TestCorruptionRepository_CountDetectedToday(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+
+	// Today, not ignored → counts.
+	seedCorruption(t, db, "today1", "/a", "CorruptionDetected", now)
+	// Today but ignored → excluded.
+	seedCorruption(t, db, "today2", "/b", "CorruptionIgnored", now)
+	// Old → excluded.
+	seedCorruption(t, db, "old1", "/c", "CorruptionDetected", now.Add(-72*time.Hour))
+
+	n, err := repo.CountDetectedToday(context.Background())
+	if err != nil {
+		t.Fatalf("CountDetectedToday: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("CountDetectedToday = %d, want 1", n)
+	}
+}
+
+func TestCorruptionRepository_CountByCorruptionType(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	appendEvent(t, db, "c1", "CorruptionDetected", `{"file_path":"/a","corruption_type":"CorruptHeader"}`, base)
+	appendEvent(t, db, "c2", "CorruptionDetected", `{"file_path":"/b","corruption_type":"CorruptHeader"}`, base)
+	appendEvent(t, db, "c3", "CorruptionDetected", `{"file_path":"/c","corruption_type":"TruncatedFile"}`, base)
+
+	types, err := repo.CountByCorruptionType(context.Background())
+	if err != nil {
+		t.Fatalf("CountByCorruptionType: %v", err)
+	}
+	got := map[string]int{}
+	for _, tc := range types {
+		got[tc.Type] = tc.Count
+	}
+	if got["CorruptHeader"] != 2 || got["TruncatedFile"] != 1 {
+		t.Errorf("type counts = %v, want CorruptHeader=2 TruncatedFile=1", got)
+	}
+}
+
+func TestCorruptionRepository_PathCorruptionStats(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// path_id 1: one active (detected), one resolved.
+	appendEvent(t, db, "p1a", "CorruptionDetected", `{"file_path":"/m/a","path_id":1}`, base)
+	appendEvent(t, db, "p1b", "CorruptionDetected", `{"file_path":"/m/b","path_id":1}`, base)
+	appendEvent(t, db, "p1b", "VerificationSuccess", `{}`, base.Add(time.Minute))
+	// path_id 2: one active — must not bleed into path 1's stats.
+	appendEvent(t, db, "p2a", "CorruptionDetected", `{"file_path":"/t/a","path_id":2}`, base)
+
+	active, total, resolved, err := repo.PathCorruptionStats(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PathCorruptionStats: %v", err)
+	}
+	if active != 1 || total != 2 || resolved != 1 {
+		t.Errorf("path 1 stats = active=%d total=%d resolved=%d, want 1/2/1", active, total, resolved)
+	}
+}
+
+func TestCorruptionRepository_HasActive(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+
+	// Active corruption (detected, unresolved, recent).
+	appendEvent(t, db, "act", "CorruptionDetected", `{"file_path":"/active.mkv"}`, now)
+	// Resolved → not active.
+	appendEvent(t, db, "res", "CorruptionDetected", `{"file_path":"/resolved.mkv"}`, now)
+	appendEvent(t, db, "res", "VerificationSuccess", `{}`, now.Add(time.Minute))
+
+	if ok, err := repo.HasActive(context.Background(), "/active.mkv"); err != nil || !ok {
+		t.Errorf("HasActive(/active.mkv) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if ok, err := repo.HasActive(context.Background(), "/resolved.mkv"); err != nil || ok {
+		t.Errorf("HasActive(/resolved.mkv) = (%v, %v), want (false, nil)", ok, err)
+	}
+	if ok, err := repo.HasActive(context.Background(), "/unknown.mkv"); err != nil || ok {
+		t.Errorf("HasActive(/unknown.mkv) = (%v, %v), want (false, nil)", ok, err)
+	}
+}
+
+func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+
+	appendEvent(t, db, "a", "CorruptionDetected", `{"file_path":"/movies/a.mkv"}`, now)
+	appendEvent(t, db, "b", "CorruptionDetected", `{"file_path":"/movies/sub/b.mkv"}`, now)
+	// Under a different root → excluded.
+	appendEvent(t, db, "c", "CorruptionDetected", `{"file_path":"/tv/c.mkv"}`, now)
+	// Resolved → excluded.
+	appendEvent(t, db, "d", "CorruptionDetected", `{"file_path":"/movies/d.mkv"}`, now)
+	appendEvent(t, db, "d", "VerificationSuccess", `{}`, now.Add(time.Minute))
+
+	set, err := repo.ListActiveFilePathsUnderRoot(context.Background(), "/movies")
+	if err != nil {
+		t.Fatalf("ListActiveFilePathsUnderRoot: %v", err)
+	}
+	if len(set) != 2 || !set["/movies/a.mkv"] || !set["/movies/sub/b.mkv"] {
+		t.Errorf("active set = %v, want /movies/a.mkv and /movies/sub/b.mkv", set)
+	}
+}
+
+func TestCorruptionRepository_CountDetectedByDay(t *testing.T) {
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+
+	// Two on the same recent day, one older-but-within-window.
+	appendEvent(t, db, "d1", "CorruptionDetected", `{"file_path":"/a"}`, now)
+	appendEvent(t, db, "d2", "CorruptionDetected", `{"file_path":"/b"}`, now)
+	appendEvent(t, db, "d3", "CorruptionDetected", `{"file_path":"/c"}`, now.Add(-48*time.Hour))
+	// Outside the 30-day window → excluded.
+	appendEvent(t, db, "d4", "CorruptionDetected", `{"file_path":"/d"}`, now.Add(-60*24*time.Hour))
+
+	days, err := repo.CountDetectedByDay(context.Background(), 30)
+	if err != nil {
+		t.Fatalf("CountDetectedByDay: %v", err)
+	}
+	total := 0
+	for _, d := range days {
+		total += d.Count
+	}
+	if total != 3 {
+		t.Errorf("total within 30d = %d, want 3", total)
+	}
+	// Days are ordered ascending; the most recent day has 2.
+	if len(days) == 0 || days[len(days)-1].Count != 2 {
+		t.Errorf("most recent day count = %+v, want 2", days)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -310,6 +310,7 @@ type ScannerService struct {
 	rescans       *repository.RescanRepository
 	scanFilesRepo *repository.ScanFileRepository
 	scans         *repository.ScanRepository
+	corruptions   *repository.CorruptionRepository
 	eventBus      *eventbus.EventBus
 	detector      integration.HealthChecker
 	pathMapper    integration.PathMapper
@@ -364,6 +365,15 @@ func (s *ScannerService) initRepositories() {
 	if s.scans == nil {
 		s.scans = repository.NewScanRepository(s.db)
 	}
+	if s.corruptions == nil {
+		s.corruptions = repository.NewCorruptionRepository(s.db)
+	}
+}
+
+// corruptionRepo returns the lazy-initialized CorruptionRepository.
+func (s *ScannerService) corruptionRepo() *repository.CorruptionRepository {
+	s.initRepositories()
+	return s.corruptions
 }
 
 // scanPathRepo returns the lazy-initialized ScanPathRepository.
@@ -1788,65 +1798,26 @@ func (s *ScannerService) hasActiveCorruption(filePath string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
-	var count int
-	err := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM events e1
-		WHERE e1.event_type = 'CorruptionDetected'
-		AND json_extract(e1.event_data, '$.file_path') = ?
-		AND e1.created_at > datetime('now', '-7 days')
-		AND NOT EXISTS (
-			SELECT 1 FROM events e2
-			WHERE e2.aggregate_id = e1.aggregate_id
-			AND e2.event_type IN ('VerificationSuccess', 'MaxRetriesReached')
-		)
-	`, filePath).Scan(&count)
-
+	active, err := s.corruptionRepo().HasActive(ctx, filePath)
 	if err != nil {
 		logger.Debugf("Error checking for active corruption: %v", err)
 		return false // Err on the side of processing
 	}
-
-	return count > 0
+	return active
 }
 
 // LoadActiveCorruptionsForPath preloads all active corruptions for a given root path.
 // This fixes the N+1 query problem during path scans by doing a single query upfront.
 // Returns a map of file_path -> true for files with active corruptions.
 func (s *ScannerService) LoadActiveCorruptionsForPath(rootPath string) map[string]bool {
-	result := make(map[string]bool)
-
 	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 	defer cancel()
 
 	// Get all active corruptions for files under this path in a single query
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT DISTINCT json_extract(e1.event_data, '$.file_path') as file_path
-		FROM events e1
-		WHERE e1.event_type = 'CorruptionDetected'
-		AND json_extract(e1.event_data, '$.file_path') LIKE ? || '%'
-		AND e1.created_at > datetime('now', '-7 days')
-		AND NOT EXISTS (
-			SELECT 1 FROM events e2
-			WHERE e2.aggregate_id = e1.aggregate_id
-			AND e2.event_type IN ('VerificationSuccess', 'MaxRetriesReached')
-		)
-	`, rootPath)
+	result, err := s.corruptionRepo().ListActiveFilePathsUnderRoot(ctx, rootPath)
 	if err != nil {
 		logger.Debugf("Error loading active corruptions for path %s: %v", rootPath, err)
-		return result
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var filePath string
-		if rows.Scan(&filePath) != nil {
-			continue
-		}
-		result[filePath] = true
-	}
-
-	if err := rows.Err(); err != nil {
-		logger.Errorf("Error iterating active corruptions for path %s: %v", rootPath, err)
+		return make(map[string]bool)
 	}
 
 	logger.Debugf("Preloaded %d active corruptions for path %s", len(result), rootPath)


### PR DESCRIPTION
## Summary

Extends \`CorruptionRepository\` with the dashboard/stats aggregates and the scanner's active-corruption dedup lookups — the analytical event-store reads layered on the #211 EventStore foundation. **After this PR, scanner.go holds zero raw SQL.**

| Method | Consumer |
|---|---|
| StateCounts | getDashboardStats (lifecycle breakdown) |
| CountDetectedToday | getDashboardStats |
| CountDetectedByDay(30) | getStatsHistory |
| CountByCorruptionType | getStatsTypes |
| PathCorruptionStats | getPathHealth (loadPathCorruptionStats) |
| CountByState (existing) | handlers_health pending count |
| HasActive | scanner.hasActiveCorruption |
| ListActiveFilePathsUnderRoot | scanner.LoadActiveCorruptionsForPath |

## Design notes

- \`ListActiveFilePathsUnderRoot\` returns a `map[string]bool` set so the scanner does O(1) lookups while walking a path — that's the existing N+1-avoidance optimization, now behind the repo.
- \`HasActive\` / \`ListActiveFilePathsUnderRoot\` share the "active = CorruptionDetected in last 7d with no terminal (VerificationSuccess/MaxRetriesReached) event" definition — encoded once in the repo instead of duplicated across two scanner methods.
- \`PathCorruptionStats\` returns `(active, total, resolved, err)` matching the handler's existing shape.
- \`database/sql\` drops out of handlers_stats.go; scanner.go's last two `s.db` reads are gone.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New corruption_test.go cases: StateCounts, CountDetectedToday (excludes ignored + old), CountDetectedByDay (30d window + ordering), CountByCorruptionType, PathCorruptionStats (per-path isolation), HasActive (active/resolved/unknown), ListActiveFilePathsUnderRoot (root-prefix + resolved exclusion)