### PR TITLE
feat(frontend): subscription-based WebSocket event emitter (Phase 5.1)

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -12,7 +12,7 @@ vi.mock('../../contexts/WebSocketProvider', () => ({
   useWebSocket: () => ({
     reconnect: vi.fn(),
     isConnected: false,
-    connectionState: 'disconnected',
+    subscribe: vi.fn(() => () => {}),
   }),
 }));
 

--- a/frontend/src/contexts/WebSocketProvider.test.tsx
+++ b/frontend/src/contexts/WebSocketProvider.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+    WebSocketProvider,
+    useWebSocket,
+    useWebSocketEvent,
+    type WSMessage,
+} from './WebSocketProvider';
+
+/**
+ * Minimal controllable WebSocket stand-in. jsdom has no WebSocket, so we install
+ * this on the global and drive open/message events by hand from the test.
+ */
+class MockWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    static instances: MockWebSocket[] = [];
+
+    readyState = MockWebSocket.CONNECTING;
+    url: string;
+    onopen: ((ev: Event) => void) | null = null;
+    onclose: ((ev: Event) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+
+    constructor(url: string) {
+        this.url = url;
+        MockWebSocket.instances.push(this);
+    }
+
+    close() {
+        // Intentionally does not fire onclose: these tests don't exercise the
+        // reconnect-on-close path, and firing it on unmount would schedule a
+        // dangling backoff timer.
+        this.readyState = MockWebSocket.CLOSED;
+    }
+
+    // --- test helpers ---
+    fireOpen() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.(new Event('open'));
+    }
+    fireMessage(payload: unknown) {
+        this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent);
+    }
+}
+
+function renderWithProvider(ui: React.ReactNode) {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <WebSocketProvider>{ui}</WebSocketProvider>
+        </QueryClientProvider>
+    );
+}
+
+// Calls reconnect() on mount so the provider opens a (mock) socket.
+function Connector() {
+    const { reconnect } = useWebSocket();
+    useEffect(() => {
+        reconnect();
+    }, [reconnect]);
+    return null;
+}
+
+function Listener({ onMessage }: { onMessage: (m: WSMessage) => void }) {
+    useWebSocketEvent(onMessage);
+    return null;
+}
+
+const socket = () => MockWebSocket.instances[0];
+
+describe('WebSocketProvider event emitter', () => {
+    beforeEach(() => {
+        MockWebSocket.instances = [];
+        // setup.ts replaces localStorage with vi.fn() stubs, so drive getItem directly.
+        vi.mocked(localStorage.getItem).mockReturnValue('test-token');
+        vi.stubGlobal('WebSocket', MockWebSocket);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.mocked(localStorage.getItem).mockReset();
+    });
+
+    it('delivers every message to a subscriber, including bursts in one tick', () => {
+        const received: WSMessage[] = [];
+        renderWithProvider(<><Connector /><Listener onMessage={(m) => received.push(m)} /></>);
+
+        act(() => socket().fireOpen());
+        act(() => {
+            // Two messages back-to-back: the old single lastMessage value would
+            // have only surfaced the last one. The emitter must deliver both.
+            socket().fireMessage({ type: 'log', data: { line: 'a' } });
+            socket().fireMessage({ type: 'log', data: { line: 'b' } });
+        });
+
+        expect(received).toHaveLength(2);
+        expect((received[0].data as { line: string }).line).toBe('a');
+        expect((received[1].data as { line: string }).line).toBe('b');
+    });
+
+    it('normalizes backend event envelopes to {type, data}', () => {
+        const received: WSMessage[] = [];
+        renderWithProvider(<><Connector /><Listener onMessage={(m) => received.push(m)} /></>);
+
+        act(() => socket().fireOpen());
+        act(() =>
+            socket().fireMessage({
+                type: 'event',
+                data: { event_type: 'ScanProgress', event_data: { files_done: 3 } },
+            })
+        );
+
+        expect(received).toHaveLength(1);
+        expect(received[0].type).toBe('ScanProgress');
+        expect((received[0].data as { files_done: number }).files_done).toBe(3);
+    });
+
+    it('stops delivering after the subscriber unmounts', () => {
+        const received: WSMessage[] = [];
+        function Harness({ listening }: { listening: boolean }) {
+            return (
+                <>
+                    <Connector />
+                    {listening && <Listener onMessage={(m) => received.push(m)} />}
+                </>
+            );
+        }
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const { rerender } = render(
+            <QueryClientProvider client={queryClient}>
+                <WebSocketProvider><Harness listening={true} /></WebSocketProvider>
+            </QueryClientProvider>
+        );
+
+        act(() => socket().fireOpen());
+        act(() => socket().fireMessage({ type: 'log', data: { line: 'a' } }));
+        expect(received).toHaveLength(1);
+
+        rerender(
+            <QueryClientProvider client={queryClient}>
+                <WebSocketProvider><Harness listening={false} /></WebSocketProvider>
+            </QueryClientProvider>
+        );
+
+        act(() => socket().fireMessage({ type: 'log', data: { line: 'b' } }));
+        expect(received).toHaveLength(1); // unchanged: handler was unsubscribed
+    });
+
+    it('isolates a throwing subscriber from the others', () => {
+        const received: WSMessage[] = [];
+        renderWithProvider(
+            <>
+                <Connector />
+                <Listener onMessage={() => { throw new Error('boom'); }} />
+                <Listener onMessage={(m) => received.push(m)} />
+            </>
+        );
+
+        act(() => socket().fireOpen());
+        act(() => socket().fireMessage({ type: 'log', data: { line: 'a' } }));
+
+        // The healthy subscriber still receives the message.
+        expect(received).toHaveLength(1);
+    });
+
+    it('always invokes the latest handler closure (no stale state)', () => {
+        const seen: number[] = [];
+        function Probe({ value }: { value: number }) {
+            useWebSocketEvent(() => seen.push(value));
+            return null;
+        }
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        const tree = (value: number) => (
+            <QueryClientProvider client={queryClient}>
+                <WebSocketProvider><Connector /><Probe value={value} /></WebSocketProvider>
+            </QueryClientProvider>
+        );
+        const { rerender } = render(tree(0));
+
+        act(() => socket().fireOpen());
+        rerender(tree(9)); // handler closure must update to the new prop value
+        act(() => socket().fireMessage({ type: 'log', data: {} }));
+
+        expect(seen).toEqual([9]);
+    });
+});

--- a/frontend/src/contexts/WebSocketProvider.tsx
+++ b/frontend/src/contexts/WebSocketProvider.tsx
@@ -3,9 +3,22 @@ import React, { createContext, useContext, useEffect, useState, useRef, useCallb
 import { useQueryClient } from '@tanstack/react-query';
 import { getWebSocketUrl } from '../lib/basePath';
 
+/**
+ * A WebSocket message after normalization. Backend `event` envelopes are
+ * flattened so consumers see `{ type: <event_type>, data: <event_data> }`.
+ */
+export interface WSMessage {
+    type: string;
+    data: unknown;
+    _raw?: unknown;
+}
+
+type WSHandler = (message: WSMessage) => void;
+
 interface WebSocketContextType {
     isConnected: boolean;
-    lastMessage: unknown;
+    /** Register a handler for every incoming message. Returns an unsubscribe fn. */
+    subscribe: (handler: WSHandler) => () => void;
     reconnect: () => void;
 }
 
@@ -19,14 +32,39 @@ export const useWebSocket = () => {
     return context;
 };
 
+/**
+ * Subscribe to every WebSocket message exactly once, decoupled from render
+ * timing. The handler may freely close over current props/state — the latest
+ * version is always invoked, so there are no stale closures, no dependency
+ * array to maintain, and no messages dropped when several arrive in one tick
+ * (the failure mode of reading a single `lastMessage` value via useEffect).
+ */
+export const useWebSocketEvent = (handler: WSHandler) => {
+    const { subscribe } = useWebSocket();
+    const handlerRef = useRef(handler);
+    useEffect(() => {
+        handlerRef.current = handler;
+    });
+    useEffect(() => subscribe((msg) => handlerRef.current(msg)), [subscribe]);
+};
+
 export const WebSocketProvider = ({ children }: { children: React.ReactNode }) => {
     const [isConnected, setIsConnected] = useState(false);
-    const [lastMessage, setLastMessage] = useState<unknown>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const retryCountRef = useRef(0);
+    const subscribersRef = useRef<Set<WSHandler>>(new Set());
     const queryClient = useQueryClient();
 
     const connectRef = useRef<() => void>(() => { });
+
+    // Stable across renders: handlers live in a ref, so subscribing never
+    // forces useWebSocketEvent's effect to re-run.
+    const subscribe = useCallback((handler: WSHandler) => {
+        subscribersRef.current.add(handler);
+        return () => {
+            subscribersRef.current.delete(handler);
+        };
+    }, []);
 
     const connect = useCallback(() => {
         // Don't attempt connection on login page
@@ -95,7 +133,7 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
                 // Transform event messages to use event_type as the type
                 // Backend sends: {"type": "event", "data": {"event_type": "ScanProgress", "event_data": {...}}}
                 // Transform to: {"type": "ScanProgress", "data": {...event_data fields...}}
-                let message = rawMessage;
+                let message: WSMessage = rawMessage;
                 if (rawMessage.type === 'event' && rawMessage.data?.event_type) {
                     const eventData = rawMessage.data.event_data || {};
                     message = {
@@ -106,7 +144,15 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
                     };
                 }
 
-                setLastMessage(message);
+                // Fan out to every subscriber. A subscriber throwing must not
+                // skip the others or the centralized query invalidation below.
+                subscribersRef.current.forEach((handler) => {
+                    try {
+                        handler(message);
+                    } catch (err) {
+                        console.error('WebSocket subscriber threw:', err);
+                    }
+                });
 
                 // Invalidate queries based on event type
                 const eventType = message.type;
@@ -174,7 +220,7 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
     }, []);
 
     return (
-        <WebSocketContext.Provider value={{ isConnected, lastMessage, reconnect: connect }}>
+        <WebSocketContext.Provider value={{ isConnected, subscribe, reconnect: connect }}>
             {children}
         </WebSocketContext.Provider>
     );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,7 +8,7 @@ import type { PathHealth } from '../types/api';
 import { FolderOpen, FolderCheck, FolderX, FolderSearch, FolderMinus } from 'lucide-react';
 import ActivityChart from '../components/charts/ActivityChart';
 import TypeDistributionChart from '../components/charts/TypeDistributionChart';
-import { useWebSocket } from '../contexts/WebSocketProvider';
+import { useWebSocketEvent } from '../contexts/WebSocketProvider';
 import { useToast } from '../contexts/ToastContext';
 import { useNavigate } from 'react-router-dom';
 import ConfigWarningBanner from '../components/ConfigWarningBanner';
@@ -143,7 +143,6 @@ const PathHealthCard = ({ path, formatTimeAgo, onClick }: { path: PathHealth; fo
 
 const ActiveScansTable = () => {
     const [scans, setScans] = useState<Record<string, ScanProgress>>({});
-    const { lastMessage } = useWebSocket();
     const toast = useToast();
     const navigate = useNavigate();
 
@@ -156,26 +155,21 @@ const ActiveScansTable = () => {
         });
     }, []);
 
-    // Handle WS updates
-    useEffect(() => {
-        if (!lastMessage) return;
-
-        if (lastMessage && typeof lastMessage === 'object' && 'type' in lastMessage) {
-            const msg = lastMessage as { type: string; data: unknown };
-            if (msg.type === 'ScanProgress') {
-                const progress = msg.data as ScanProgress;
-                // eslint-disable-next-line react-hooks/set-state-in-effect -- reacting to WebSocket message state
-                setScans(prev => ({ ...prev, [progress.id]: progress }));
-            } else if (msg.type === 'ScanCompleted') {
-                const { scan_id } = msg.data as { scan_id: string };
-                setScans(prev => {
-                    const next = { ...prev };
-                    delete next[scan_id];
-                    return next;
-                });
-            }
+    // Handle WS updates. Subscribing delivers every ScanProgress/ScanCompleted
+    // event exactly once, so no active-scan update is missed under bursts.
+    useWebSocketEvent((msg) => {
+        if (msg.type === 'ScanProgress') {
+            const progress = msg.data as ScanProgress;
+            setScans(prev => ({ ...prev, [progress.id]: progress }));
+        } else if (msg.type === 'ScanCompleted') {
+            const { scan_id } = msg.data as { scan_id: string };
+            setScans(prev => {
+                const next = { ...prev };
+                delete next[scan_id];
+                return next;
+            });
         }
-    }, [lastMessage]);
+    });
 
     const activeScansList = Object.values(scans);
 

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useWebSocket } from '../contexts/WebSocketProvider';
+import { useWebSocket, useWebSocketEvent } from '../contexts/WebSocketProvider';
 import { useConnection } from '../contexts/ConnectionContext';
 import { getRecentLogs, downloadLogs, type LogEntry } from '../lib/api';
 import clsx from 'clsx';
@@ -11,7 +11,7 @@ const LOGS_PER_PAGE = 100;
 const SCROLL_THRESHOLD = 50; // pixels from bottom to consider "at bottom"
 
 const Logs = () => {
-    const { lastMessage, isConnected: wsConnected, reconnect: wsReconnect } = useWebSocket();
+    const { isConnected: wsConnected, reconnect: wsReconnect } = useWebSocket();
     const { isConnected: backendConnected } = useConnection();
     const [logs, setLogs] = useState<LogEntry[]>([]);
     const [isPaused, setIsPaused] = useState(false);
@@ -159,16 +159,14 @@ const Logs = () => {
         fetchLogs();
     }, []);
 
-    // Handle new logs from WebSocket
-    useEffect(() => {
-        if (lastMessage && typeof lastMessage === 'object' && 'type' in lastMessage && !isPaused) {
-            const msg = lastMessage as { type: string; data: LogEntry };
-            if (msg.type === 'log') {
-                // eslint-disable-next-line react-hooks/set-state-in-effect -- reacting to WebSocket message state
-                setLogs(prev => [...prev, msg.data].slice(-1000));
-            }
+    // Handle new logs from WebSocket. Subscribing (rather than watching a single
+    // lastMessage value) guarantees no log line is dropped when several arrive in
+    // the same tick, and reads the current isPaused without re-subscribing.
+    useWebSocketEvent((msg) => {
+        if (msg.type === 'log' && !isPaused) {
+            setLogs(prev => [...prev, msg.data as LogEntry].slice(-1000));
         }
-    }, [lastMessage, isPaused]);
+    });
 
     // Auto-scroll to bottom for new logs when user is at bottom and not paused
     useEffect(() => {

--- a/frontend/src/pages/ScanDetails.tsx
+++ b/frontend/src/pages/ScanDetails.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, FileCheck, FileX, Loader2, Filter, HardDrive, Clock, FolderOpen, AlertCircle, X, RefreshCw, ClockArrowDown, ExternalLink, Radio, SkipForward, ShieldAlert, HelpCircle } from 'lucide-react';
@@ -7,7 +7,7 @@ import { getScanDetails, getScanFiles, cancelScan, rescanPath, type ScanFile, ty
 import DataGrid from '../components/ui/DataGrid';
 import { useDateFormat } from '../lib/useDateFormat';
 import { useToast } from '../contexts/ToastContext';
-import { useWebSocket } from '../contexts/WebSocketProvider';
+import { useWebSocketEvent } from '../contexts/WebSocketProvider';
 import { formatBytes } from '../lib/formatters';
 
 const ScanDetails = () => {
@@ -22,7 +22,6 @@ const ScanDetails = () => {
     const { formatCompact, formatTime } = useDateFormat();
     const toast = useToast();
     const queryClient = useQueryClient();
-    const { lastMessage } = useWebSocket();
 
     const scanId = parseInt(id || '0', 10);
 
@@ -46,29 +45,29 @@ const ScanDetails = () => {
         refetchInterval: isRunning ? 3000 : false,
     });
 
-    // Listen for WebSocket ScanProgress events to show current file
-    useEffect(() => {
-        if (!lastMessage || !isRunning) return;
+    // Listen for WebSocket ScanProgress events to show current file. Subscribing
+    // delivers every progress update; the handler reads current scanId/isRunning.
+    useWebSocketEvent((msg) => {
+        if (!isRunning) return;
 
-        if (lastMessage && typeof lastMessage === 'object' && 'type' in lastMessage) {
-            const msg = lastMessage as { type: string; data: ScanProgress };
-            if (msg.type === 'ScanProgress' && msg.data.scan_db_id === scanId) {
-                // eslint-disable-next-line react-hooks/set-state-in-effect -- reacting to WebSocket message state
-                setCurrentFile(msg.data.current_file);
+        if (msg.type === 'ScanProgress') {
+            const data = msg.data as ScanProgress;
+            if (data.scan_db_id === scanId) {
+                setCurrentFile(data.current_file);
                 setScanProgress({
-                    filesDone: msg.data.files_done,
-                    totalFiles: msg.data.total_files,
+                    filesDone: data.files_done,
+                    totalFiles: data.total_files,
                 });
-            } else if (msg.type === 'ScanCompleted') {
-                // Clear current file indicator when scan completes
-                setCurrentFile(null);
-                setScanProgress(null);
-                // Refresh data
-                queryClient.invalidateQueries({ queryKey: ['scan-details', scanId] });
-                queryClient.invalidateQueries({ queryKey: ['scan-files', scanId] });
             }
+        } else if (msg.type === 'ScanCompleted') {
+            // Clear current file indicator when scan completes
+            setCurrentFile(null);
+            setScanProgress(null);
+            // Refresh data
+            queryClient.invalidateQueries({ queryKey: ['scan-details', scanId] });
+            queryClient.invalidateQueries({ queryKey: ['scan-files', scanId] });
         }
-    }, [lastMessage, scanId, isRunning, queryClient]);
+    });
 
     const handleCancel = async () => {
         setIsActionLoading(true);


### PR DESCRIPTION
## Summary

The WebSocket layer exposed a single `lastMessage` state value that three pages (`Logs`, `ScanDetails`, `Dashboard`) consumed by watching it through a `useEffect`. That's an event-bus-via-state anti-pattern with two real bugs:

1. **Dropped messages** — when two messages arrive in the same tick, `setLastMessage` overwrites and the effect only ever sees the last one. For the live log tail in `Logs` that silently loses lines; for `ScanDetails` it drops progress updates.
2. **Duplicate processing** — the effect re-runs whenever its *other* deps change (`isPaused`, `scanId`, `isRunning`), re-handling the same stale message.

All three consumers carried `// eslint-disable-next-line react-hooks/set-state-in-effect` to silence the smell.

## Change

`WebSocketProvider` becomes a **subscription emitter**:

- handlers live in a ref'd `Set`; `subscribe(handler)` returns an unsubscribe fn (stable identity, so subscribing never re-runs effects)
- `onmessage` normalizes the backend `event` envelope once, then fans the message out to every subscriber (each wrapped in try/catch so one throwing subscriber can't skip the others or the centralized query invalidation)
- new `useWebSocketEvent(handler)` hook delivers **every message exactly once** via a ref to the latest handler — consumers close over current state with no dependency array and no dropped events
- `lastMessage` is removed; `Logs`, `ScanDetails`, `Dashboard` migrate to `useWebSocketEvent`, deleting the three eslint-disable hacks

Centralized query invalidation by event type is unchanged.

## Test plan

- [x] New `WebSocketProvider.test.tsx` (5 tests): burst delivery (the core fix), envelope normalization, unsubscribe-on-unmount, throwing-subscriber isolation, latest-closure delivery
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 132 passed, 1 pre-existing skip
- [x] `npm run build` — succeeds