### PR TITLE
perf(test): make db RetryDelay injectable — db tests 2.8s → 1.3s (Phase 4.7)

### DIFF
--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -21,8 +21,11 @@ import (
 // MaxRetries is the number of times to retry a database operation on SQLITE_BUSY
 const MaxRetries = 5
 
-// RetryDelay is the base delay between retries (increases exponentially)
-const RetryDelay = 100 * time.Millisecond
+// RetryDelay is the base delay between retries (increases exponentially).
+// A var (not a const) so tests exercising full retry exhaustion can shrink
+// it to avoid paying the real 100+200+400+800ms backoff; production keeps
+// the 100ms default.
+var RetryDelay = 100 * time.Millisecond
 
 //go:embed migrations/*.sql
 var migrationsFS embed.FS

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -929,6 +929,12 @@ func TestRepository_MigrateAPIKeyEncryption_PlainKey(t *testing.T) {
 }
 
 func TestExecWithRetry_BusyExhausted(t *testing.T) {
+	// Exercise the retry loop without paying the real 100+200+400+800ms
+	// backoff. RetryDelay is a package var; restore it after.
+	origRetryDelay := RetryDelay
+	RetryDelay = 0
+	defer func() { RetryDelay = origRetryDelay }()
+
 	tmpDir, err := os.MkdirTemp("", "healarr-busy-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -986,6 +992,11 @@ func TestExecWithRetry_BusyExhausted(t *testing.T) {
 }
 
 func TestQueryWithRetry_BusyExhausted(t *testing.T) {
+	// Exercise the retry loop without paying the real exponential backoff.
+	origRetryDelay := RetryDelay
+	RetryDelay = 0
+	defer func() { RetryDelay = origRetryDelay }()
+
 	tmpDir, err := os.MkdirTemp("", "healarr-busy-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)


### PR DESCRIPTION
## Summary

Final Phase 4 backoff-injection cleanup. \`ExecWithRetry\`/\`QueryWithRetry\` exhaust \`MaxRetries=5\` with exponential backoff off \`RetryDelay\` (100+200+400+800ms ≈ 1.5s). The two \`*_BusyExhausted\` tests deliberately trigger a SQLITE_BUSY and ran the full backoff for real.

## Change

Convert \`RetryDelay\` from \`const\` to \`var\` (default unchanged at 100ms — production behavior and \`TestRetryConstants\` untouched). The two busy-exhausted tests save it, set it to 0, and restore via \`defer\`. They still exercise the full retry loop, just without the sleeps.

## Result

- \`db\` package: **2.8s → 1.3s**
- Last backoff-sleep hotspot in the suite.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/db/\` — passes, 1.3s; both BusyExhausted tests still exercise the retry loop
- [x] TestRetryConstants still passes (default RetryDelay = 100ms)
- [x] \`/usr/bin/golangci-lint run ./internal/db/...\` — 0 issues