### PR TITLE
feat(repository): migrate verifier + remediator event reads (Phase 3.16)

### DIFF
--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/mescon/Healarr/internal/db"
 	"github.com/mescon/Healarr/internal/domain"
@@ -119,4 +121,24 @@ func scanEventRow(scanner interface {
 		}
 	}
 	return event, nil
+}
+
+// FirstEventTime returns the created_at of the earliest event of the given
+// type for an aggregate. Returns ErrNotFound when the aggregate has no such
+// event. Used to measure elapsed time since a lifecycle milestone (e.g.
+// "how long since CorruptionDetected").
+func (r *EventRepository) FirstEventTime(ctx context.Context, aggregateID string, eventType domain.EventType) (time.Time, error) {
+	var t time.Time
+	err := r.db.QueryRowContext(ctx, `
+		SELECT created_at FROM events
+		WHERE aggregate_id = ? AND event_type = ?
+		ORDER BY created_at ASC LIMIT 1
+	`, aggregateID, eventType).Scan(&t)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, ErrNotFound
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("query first event time: %w", err)
+	}
+	return t, nil
 }

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -130,5 +131,35 @@ func TestEventRepository_ListUnprocessed_skipsCorruptData(t *testing.T) {
 	}
 	if len(events) != 1 || events[0].AggregateID != "good" {
 		t.Errorf("got %+v, want only the good row", events)
+	}
+}
+
+func TestEventRepository_FirstEventTime(t *testing.T) {
+	db := newEventTestDB(t)
+	repo := NewEventRepository(db)
+
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// Two CorruptionDetected events for the same aggregate; FirstEventTime
+	// must return the earliest.
+	for _, at := range []time.Time{base.Add(time.Hour), base} {
+		if _, err := db.Exec(
+			`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at) VALUES ('corruption', 'c1', ?, '{}', ?)`,
+			domain.CorruptionDetected, at.Format("2006-01-02 15:04:05"),
+		); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	got, err := repo.FirstEventTime(context.Background(), "c1", domain.CorruptionDetected)
+	if err != nil {
+		t.Fatalf("FirstEventTime: %v", err)
+	}
+	if !got.Equal(base) {
+		t.Errorf("FirstEventTime = %v, want earliest %v", got, base)
+	}
+
+	// Aggregate with no event of that type → ErrNotFound.
+	if _, err := repo.FirstEventTime(context.Background(), "c1", domain.DownloadProgress); !errors.Is(err, ErrNotFound) {
+		t.Errorf("FirstEventTime missing type = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
@@ -24,11 +27,12 @@ const semaphoreAcquireTimeout = 2 * time.Minute
 
 // RemediatorService handles corruption events by deleting files and triggering searches.
 type RemediatorService struct {
-	eventBus   eventbus.Publisher
-	arrClient  integration.ArrClient
-	pathMapper integration.PathMapper
-	db         *sql.DB
-	semaphore  chan struct{} // limits concurrent remediations
+	eventBus    eventbus.Publisher
+	arrClient   integration.ArrClient
+	pathMapper  integration.PathMapper
+	db          *sql.DB
+	corruptions *repository.CorruptionRepository
+	semaphore   chan struct{} // limits concurrent remediations
 	// Lifecycle management
 	wg         sync.WaitGroup
 	shutdownCh chan struct{}
@@ -45,6 +49,9 @@ func NewRemediatorService(eb eventbus.Publisher, arr integration.ArrClient, pm i
 		db:         db,
 		semaphore:  make(chan struct{}, maxConcurrentRemediations),
 		shutdownCh: make(chan struct{}),
+	}
+	if db != nil {
+		r.corruptions = repository.NewCorruptionRepository(db)
 	}
 	return r
 }
@@ -101,34 +108,26 @@ func (r *RemediatorService) handleRetry(event domain.Event) {
 // checkDeletionCompleted checks if a DeletionCompleted event exists for this corruption
 // and returns the media_id and metadata from that event
 func (r *RemediatorService) checkDeletionCompleted(corruptionID string) (bool, int64, map[string]interface{}) {
-	if r.db == nil {
+	if r.corruptions == nil {
 		return false, 0, nil
 	}
 
-	var mediaIDFloat sql.NullFloat64
-	var metadataJSON sql.NullString
-
-	err := r.db.QueryRow(`
-		SELECT
-			json_extract(event_data, '$.media_id'),
-			json_extract(event_data, '$.metadata')
-		FROM events
-		WHERE aggregate_id = ? AND event_type = 'DeletionCompleted'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`, corruptionID).Scan(&mediaIDFloat, &metadataJSON)
-
+	// Latest DeletionCompleted event for this corruption, if any.
+	raw, err := r.corruptions.LatestEventData(context.Background(), corruptionID, string(domain.DeletionCompleted), "DESC")
 	if err != nil {
-		// No DeletionCompleted event found
+		// No DeletionCompleted event found (ErrNotFound) or query error.
 		return false, 0, nil
 	}
 
-	mediaID := int64(0)
-	if mediaIDFloat.Valid {
-		mediaID = int64(mediaIDFloat.Float64)
+	// Pull media_id from the (decrypted, unmarshaled) event data. JSON numbers
+	// decode to float64; mirror the prior json_extract → int64 conversion.
+	var data struct {
+		MediaID float64 `json:"media_id"`
 	}
-
-	return true, mediaID, nil
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return true, 0, nil
+	}
+	return true, int64(data.MediaID), nil
 }
 
 // retrySearchOnly triggers a new search without attempting deletion

--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -61,6 +61,7 @@ type VerifierService struct {
 	pathMapper integration.PathMapper
 	arrClient  integration.ArrClient
 	db         *sql.DB
+	events     *repository.EventRepository
 	scanPaths  *repository.ScanPathRepository
 	clk        clock.Clock
 
@@ -106,6 +107,7 @@ func NewVerifierService(eb *eventbus.EventBus, detector integration.HealthChecke
 	}
 	if db != nil {
 		v.scanPaths = repository.NewScanPathRepository(db)
+		v.events = repository.NewEventRepository(db)
 	}
 	return v
 }
@@ -450,12 +452,7 @@ func (v *VerifierService) getDurationMetrics(corruptionID string) (int64, int64)
 	defer cancel()
 
 	// Get CorruptionDetected timestamp
-	var corruptionTime time.Time
-	err := v.db.QueryRowContext(ctx, `
-		SELECT created_at FROM events
-		WHERE aggregate_id = ? AND event_type = 'CorruptionDetected'
-		ORDER BY created_at ASC LIMIT 1
-	`, corruptionID).Scan(&corruptionTime)
+	corruptionTime, err := v.events.FirstEventTime(ctx, corruptionID, domain.CorruptionDetected)
 	if err != nil {
 		return 0, 0
 	}
@@ -463,12 +460,7 @@ func (v *VerifierService) getDurationMetrics(corruptionID string) (int64, int64)
 	totalDuration := int64(now.Sub(corruptionTime).Seconds())
 
 	// Get first DownloadProgress timestamp (if any)
-	var downloadStartTime time.Time
-	err = v.db.QueryRowContext(ctx, `
-		SELECT created_at FROM events
-		WHERE aggregate_id = ? AND event_type = 'DownloadProgress'
-		ORDER BY created_at ASC LIMIT 1
-	`, corruptionID).Scan(&downloadStartTime)
+	downloadStartTime, err := v.events.FirstEventTime(ctx, corruptionID, domain.DownloadProgress)
 	if err != nil {
 		// No DownloadProgress event - maybe it completed very quickly
 		return totalDuration, 0


### PR DESCRIPTION
## Summary

Migrates the simple single-table event reads in verifier and remediator onto the repository layer.

| Method | Consumer |
|---|---|
| EventRepository.FirstEventTime (new) | verifier.getDurationMetrics (×2) |
| CorruptionRepository.LatestEventData (existing) | remediator.checkDeletionCompleted |

## Design notes

- **`FirstEventTime`** collapses the verifier's two near-identical `SELECT created_at ... ORDER BY created_at ASC LIMIT 1` lookups (CorruptionDetected timestamp, first DownloadProgress timestamp) into one method. Returns `ErrNotFound` when the aggregate has no such event.
- **remediator** reuses the existing `LatestEventData` and unmarshals `media_id` in Go instead of SQL `json_extract`. Behavior preserved exactly: JSON numbers decode to float64 → int64 (matching the old conversion); `metadata` stays unused (the prior code scanned it into a var but never returned it).
- Both services gain a repo field initialized only when `db != nil` (same guard pattern as the existing `scanPaths` field).

## Remaining after this PR

- Complex health/recovery analytics: `health_monitor` (4), `monitor` (2), `recovery` (2) — each a bespoke single-caller aggregation that merits a deliberate look.
- Genuinely-infra SQL — `PRAGMA integrity_check`, `VACUUM INTO` backup, `sqlite_master`, restart — which is DB administration, not domain data, and arguably should not become a domain repository.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`/usr/bin/golangci-lint run ./...\` — 0 issues
- [x] New \`FirstEventTime\` test: returns earliest of multiple events, ErrNotFound for a missing type