### PR TITLE
test(repository): mark repository tests t.Parallel() (Phase 4.6)

### DIFF
--- a/internal/repository/arr_instance_test.go
+++ b/internal/repository/arr_instance_test.go
@@ -42,6 +42,7 @@ func newArrInstanceTestDB(t *testing.T) *sql.DB {
 }
 
 func TestArrInstanceRepository_Count_empty(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	n, err := repo.Count(context.Background())
 	if err != nil {
@@ -53,6 +54,7 @@ func TestArrInstanceRepository_Count_empty(t *testing.T) {
 }
 
 func TestArrInstanceRepository_Create_andGetByID(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 
 	id, err := repo.Create(context.Background(), CreateArrInstanceParams{
@@ -83,6 +85,7 @@ func TestArrInstanceRepository_Create_andGetByID(t *testing.T) {
 }
 
 func TestArrInstanceRepository_Create_nullWebhookSecret(t *testing.T) {
+	t.Parallel()
 	// Empty EncryptedWebhookSecret should land as SQL NULL, matching the
 	// legacy instance shape that pre-dates per-instance webhook secrets.
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
@@ -105,6 +108,7 @@ func TestArrInstanceRepository_Create_nullWebhookSecret(t *testing.T) {
 }
 
 func TestArrInstanceRepository_GetByID_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	_, err := repo.GetByID(context.Background(), 999)
 	if !errors.Is(err, ErrNotFound) {
@@ -113,6 +117,7 @@ func TestArrInstanceRepository_GetByID_notFound(t *testing.T) {
 }
 
 func TestArrInstanceRepository_FindIDByURL(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	id, _ := repo.Create(context.Background(), CreateArrInstanceParams{
 		Name: "S", Type: "sonarr", URL: "http://a", EncryptedAPIKey: "k", Enabled: true,
@@ -130,6 +135,7 @@ func TestArrInstanceRepository_FindIDByURL(t *testing.T) {
 }
 
 func TestArrInstanceRepository_ListAll_andListEnabled(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	ctx := context.Background()
 	mustCreate := func(p CreateArrInstanceParams) int64 {
@@ -160,6 +166,7 @@ func TestArrInstanceRepository_ListAll_andListEnabled(t *testing.T) {
 }
 
 func TestArrInstanceRepository_ListEnabledWithScanPaths(t *testing.T) {
+	t.Parallel()
 	db := newArrInstanceTestDB(t)
 	repo := NewArrInstanceRepository(db)
 	ctx := context.Background()
@@ -216,6 +223,7 @@ func mustExecArr(t *testing.T, db *sql.DB, query string, args ...interface{}) {
 }
 
 func TestArrInstanceRepository_CountByType_andPrefix(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	ctx := context.Background()
 	for _, p := range []CreateArrInstanceParams{
@@ -239,6 +247,7 @@ func TestArrInstanceRepository_CountByType_andPrefix(t *testing.T) {
 }
 
 func TestArrInstanceRepository_Update(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, CreateArrInstanceParams{
@@ -264,6 +273,7 @@ func TestArrInstanceRepository_Update(t *testing.T) {
 }
 
 func TestArrInstanceRepository_UpdateWebhookSecret(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, CreateArrInstanceParams{
@@ -284,6 +294,7 @@ func TestArrInstanceRepository_UpdateWebhookSecret(t *testing.T) {
 }
 
 func TestArrInstanceRepository_Delete(t *testing.T) {
+	t.Parallel()
 	repo := NewArrInstanceRepository(newArrInstanceTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, CreateArrInstanceParams{

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -76,6 +76,7 @@ func seedCorruption(t *testing.T, db *sql.DB, id, filePath, finalState string, b
 }
 
 func TestCorruptionRepository_CountFiltered_andListFiltered(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -105,6 +106,7 @@ func TestCorruptionRepository_CountFiltered_andListFiltered(t *testing.T) {
 }
 
 func TestCorruptionRepository_CountByState_andListByState(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -128,6 +130,7 @@ func TestCorruptionRepository_CountByState_andListByState(t *testing.T) {
 }
 
 func TestCorruptionRepository_LatestEventData(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -153,6 +156,7 @@ func TestCorruptionRepository_LatestEventData(t *testing.T) {
 }
 
 func TestCorruptionRepository_ListEvents(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -171,6 +175,7 @@ func TestCorruptionRepository_ListEvents(t *testing.T) {
 }
 
 func TestCorruptionRepository_CorruptionDetectedFileInfo(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -195,6 +200,7 @@ func TestCorruptionRepository_CorruptionDetectedFileInfo(t *testing.T) {
 }
 
 func TestCorruptionRepository_DeleteEvents(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -216,6 +222,7 @@ func TestCorruptionRepository_DeleteEvents(t *testing.T) {
 }
 
 func TestCorruptionRepository_StateCounts(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -236,6 +243,7 @@ func TestCorruptionRepository_StateCounts(t *testing.T) {
 }
 
 func TestCorruptionRepository_CountDetectedToday(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	now := time.Now().UTC()
@@ -257,6 +265,7 @@ func TestCorruptionRepository_CountDetectedToday(t *testing.T) {
 }
 
 func TestCorruptionRepository_CountByCorruptionType(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -278,6 +287,7 @@ func TestCorruptionRepository_CountByCorruptionType(t *testing.T) {
 }
 
 func TestCorruptionRepository_PathCorruptionStats(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
@@ -298,6 +308,7 @@ func TestCorruptionRepository_PathCorruptionStats(t *testing.T) {
 }
 
 func TestCorruptionRepository_HasActive(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	now := time.Now().UTC()
@@ -320,6 +331,7 @@ func TestCorruptionRepository_HasActive(t *testing.T) {
 }
 
 func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	now := time.Now().UTC()
@@ -342,6 +354,7 @@ func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
 }
 
 func TestCorruptionRepository_CountDetectedByDay(t *testing.T) {
+	t.Parallel()
 	db := newCorruptionTestDB(t)
 	repo := NewCorruptionRepository(db)
 	now := time.Now().UTC()

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -39,6 +39,7 @@ func newEventTestDB(t *testing.T) *sql.DB {
 }
 
 func TestEventRepository_Append(t *testing.T) {
+	t.Parallel()
 	db := newEventTestDB(t)
 	repo := NewEventRepository(db)
 
@@ -71,6 +72,7 @@ func TestEventRepository_Append(t *testing.T) {
 }
 
 func TestEventRepository_ListUnprocessed_endOfStreamOnly(t *testing.T) {
+	t.Parallel()
 	db := newEventTestDB(t)
 	repo := NewEventRepository(db)
 	ctx := context.Background()
@@ -108,6 +110,7 @@ func TestEventRepository_ListUnprocessed_endOfStreamOnly(t *testing.T) {
 }
 
 func TestEventRepository_ListUnprocessed_skipsCorruptData(t *testing.T) {
+	t.Parallel()
 	db := newEventTestDB(t)
 	repo := NewEventRepository(db)
 
@@ -135,6 +138,7 @@ func TestEventRepository_ListUnprocessed_skipsCorruptData(t *testing.T) {
 }
 
 func TestEventRepository_FirstEventTime(t *testing.T) {
+	t.Parallel()
 	db := newEventTestDB(t)
 	repo := NewEventRepository(db)
 

--- a/internal/repository/notification_test.go
+++ b/internal/repository/notification_test.go
@@ -57,6 +57,7 @@ func defaultNotifFields(name string) NotificationFields {
 }
 
 func TestNotificationRepository_Create_andGetByID(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	id, err := repo.Create(context.Background(), defaultNotifFields("test"))
 	if err != nil {
@@ -75,6 +76,7 @@ func TestNotificationRepository_Create_andGetByID(t *testing.T) {
 }
 
 func TestNotificationRepository_GetByID_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
 		t.Errorf("GetByID = %v, want ErrNotFound", err)
@@ -82,6 +84,7 @@ func TestNotificationRepository_GetByID_notFound(t *testing.T) {
 }
 
 func TestNotificationRepository_ListEnabled_andListAll(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	ctx := context.Background()
 
@@ -111,6 +114,7 @@ func TestNotificationRepository_ListEnabled_andListAll(t *testing.T) {
 }
 
 func TestNotificationRepository_Update(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultNotifFields("old"))
@@ -128,6 +132,7 @@ func TestNotificationRepository_Update(t *testing.T) {
 }
 
 func TestNotificationRepository_Delete_cascadesLogs(t *testing.T) {
+	t.Parallel()
 	db := newNotificationTestDB(t)
 	repo := NewNotificationRepository(db)
 	ctx := context.Background()
@@ -150,6 +155,7 @@ func TestNotificationRepository_Delete_cascadesLogs(t *testing.T) {
 }
 
 func TestNotificationRepository_AppendLog_andListLog(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultNotifFields("x"))
@@ -175,6 +181,7 @@ func TestNotificationRepository_AppendLog_andListLog(t *testing.T) {
 }
 
 func TestNotificationRepository_ListLog_unfilteredReturnsAll(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	ctx := context.Background()
 	a, _ := repo.Create(ctx, defaultNotifFields("a"))
@@ -189,6 +196,7 @@ func TestNotificationRepository_ListLog_unfilteredReturnsAll(t *testing.T) {
 }
 
 func TestNotificationRepository_SweepLogsOlderThan(t *testing.T) {
+	t.Parallel()
 	db := newNotificationTestDB(t)
 	repo := NewNotificationRepository(db)
 	ctx := context.Background()
@@ -220,6 +228,7 @@ func TestNotificationRepository_SweepLogsOlderThan(t *testing.T) {
 }
 
 func TestNotificationRepository_LimitLogTotal(t *testing.T) {
+	t.Parallel()
 	repo := NewNotificationRepository(newNotificationTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultNotifFields("x"))

--- a/internal/repository/rescan_test.go
+++ b/internal/repository/rescan_test.go
@@ -40,6 +40,7 @@ func newRescanTestDB(t *testing.T) *sql.DB {
 }
 
 func TestRescanRepository_Queue_insertsAndReQueues(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	ctx := context.Background()
@@ -68,6 +69,7 @@ func TestRescanRepository_Queue_insertsAndReQueues(t *testing.T) {
 }
 
 func TestRescanRepository_ListReady(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	ctx := context.Background()
@@ -95,6 +97,7 @@ func TestRescanRepository_ListReady(t *testing.T) {
 }
 
 func TestRescanRepository_ListReady_respectsLimit(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	for _, p := range []string{"/a", "/b", "/c"} {
@@ -108,6 +111,7 @@ func TestRescanRepository_ListReady_respectsLimit(t *testing.T) {
 }
 
 func TestRescanRepository_MarkResolved(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	ctx := context.Background()
@@ -132,6 +136,7 @@ func TestRescanRepository_MarkResolved(t *testing.T) {
 }
 
 func TestRescanRepository_BumpRetry(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	ctx := context.Background()
@@ -152,6 +157,7 @@ func TestRescanRepository_BumpRetry(t *testing.T) {
 }
 
 func TestRescanRepository_Stats(t *testing.T) {
+	t.Parallel()
 	db := newRescanTestDB(t)
 	repo := NewRescanRepository(db)
 	mustExec(t, db, `INSERT INTO pending_rescans (file_path, error_type, status) VALUES ('/p1', 'X', 'pending')`)

--- a/internal/repository/scan_file_test.go
+++ b/internal/repository/scan_file_test.go
@@ -35,6 +35,7 @@ func newScanFileTestDB(t *testing.T) *sql.DB {
 }
 
 func TestScanFileRepository_Record_healthyStoresNullOptionals(t *testing.T) {
+	t.Parallel()
 	db := newScanFileTestDB(t)
 	repo := NewScanFileRepository(db)
 
@@ -60,6 +61,7 @@ func TestScanFileRepository_Record_healthyStoresNullOptionals(t *testing.T) {
 }
 
 func TestScanFileRepository_Record_corruptStoresDetails(t *testing.T) {
+	t.Parallel()
 	db := newScanFileTestDB(t)
 	repo := NewScanFileRepository(db)
 
@@ -81,6 +83,7 @@ func TestScanFileRepository_Record_corruptStoresDetails(t *testing.T) {
 }
 
 func TestScanFileRepository_CountByStatus(t *testing.T) {
+	t.Parallel()
 	db := newScanFileTestDB(t)
 	repo := NewScanFileRepository(db)
 	ctx := context.Background()
@@ -108,6 +111,7 @@ func TestScanFileRepository_CountByStatus(t *testing.T) {
 }
 
 func TestScanFileRepository_CountForScan_andListForScan(t *testing.T) {
+	t.Parallel()
 	db := newScanFileTestDB(t)
 	repo := NewScanFileRepository(db)
 	ctx := context.Background()
@@ -141,6 +145,7 @@ func TestScanFileRepository_CountForScan_andListForScan(t *testing.T) {
 }
 
 func TestScanFileRepository_ListForScan_pagination(t *testing.T) {
+	t.Parallel()
 	db := newScanFileTestDB(t)
 	repo := NewScanFileRepository(db)
 	ctx := context.Background()

--- a/internal/repository/scan_path_test.go
+++ b/internal/repository/scan_path_test.go
@@ -52,6 +52,7 @@ func defaultFields(localPath string) ScanPathFields {
 }
 
 func TestScanPathRepository_Create_andGetByID(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 
@@ -87,6 +88,7 @@ func TestScanPathRepository_Create_andGetByID(t *testing.T) {
 }
 
 func TestScanPathRepository_Create_emptyDetectionArgsStoresNull(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	id, err := repo.Create(context.Background(), defaultFields("/p"))
 	if err != nil {
@@ -99,6 +101,7 @@ func TestScanPathRepository_Create_emptyDetectionArgsStoresNull(t *testing.T) {
 }
 
 func TestScanPathRepository_GetByID_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	if _, err := repo.GetByID(context.Background(), 99); !errors.Is(err, ErrNotFound) {
 		t.Errorf("GetByID = %v, want ErrNotFound", err)
@@ -106,6 +109,7 @@ func TestScanPathRepository_GetByID_notFound(t *testing.T) {
 }
 
 func TestScanPathRepository_FindIDByLocalPath(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultFields("/movies"))
@@ -121,6 +125,7 @@ func TestScanPathRepository_FindIDByLocalPath(t *testing.T) {
 }
 
 func TestScanPathRepository_FindEnabledIDByLocalPath_skipsDisabled(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 	f := defaultFields("/movies")
@@ -133,6 +138,7 @@ func TestScanPathRepository_FindEnabledIDByLocalPath_skipsDisabled(t *testing.T)
 }
 
 func TestScanPathRepository_ListAll_andListEnabled(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 
@@ -163,6 +169,7 @@ func TestScanPathRepository_ListAll_andListEnabled(t *testing.T) {
 }
 
 func TestScanPathRepository_ListOrderedByLocalPath(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 	// Insert in non-alphabetical order.
@@ -183,6 +190,7 @@ func TestScanPathRepository_ListOrderedByLocalPath(t *testing.T) {
 }
 
 func TestScanPathRepository_Update(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultFields("/old"))
@@ -201,6 +209,7 @@ func TestScanPathRepository_Update(t *testing.T) {
 }
 
 func TestScanPathRepository_Delete(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 	id, _ := repo.Create(ctx, defaultFields("/x"))
@@ -218,6 +227,7 @@ func TestScanPathRepository_Delete(t *testing.T) {
 }
 
 func TestScanPathRepository_Count(t *testing.T) {
+	t.Parallel()
 	repo := NewScanPathRepository(newScanPathTestDB(t))
 	ctx := context.Background()
 

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -64,6 +64,7 @@ func seedScan(t *testing.T, db *sql.DB, path, status string, files, corruptions 
 }
 
 func TestScanRepository_Count(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	if n, _ := repo.Count(context.Background()); n != 0 {
@@ -77,6 +78,7 @@ func TestScanRepository_Count(t *testing.T) {
 }
 
 func TestScanRepository_GetByID(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	id := seedScan(t, db, "/path", "completed", 100, 3, "2026-05-01 00:00:00")
@@ -91,6 +93,7 @@ func TestScanRepository_GetByID(t *testing.T) {
 }
 
 func TestScanRepository_GetByID_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewScanRepository(newScanTestDB(t))
 	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
 		t.Errorf("GetByID = %v, want ErrNotFound", err)
@@ -98,6 +101,7 @@ func TestScanRepository_GetByID_notFound(t *testing.T) {
 }
 
 func TestScanRepository_Exists(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	id := seedScan(t, db, "/p", "completed", 1, 0, "")
@@ -111,6 +115,7 @@ func TestScanRepository_Exists(t *testing.T) {
 }
 
 func TestScanRepository_ListPaged(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	for i := 0; i < 5; i++ {
@@ -129,6 +134,7 @@ func TestScanRepository_ListPaged(t *testing.T) {
 }
 
 func TestScanRepository_GetScanStats(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	// Seed some scans with timestamps that fall in today/this-week ranges.
@@ -158,6 +164,7 @@ func TestScanRepository_GetScanStats(t *testing.T) {
 }
 
 func TestScanRepository_GetLastCompletedScan(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	seedScan(t, db, "/older", "completed", 0, 0, "2026-05-01 00:00:00")
@@ -174,6 +181,7 @@ func TestScanRepository_GetLastCompletedScan(t *testing.T) {
 }
 
 func TestScanRepository_GetLastCompletedScan_empty(t *testing.T) {
+	t.Parallel()
 	repo := NewScanRepository(newScanTestDB(t))
 	if _, err := repo.GetLastCompletedScan(context.Background()); !errors.Is(err, ErrNotFound) {
 		t.Errorf("empty DB = %v, want ErrNotFound", err)
@@ -181,6 +189,7 @@ func TestScanRepository_GetLastCompletedScan_empty(t *testing.T) {
 }
 
 func TestScanRepository_GetLastCompletedScanByPathID(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	// Two paths, two completed scans each — the per-path query should pick
@@ -207,6 +216,7 @@ func TestScanRepository_GetLastCompletedScanByPathID(t *testing.T) {
 }
 
 func TestScanRepository_Create_andStatusTransitions(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	ctx := context.Background()
@@ -242,6 +252,7 @@ func TestScanRepository_Create_andStatusTransitions(t *testing.T) {
 }
 
 func TestScanRepository_MarkInterrupted_Paused_Aborted(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	ctx := context.Background()
@@ -277,6 +288,7 @@ func TestScanRepository_MarkInterrupted_Paused_Aborted(t *testing.T) {
 }
 
 func TestScanRepository_UpdateProgress_andIncrementCorruptions(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	ctx := context.Background()
@@ -304,6 +316,7 @@ func TestScanRepository_UpdateProgress_andIncrementCorruptions(t *testing.T) {
 }
 
 func TestScanRepository_ListInterrupted(t *testing.T) {
+	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
 	ctx := context.Background()

--- a/internal/repository/schedule_test.go
+++ b/internal/repository/schedule_test.go
@@ -48,6 +48,7 @@ func seedScanPath(t *testing.T, db *sql.DB, localPath string) int64 {
 }
 
 func TestScheduleRepository_Create_andListEnabled(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -70,6 +71,7 @@ func TestScheduleRepository_Create_andListEnabled(t *testing.T) {
 }
 
 func TestScheduleRepository_ListEnabled_skipsDisabled(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -83,6 +85,7 @@ func TestScheduleRepository_ListEnabled_skipsDisabled(t *testing.T) {
 }
 
 func TestScheduleRepository_ListWithPaths(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/movies")
@@ -98,6 +101,7 @@ func TestScheduleRepository_ListWithPaths(t *testing.T) {
 }
 
 func TestScheduleRepository_ListWithPaths_skipsOrphans(t *testing.T) {
+	t.Parallel()
 	// A schedule referencing a deleted scan_path should be excluded by the
 	// INNER JOIN (the export endpoint doesn't show stale rows).
 	db := newScheduleTestDB(t)
@@ -119,6 +123,7 @@ func TestScheduleRepository_ListWithPaths_skipsOrphans(t *testing.T) {
 }
 
 func TestScheduleRepository_GetByID_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewScheduleRepository(newScheduleTestDB(t))
 	if _, err := repo.GetByID(context.Background(), 999); !errors.Is(err, ErrNotFound) {
 		t.Errorf("GetByID = %v, want ErrNotFound", err)
@@ -126,6 +131,7 @@ func TestScheduleRepository_GetByID_notFound(t *testing.T) {
 }
 
 func TestScheduleRepository_FindIDByPathAndCron(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -142,6 +148,7 @@ func TestScheduleRepository_FindIDByPathAndCron(t *testing.T) {
 }
 
 func TestScheduleRepository_Update_cronAndEnabled(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -157,6 +164,7 @@ func TestScheduleRepository_Update_cronAndEnabled(t *testing.T) {
 }
 
 func TestScheduleRepository_Update_emptyCronOnlyChangesEnabled(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -175,6 +183,7 @@ func TestScheduleRepository_Update_emptyCronOnlyChangesEnabled(t *testing.T) {
 }
 
 func TestScheduleRepository_Delete(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")
@@ -189,6 +198,7 @@ func TestScheduleRepository_Delete(t *testing.T) {
 }
 
 func TestScheduleRepository_DeleteOrphaned(t *testing.T) {
+	t.Parallel()
 	db := newScheduleTestDB(t)
 	repo := NewScheduleRepository(db)
 	pathID := seedScanPath(t, db, "/a")

--- a/internal/repository/session_test.go
+++ b/internal/repository/session_test.go
@@ -35,6 +35,7 @@ func newSessionTestDB(t *testing.T) *sql.DB {
 }
 
 func TestSessionRepository_Create_persistsRow(t *testing.T) {
+	t.Parallel()
 	repo := NewSessionRepository(newSessionTestDB(t))
 
 	session, err := repo.Create(context.Background(), "tok-abc", time.Hour, "ua/1.0", "192.0.2.1")
@@ -53,6 +54,7 @@ func TestSessionRepository_Create_persistsRow(t *testing.T) {
 }
 
 func TestSessionRepository_Validate_active(t *testing.T) {
+	t.Parallel()
 	repo := NewSessionRepository(newSessionTestDB(t))
 	if _, err := repo.Create(context.Background(), "tok", time.Hour, "", ""); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -64,6 +66,7 @@ func TestSessionRepository_Validate_active(t *testing.T) {
 }
 
 func TestSessionRepository_Validate_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewSessionRepository(newSessionTestDB(t))
 
 	err := repo.Validate(context.Background(), "no-such-token")
@@ -73,6 +76,7 @@ func TestSessionRepository_Validate_notFound(t *testing.T) {
 }
 
 func TestSessionRepository_Validate_expired(t *testing.T) {
+	t.Parallel()
 	db := newSessionTestDB(t)
 	// Insert an already-expired row directly so we don't depend on time travel.
 	past := time.Now().UTC().Add(-time.Hour)
@@ -91,6 +95,7 @@ func TestSessionRepository_Validate_expired(t *testing.T) {
 }
 
 func TestSessionRepository_BumpLastUsed_updatesRow(t *testing.T) {
+	t.Parallel()
 	db := newSessionTestDB(t)
 	repo := NewSessionRepository(db)
 
@@ -125,6 +130,7 @@ func TestSessionRepository_BumpLastUsed_updatesRow(t *testing.T) {
 }
 
 func TestSessionRepository_BumpLastUsed_missingTokenIsNotError(t *testing.T) {
+	t.Parallel()
 	repo := NewSessionRepository(newSessionTestDB(t))
 	// Bumping a token that doesn't exist is fine — last_used_at is purely
 	// diagnostic, so a no-op update isn't an error condition.
@@ -134,6 +140,7 @@ func TestSessionRepository_BumpLastUsed_missingTokenIsNotError(t *testing.T) {
 }
 
 func TestSessionRepository_Delete_removesRow(t *testing.T) {
+	t.Parallel()
 	db := newSessionTestDB(t)
 	repo := NewSessionRepository(db)
 
@@ -154,6 +161,7 @@ func TestSessionRepository_Delete_removesRow(t *testing.T) {
 }
 
 func TestSessionRepository_SweepExpired(t *testing.T) {
+	t.Parallel()
 	db := newSessionTestDB(t)
 	repo := NewSessionRepository(db)
 

--- a/internal/repository/settings_test.go
+++ b/internal/repository/settings_test.go
@@ -31,6 +31,7 @@ func newSettingsTestDB(t *testing.T) *sql.DB {
 }
 
 func TestSettingsRepository_Set_andGet(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
 
@@ -44,6 +45,7 @@ func TestSettingsRepository_Set_andGet(t *testing.T) {
 }
 
 func TestSettingsRepository_Set_overwrites(t *testing.T) {
+	t.Parallel()
 	// SQLite ON CONFLICT(key) DO UPDATE — Set is upsert, not strict insert.
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
@@ -57,6 +59,7 @@ func TestSettingsRepository_Set_overwrites(t *testing.T) {
 }
 
 func TestSettingsRepository_Get_notFound(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	_, err := repo.Get(context.Background(), "nope")
 	if !errors.Is(err, ErrNotFound) {
@@ -65,6 +68,7 @@ func TestSettingsRepository_Get_notFound(t *testing.T) {
 }
 
 func TestSettingsRepository_GetOr_fallback(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	got, err := repo.GetOr(context.Background(), "nope", "default-value")
 	if err != nil || got != "default-value" {
@@ -73,6 +77,7 @@ func TestSettingsRepository_GetOr_fallback(t *testing.T) {
 }
 
 func TestSettingsRepository_GetOr_existing(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	_ = repo.Set(context.Background(), "k", "actual")
 	got, _ := repo.GetOr(context.Background(), "k", "default-value")
@@ -82,6 +87,7 @@ func TestSettingsRepository_GetOr_existing(t *testing.T) {
 }
 
 func TestSettingsRepository_Exists(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
 
@@ -95,6 +101,7 @@ func TestSettingsRepository_Exists(t *testing.T) {
 }
 
 func TestSettingsRepository_Delete(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
 	_ = repo.Set(ctx, "k", "v")
@@ -112,6 +119,7 @@ func TestSettingsRepository_Delete(t *testing.T) {
 }
 
 func TestSettingsRepository_SetMany_atomic(t *testing.T) {
+	t.Parallel()
 	// SetMany commits all keys or none. Verify the happy path first.
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
@@ -128,6 +136,7 @@ func TestSettingsRepository_SetMany_atomic(t *testing.T) {
 }
 
 func TestSettingsRepository_SetMany_overwrites(t *testing.T) {
+	t.Parallel()
 	repo := NewSettingsRepository(newSettingsTestDB(t))
 	ctx := context.Background()
 	_ = repo.Set(ctx, "a", "old")


### PR DESCRIPTION
## Summary

Phase 4 \`t.Parallel()\` item. Adds \`t.Parallel()\` to all **98** top-level test functions across \`internal/repository\`.

The package is **provably isolation-safe**: every test acquires its own in-memory SQLite DB via a \`newXTestDB(t)\` helper (\`sql.Open("sqlite", ":memory:")\`), there are no package-level mutable vars, no \`TestMain\`, and no shared global state. Verified **race-clean** (\`go test -race ./internal/repository/\` passes).

## Honest payoff note

This package already runs in ~40ms, so the wall-clock win *today* is negligible — the value is correctness + future-proofing. As the repository layer grows (it gained 11 repos this phase), parallel execution keeps it fast, and the \`-race\` run now exercises concurrent independent DB access.

## Scope

Repository only. The packages with real runtime (\`services\`, \`api\`) share global state — \`TestMain\`-set config and the global metrics service — so a blanket \`t.Parallel()\` there would risk flakiness and is deliberately left sequential. (The remaining \`db\` hotspot, \`TestExecWithRetry_BusyExhausted\` at 1.5s, is a backoff-injection target, not a parallelism one.)

## Test plan

- [x] \`go vet ./internal/repository/\`
- [x] \`go test ./internal/repository/\` — passes
- [x] \`go test -race ./internal/repository/\` — passes, no data races
- [x] \`/usr/bin/golangci-lint run ./internal/repository/...\` — 0 issues