### PR TITLE
perf(test): inject arr-client retry backoff — 156s → 1.6s integration suite (Phase 4.1)

### DIFF
--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -147,7 +147,15 @@ type HTTPArrClient struct {
 	httpClient      *http.Client
 	rateLimiter     *RateLimiter
 	circuitBreakers *CircuitBreakerRegistry
+	// retryBackoff is the base delay between retry attempts; the nth retry
+	// waits (n+1)*retryBackoff. A field (not a const) so tests can set it
+	// near-zero — the retry COUNT behavior is unchanged, only the wall-clock
+	// sleep is removed.
+	retryBackoff time.Duration
 }
+
+// defaultRetryBackoff is the production base delay between *arr request retries.
+const defaultRetryBackoff = 2 * time.Second
 
 // NewArrClient creates an HTTPArrClient with rate limiting and circuit breaker support.
 func NewArrClient(db *sql.DB) *HTTPArrClient {
@@ -160,6 +168,7 @@ func NewArrClient(db *sql.DB) *HTTPArrClient {
 		},
 		rateLimiter:     NewRateLimiter(cfg.ArrRateLimitRPS, cfg.ArrRateLimitBurst),
 		circuitBreakers: NewCircuitBreakerRegistry(DefaultCircuitBreakerConfig()),
+		retryBackoff:    defaultRetryBackoff,
 	}
 }
 
@@ -430,7 +439,7 @@ func (c *HTTPArrClient) buildRequest(instance *ArrInstance, method, endpoint str
 }
 
 // handleServerError handles 5xx responses and determines if we should retry
-func handleServerError(resp *http.Response, cb *CircuitBreaker, instance *ArrInstance, attempt, maxRetries int) (retryAction, error) {
+func (c *HTTPArrClient) handleServerError(resp *http.Response, cb *CircuitBreaker, instance *ArrInstance, attempt, maxRetries int) (retryAction, error) {
 	isLastAttempt := attempt >= maxRetries-1
 
 	if isLastAttempt {
@@ -444,7 +453,7 @@ func handleServerError(resp *http.Response, cb *CircuitBreaker, instance *ArrIns
 
 	if !isLastAttempt {
 		logger.Infof("*arr API returned %d, retrying (%d/%d)...", resp.StatusCode, attempt+1, maxRetries)
-		time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+		time.Sleep(time.Duration(attempt+1) * c.retryBackoff)
 		return retryActionContinue, nil
 	}
 
@@ -510,7 +519,7 @@ func (c *HTTPArrClient) handleRequestError(err error, cb *CircuitBreaker, attemp
 
 	if attempt < maxRetries-1 {
 		logger.Infof("*arr API request failed (attempt %d/%d): %v, retrying...", attempt+1, maxRetries, err)
-		time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+		time.Sleep(time.Duration(attempt+1) * c.retryBackoff)
 	}
 	return nil, err, false // Continue retrying
 }
@@ -519,7 +528,7 @@ func (c *HTTPArrClient) handleRequestError(err error, cb *CircuitBreaker, attemp
 func (c *HTTPArrClient) handleRequestSuccess(resp *http.Response, cb *CircuitBreaker, instance *ArrInstance, attempt, maxRetries int) (*http.Response, error, bool) {
 	// Handle 5xx server errors
 	if resp.StatusCode >= 500 && resp.StatusCode < 600 {
-		action, retryErr := handleServerError(resp, cb, instance, attempt, maxRetries)
+		action, retryErr := c.handleServerError(resp, cb, instance, attempt, maxRetries)
 		if action == retryActionContinue {
 			return nil, nil, false // Continue retrying
 		}

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -173,6 +173,11 @@ func setupTestClient(t *testing.T) (*HTTPArrClient, *testDB) {
 
 	db := newTestDB(t)
 	client := NewArrClient(db.DB)
+	// Eliminate real retry backoff sleeps in tests: retry COUNT behavior is
+	// unchanged, only the (attempt+1)*2s wall-clock waits are removed. This
+	// is the single biggest test-suite speedup (the 5xx/network-retry tests
+	// were each paying 2s+4s+... per exhausted retry).
+	client.retryBackoff = 0
 	return client, db
 }
 


### PR DESCRIPTION
## Summary

First Phase 4 (test infrastructure) PR — the "backoff injection for test speedup" item. The integration package took **~156s**; ~99% of that was real wall-clock sleeps in the *arr HTTP retry path.

\`doRequestWithRetry\` sleeps \`(attempt+1)*2s\` between retries on 5xx and network errors. Across 193 tests, the mock-server retry/exhaustion cases each paid 2s+4s+… per exhausted retry.

## Change

Make the base delay an injectable field instead of a hardcoded literal:

- \`HTTPArrClient.retryBackoff time.Duration\`; \`NewArrClient\` sets it to \`defaultRetryBackoff\` (2s) — **production behavior unchanged**.
- \`handleServerError\` becomes a method so it can read \`c.retryBackoff\` (\`handleRequestError\` already was). Both sleeps use \`(attempt+1) * c.retryBackoff\`.
- \`setupTestClient\` (the shared mock-server helper, the package's sole \`NewArrClient\` call site) sets \`client.retryBackoff = 0\`.

**Retry COUNT behavior is unchanged** — tests still exercise every retry/exhaustion path; only the sleeps are removed.

## Result

\`go test ./internal/integration/\`: **156.2s → 1.6s** (~100×), identical coverage. This was the dominant term in the whole suite's wall time.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/integration/\` — passes in 1.6s (was 156s)
- [x] Retry/exhaustion tests (TestHTTPArrClient_ServerError_Retry, Server500_RetryExhausted, doRequestWithRetry 503) still pass
- [x] \`/usr/bin/golangci-lint run ./internal/integration/...\` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal retry handling mechanism with enhanced configurability.

* **Tests**
  * Optimized test execution performance for retry-related scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->