### PR TITLE
perf(test): shrink remediator semaphore-wait test sleep 5s → 500ms (Phase 4.4)

### DIFF
--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -1651,8 +1651,10 @@ func TestRemediatorService_ExecuteRemediation_ShutdownWhileWaitingForSemaphore(t
 	mockEventBus := testutil.NewMockEventBus()
 	mockClient := &testutil.MockArrClient{
 		FindMediaByPathFunc: func(path string) (int64, error) {
-			// Slow response to keep semaphore busy
-			time.Sleep(5 * time.Second)
+			// Hold the semaphore slot long enough that the waiting goroutine
+			// is still blocked when Stop() fires (~150ms into the test). 500ms
+			// is ample margin without making wg.Wait() pay a full 5s.
+			time.Sleep(500 * time.Millisecond)
 			return 123, nil
 		},
 	}


### PR DESCRIPTION
## Summary

\`TestRemediatorService_ExecuteRemediation_ShutdownWhileWaitingForSemaphore\` fills the (size-5) semaphore with 5 goroutines whose mock \`FindMediaByPathFunc\` slept **5s** each to "keep the semaphore busy", then verifies a 6th goroutine waiting on the semaphore aborts when \`Stop()\` fires. \`wg.Wait()\` on the 5 blockers made the test ~5s.

The blockers only need to still hold their slots when \`Stop()\` is called — ~150ms into the test (100ms + 50ms setup waits). 500ms is 3× that margin while cutting \`wg.Wait()\` from 5s to ~0.5s.

## Result

- `services` package: **17.3s → 12.8s**
- This was the last multi-second test-side sleep in the repo.

## Test plan

- [x] \`go test -run ...ShutdownWhileWaitingForSemaphore -count=3\` — stable, ~0.6s each (was ~5s)
- [x] \`go test ./internal/services/\` — passes, 12.8s