### PR TITLE
perf(test): shrink verifier retry waits under test — services 68s → 27s (Phase 4.2)

### DIFF
--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/mescon/Healarr/internal/clock"
@@ -37,8 +38,15 @@ const verificationSemaphoreTimeout = 5 * time.Minute
 // errMsgShutdownInProgress is the error message used when operations are aborted due to shutdown.
 const errMsgShutdownInProgress = "shutdown in progress"
 
-// historyRetryInterval is the interval between history API retries when waiting for import.
-const historyRetryInterval = 10 * time.Second
+// defaultHistoryRetryInterval is the production interval between history API
+// retries when waiting for import. It's the default for
+// VerifierService.historyRetryInterval (a field so tests can shrink it).
+const defaultHistoryRetryInterval = 10 * time.Second
+
+// defaultRetryBackoffBase is the production base unit for the exponential
+// (1×, 2×, 4×) backoff in the history/file-path retry helpers. Default for
+// VerifierService.retryBackoffBase.
+const defaultRetryBackoffBase = 1 * time.Second
 
 // historyRetryMaxAttempts is the maximum number of history API retries (12 * 10s = 2 min).
 const historyRetryMaxAttempts = 12
@@ -64,6 +72,12 @@ type VerifierService struct {
 	events     *repository.EventRepository
 	scanPaths  *repository.ScanPathRepository
 	clk        clock.Clock
+
+	// Retry timing — fields (not consts) so tests can shrink them to keep the
+	// retry-COUNT behavior while removing real wall-clock waits. Default to
+	// the production values in NewVerifierService.
+	historyRetryInterval time.Duration
+	retryBackoffBase     time.Duration
 
 	// Graceful shutdown support
 	shutdownCh chan struct{}
@@ -104,6 +118,17 @@ func NewVerifierService(eb *eventbus.EventBus, detector integration.HealthChecke
 		lastState:    make(map[string]string),
 		verifyMeta:   make(map[string]*VerificationMeta),
 		activeVerify: make(map[string]context.CancelFunc),
+	}
+	v.historyRetryInterval = defaultHistoryRetryInterval
+	v.retryBackoffBase = defaultRetryBackoffBase
+	if testing.Testing() {
+		// Shrink retry waits to ~0 under test binaries: the retry COUNT logic
+		// is unchanged, but the history/file-path retry helpers no longer pay
+		// real 1s/2s/4s and 10s waits. Same lever as the arr-client retry
+		// backoff (PR #214); matches the existing testing.Testing() idiom in
+		// crypto.go / integration.interfaces.go.
+		v.historyRetryInterval = time.Millisecond
+		v.retryBackoffBase = time.Millisecond
 	}
 	if db != nil {
 		v.scanPaths = repository.NewScanPathRepository(db)
@@ -704,7 +729,7 @@ func (v *VerifierService) handleDisappearedQueueItem(ctx context.Context, state 
 		// Retry history check multiple times with delay (BUG-1 fix)
 		for i := 0; i < historyRetryMaxAttempts; i++ {
 			// Check for shutdown/cancellation between retries
-			if v.waitWithContext(ctx, historyRetryInterval) {
+			if v.waitWithContext(ctx, v.historyRetryInterval) {
 				return monitorStop
 			}
 
@@ -1001,7 +1026,7 @@ func (v *VerifierService) getFilePathsWithRetry(mediaID int64, metadata map[stri
 
 		lastErr = err
 		if attempt < maxRetries-1 {
-			backoff := time.Duration(1<<uint(attempt)) * time.Second
+			backoff := time.Duration(1<<uint(attempt)) * v.retryBackoffBase
 			logger.Debugf("GetAllFilePaths failed (attempt %d/%d), retrying in %v: %v", attempt+1, maxRetries, backoff, err)
 			if v.waitWithShutdown(backoff) {
 				return nil, errors.New(errMsgShutdownInProgress)
@@ -1044,8 +1069,8 @@ func (v *VerifierService) getHistoryWithRetry(arrPath string, mediaID int64, lim
 
 		lastErr = err
 		if attempt < maxRetries-1 {
-			// Exponential backoff: 1s, 2s, 4s - interruptible for graceful shutdown
-			backoff := time.Duration(1<<uint(attempt)) * time.Second
+			// Exponential backoff: 1×, 2×, 4× retryBackoffBase - interruptible for graceful shutdown
+			backoff := time.Duration(1<<uint(attempt)) * v.retryBackoffBase
 			logger.Debugf("History API failed (attempt %d/%d), retrying in %v: %v", attempt+1, maxRetries, backoff, err)
 			select {
 			case <-v.shutdownCh:


### PR DESCRIPTION
## Summary

Second Phase 4 speedup. The verifier test group took **43.5s**, nearly all real wall-clock waits in the history/file-path retry helpers:
- \`getHistoryWithRetry\` / \`getFilePathsWithRetry\` — 1s/2s/4s exponential backoff per retry (hardcoded \`* time.Second\`)
- the download-monitor history re-check loop — \`historyRetryInterval = 10s\` const

The verifier tests use the default RealClock (no clock injected), so every \`v.clk.After(d)\` / \`waitWithShutdown(d)\` waited for real.

## Change

Make the two backoffs **fields** (\`historyRetryInterval\`, \`retryBackoffBase\`) defaulted to the production 10s/1s in \`NewVerifierService\`, and shrink them to 1ms when \`testing.Testing()\` — the same prod-vs-test idiom already used in \`crypto.go\` and \`integration/interfaces.go\`. Retry COUNT behavior is unchanged.

One constructor change covers all ~39 inline \`NewVerifierService\` call sites (no shared test helper exists to hook, unlike the arr-client's \`setupTestClient\` in #214).

## Result

- Verifier test group: **43.5s → 1.5s**
- Whole `services` package: **68.6s → 26.6s**

(Remaining services time is in scanner + recovery, which have their own real waits — separate follow-ups.)

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/services/\` — passes, 26.6s (was 68.6s)
- [x] All Verifier retry tests (GetHistoryWithRetry, GetFilePathsWithRetry, HandleDisappearedQueueItem, CheckHistoryForImport, HasImportEventInHistory) still pass
- [x] \`/usr/bin/golangci-lint run ./internal/services/...\` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal retry timing configuration for better testability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->