### PR TITLE
perf(test): injectable scanner size-stability delay — scanner tests 11.6s → 2.3s (Phase 4.3)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -327,18 +327,29 @@ type ScannerService struct {
 	scanPathCache     []scanPathConfig
 	scanPathCacheMu   sync.RWMutex
 	scanPathCacheTime time.Time
+
+	// sizeStabilityDelay is how long shouldSkipChangingSize waits before
+	// re-stat'ing a file to detect an in-progress download. A field (default
+	// set by NewScannerService) so tests — which construct &ScannerService{}
+	// directly and leave it at the 0 zero-value — don't pay 500ms per file.
+	sizeStabilityDelay time.Duration
 }
+
+// defaultSizeStabilityDelay is the production re-stat interval for
+// detecting files whose size is still changing (active download/copy).
+const defaultSizeStabilityDelay = 500 * time.Millisecond
 
 // NewScannerService creates a new ScannerService with the given dependencies.
 func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.HealthChecker, pm integration.PathMapper) *ScannerService {
 	s := &ScannerService{
-		db:              db,
-		eventBus:        eb,
-		detector:        detector,
-		pathMapper:      pm,
-		activeScans:     make(map[string]*ScanProgress),
-		filesInProgress: make(map[string]bool),
-		shutdownCh:      make(chan struct{}),
+		db:                 db,
+		eventBus:           eb,
+		detector:           detector,
+		pathMapper:         pm,
+		activeScans:        make(map[string]*ScanProgress),
+		filesInProgress:    make(map[string]bool),
+		shutdownCh:         make(chan struct{}),
+		sizeStabilityDelay: defaultSizeStabilityDelay,
 	}
 	s.initRepositories()
 	return s
@@ -1125,7 +1136,7 @@ func (s *ScannerService) shouldSkipRecentlyModified(sfc *scanFileContext) bool {
 // shouldSkipChangingSize checks if file size is actively changing (download in progress).
 // Returns true if file should be skipped.
 func (s *ScannerService) shouldSkipChangingSize(sfc *scanFileContext) bool {
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(s.sizeStabilityDelay)
 	if info2, err := os.Stat(sfc.filePath); err == nil {
 		if info2.Size() != sfc.fileSize {
 			logger.Infof("Skipping file with changing size (download in progress?): %s", sfc.filePath)


### PR DESCRIPTION
## Summary

Third Phase 4 speedup. \`shouldSkipChangingSize\` sleeps **500ms** then re-stats a file to detect an in-progress download (size still changing). Tests scanning many files paid 500ms each — \`TestScannerService_ScanFiles/updates_progress_periodically\` alone was 7.5s.

## Change

Make the delay a field (\`sizeStabilityDelay\`), set to the production 500ms by \`NewScannerService\`. Test fixtures construct \`&ScannerService{}\` directly and leave it at the **0 zero-value**, so the re-stat happens immediately — no per-test edits, no production behavior change.

The size-change-detection tests still pass: they establish the size delta *before* calling \`shouldSkipChangingSize\`, not during the (now-zero) wait.

## Result

- Scanner test group: **11.6s → 2.3s**
- `services` package: **26.6s → 17.3s**

Cumulative Phase 4 suite speedup: integration 156s → 1.6s (#214), services 68s → 17s (#215 + this).

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/services/\` — passes, 17.3s
- [x] ShouldSkipChangingSize tests (incl. _WithDBRecording) still pass — size-change detection unaffected
- [x] \`/usr/bin/golangci-lint run ./internal/services/...\` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the file scanner's handling of actively changing files (such as downloads or copy operations) through enhanced configuration of file stability checks, ensuring more reliable detection of when files have completed their transfer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->