### PR TITLE
feat(frontend): focus-trap + ARIA for all modal dialogs (Phase 5.3)

### DIFF
--- a/frontend/src/components/RemediationJourney.tsx
+++ b/frontend/src/components/RemediationJourney.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface RemediationJourneyProps {
     corruptionId: string;
@@ -71,6 +72,8 @@ const getStatusLabel = (status: string): string => {
 
 const RemediationJourney: React.FC<RemediationJourneyProps> = ({ corruptionId, onClose }) => {
     const { formatFull } = useDateFormat();
+    // Mounted == open: focus trap, Escape-to-close and focus restore.
+    const dialogRef = useModalA11y(true, onClose);
     
     const { data: history, isLoading } = useQuery({
         queryKey: ['history', corruptionId],
@@ -200,13 +203,21 @@ const RemediationJourney: React.FC<RemediationJourneyProps> = ({ corruptionId, o
 
     return (
         <div className="fixed inset-0 bg-black/50 dark:bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={onClose}>
-            <div className="bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl w-full max-w-2xl h-[85vh] flex flex-col shadow-2xl overflow-hidden" onClick={e => e.stopPropagation()}>
+            <div
+                ref={dialogRef}
+                tabIndex={-1}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="remediation-journey-title"
+                className="bg-white dark:bg-slate-950 border border-slate-200 dark:border-slate-800 rounded-xl w-full max-w-2xl h-[85vh] flex flex-col shadow-2xl overflow-hidden focus:outline-none"
+                onClick={e => e.stopPropagation()}
+            >
                 {/* Header */}
                 <div className="p-6 border-b border-slate-200 dark:border-slate-800 shrink-0 bg-white dark:bg-slate-900/50 backdrop-blur">
                     <div className="flex justify-between items-start">
                         <div className="flex-1 min-w-0 pr-4">
                             <div className="flex items-center gap-3 mb-2">
-                                <h2 className="text-xl font-bold text-slate-900 dark:text-white">Remediation Journey</h2>
+                                <h2 id="remediation-journey-title" className="text-xl font-bold text-slate-900 dark:text-white">Remediation Journey</h2>
                                 {summary && (
                                     <span className={clsx(
                                         "px-2.5 py-0.5 rounded-full text-xs font-medium border",

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -2,16 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { AlertTriangle, Trash2, X } from 'lucide-react';
 import clsx from 'clsx';
-
-/**
- * Get all focusable elements within a container.
- */
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
-    const elements = container.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
-    );
-    return Array.from(elements);
-}
+import { getFocusableElements } from '../../hooks/useModalA11y';
 
 interface ConfirmDialogProps {
     isOpen: boolean;

--- a/frontend/src/components/ui/ConnectionOverlay.tsx
+++ b/frontend/src/components/ui/ConnectionOverlay.tsx
@@ -9,10 +9,16 @@ const ConnectionOverlay = () => {
     return (
         <div className="fixed inset-0 z-[100] flex items-center justify-center">
             {/* Dimmed backdrop */}
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
-            
-            {/* Connection status card */}
-            <div className="relative bg-slate-800 border border-slate-700 rounded-xl p-8 shadow-2xl max-w-md mx-4">
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" aria-hidden="true" />
+
+            {/* Connection status card. role="status" + aria-live announces the
+                lost/reconnecting state to assistive tech; it is informational and
+                non-dismissible, so no focus trap. */}
+            <div
+                role="status"
+                aria-live="polite"
+                className="relative bg-slate-800 border border-slate-700 rounded-xl p-8 shadow-2xl max-w-md mx-4"
+            >
                 <div className="flex flex-col items-center text-center">
                     {/* Icon with animation */}
                     <div className="relative mb-6">

--- a/frontend/src/components/ui/FileBrowser.tsx
+++ b/frontend/src/components/ui/FileBrowser.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Folder, FolderOpen, Home, ArrowUp, X, Loader2, AlertCircle, ChevronRight } from 'lucide-react';
 import { browseDirectory, type BrowseResponse } from '../../lib/api';
+import { useModalA11y } from '../../hooks/useModalA11y';
 
 interface FileBrowserProps {
     isOpen: boolean;
@@ -16,6 +17,9 @@ const FileBrowser = ({ isOpen, onClose, onSelect, initialPath = '/' }: FileBrows
     const [parentPath, setParentPath] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    // Focus trap, Escape-to-close and focus restore while the browser is open.
+    const dialogRef = useModalA11y(isOpen, onClose);
 
     const loadDirectory = useCallback(async (path: string) => {
         setIsLoading(true);
@@ -43,18 +47,6 @@ const FileBrowser = ({ isOpen, onClose, onSelect, initialPath = '/' }: FileBrows
             loadDirectory(initialPath || '/');
         }
     }, [isOpen, initialPath, loadDirectory]);
-
-    // Handle keyboard events
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (!isOpen) return;
-            if (e.key === 'Escape') {
-                onClose();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [isOpen, onClose]);
 
     const handleSelect = () => {
         onSelect(currentPath);
@@ -84,18 +76,23 @@ const FileBrowser = ({ isOpen, onClose, onSelect, initialPath = '/' }: FileBrows
 
                 {/* Modal */}
                 <motion.div
+                    ref={dialogRef}
+                    tabIndex={-1}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="file-browser-title"
                     initial={{ opacity: 0, scale: 0.95, y: 20 }}
                     animate={{ opacity: 1, scale: 1, y: 0 }}
                     exit={{ opacity: 0, scale: 0.95, y: 20 }}
                     transition={{ duration: 0.2, ease: 'easeOut' }}
-                    className="relative bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-2xl w-full max-w-2xl max-h-[70vh] flex flex-col overflow-hidden"
+                    className="relative bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-2xl w-full max-w-2xl max-h-[70vh] flex flex-col overflow-hidden focus:outline-none"
                     onClick={(e) => e.stopPropagation()}
                 >
                     {/* Header */}
                     <div className="flex items-center justify-between px-6 py-4 border-b border-slate-200 dark:border-slate-800">
                         <div className="flex items-center gap-3">
                             <FolderOpen className="w-5 h-5 text-blue-500" />
-                            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Browse Directory</h2>
+                            <h2 id="file-browser-title" className="text-lg font-semibold text-slate-900 dark:text-white">Browse Directory</h2>
                         </div>
                         <button
                             onClick={onClose}

--- a/frontend/src/hooks/useModalA11y.test.tsx
+++ b/frontend/src/hooks/useModalA11y.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useModalA11y, getFocusableElements } from './useModalA11y';
+
+function Dialog({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+    const ref = useModalA11y(isOpen, onClose);
+    if (!isOpen) return null;
+    return (
+        <div ref={ref} tabIndex={-1} role="dialog" aria-label="test dialog">
+            <button>first</button>
+            <button>middle</button>
+            <button>last</button>
+        </div>
+    );
+}
+
+/** Append a child to `root` with optional attributes, using safe DOM methods. */
+function append(root: HTMLElement, tag: string, attrs: Record<string, string> = {}) {
+    const el = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    root.appendChild(el);
+    return el;
+}
+
+describe('getFocusableElements', () => {
+    it('returns focusable descendants and skips disabled/[-1]', () => {
+        const root = document.createElement('div');
+        append(root, 'button');                       // focusable
+        append(root, 'button', { disabled: '' });     // excluded (disabled)
+        append(root, 'a', { href: '#x' });            // focusable
+        append(root, 'input');                        // focusable
+        append(root, 'div', { tabindex: '-1' });      // excluded (tabindex=-1)
+        append(root, 'div', { tabindex: '0' });       // focusable
+
+        const tags = getFocusableElements(root).map((el) => el.tagName.toLowerCase());
+        expect(tags).toEqual(['button', 'a', 'input', 'div']);
+    });
+});
+
+describe('useModalA11y', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('moves focus to the first focusable element on open', () => {
+        render(<Dialog isOpen onClose={() => {}} />);
+        expect(document.activeElement).toBe(screen.getByText('first'));
+    });
+
+    it('closes on Escape', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        render(<Dialog isOpen onClose={onClose} />);
+        await user.keyboard('{Escape}');
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('traps Tab: wraps from last back to first', async () => {
+        const user = userEvent.setup();
+        render(<Dialog isOpen onClose={() => {}} />);
+        screen.getByText('last').focus();
+        await user.tab();
+        expect(document.activeElement).toBe(screen.getByText('first'));
+    });
+
+    it('traps Shift+Tab: wraps from first back to last', async () => {
+        const user = userEvent.setup();
+        render(<Dialog isOpen onClose={() => {}} />);
+        screen.getByText('first').focus();
+        await user.tab({ shift: true });
+        expect(document.activeElement).toBe(screen.getByText('last'));
+    });
+
+    it('restores focus to the previously focused element on close', () => {
+        const trigger = document.createElement('button');
+        trigger.textContent = 'opener';
+        document.body.appendChild(trigger);
+        trigger.focus();
+        expect(document.activeElement).toBe(trigger);
+
+        const { rerender } = render(<Dialog isOpen onClose={() => {}} />);
+        expect(document.activeElement).toBe(screen.getByText('first'));
+
+        rerender(<Dialog isOpen={false} onClose={() => {}} />);
+        expect(document.activeElement).toBe(trigger);
+    });
+
+    it('does nothing while closed', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        render(<Dialog isOpen={false} onClose={onClose} />);
+        await user.keyboard('{Escape}');
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * All focusable descendants of `container`, in DOM order.
+ */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])'
+        )
+    );
+}
+
+/**
+ * Accessibility wiring shared by modal dialogs. While `isOpen` is true it:
+ * - moves focus into the dialog (first focusable element, else the container)
+ * - traps Tab / Shift+Tab within the dialog
+ * - closes on Escape
+ * - restores focus to the previously-focused element when it closes/unmounts
+ *
+ * Attach the returned ref to the dialog container and give that element
+ * `tabIndex={-1}` so it can hold focus when it has no focusable children yet
+ * (e.g. while loading).
+ *
+ * `onClose` is read through a ref, so passing a fresh inline callback each
+ * render does not re-run the trap (which would clobber the saved focus target).
+ */
+export function useModalA11y<T extends HTMLElement = HTMLDivElement>(
+    isOpen: boolean,
+    onClose: () => void
+) {
+    const containerRef = useRef<T>(null);
+    const onCloseRef = useRef(onClose);
+    useEffect(() => {
+        onCloseRef.current = onClose;
+    });
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const previouslyFocused = document.activeElement as HTMLElement | null;
+        const container = containerRef.current;
+
+        // Move focus into the dialog.
+        const initial = container ? getFocusableElements(container) : [];
+        (initial[0] ?? container)?.focus();
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onCloseRef.current();
+                return;
+            }
+            if (e.key !== 'Tab' || !container) return;
+
+            const focusable = getFocusableElements(container);
+            if (focusable.length === 0) {
+                // Nothing focusable inside: keep focus pinned to the container.
+                e.preventDefault();
+                container.focus();
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            if (e.shiftKey && document.activeElement === first) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && document.activeElement === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            previouslyFocused?.focus?.();
+        };
+    }, [isOpen]);
+
+    return containerRef;
+}


### PR DESCRIPTION
## Summary

`ConfirmDialog` had a complete a11y story (role/aria, Tab focus trap, Escape, focus save/restore) but the other dialogs didn't:

- **RemediationJourney** — no `role="dialog"`/`aria-modal`, no `aria-labelledby`, no focus trap, no focus restore, and **no Escape handler at all** (backdrop click only).
- **FileBrowser** — same gaps; had Escape but nothing else.

## Change

- New shared hook **`useModalA11y(isOpen, onClose)`** + `getFocusableElements`, encapsulating: focus-into-dialog on open, Tab/Shift+Tab trap, Escape-to-close, focus restore on close.
  - `onClose` is read through a ref, so an inline callback doesn't re-run the trap and clobber the saved focus target.
  - `isOpen` gating supports both always-mounted (`FileBrowser`) and conditionally-mounted (`RemediationJourney`) modals.
- Applied to `RemediationJourney` and `FileBrowser` (added `role="dialog"`, `aria-modal`, `aria-labelledby`, `tabIndex={-1}` container).
- `ConfirmDialog` now imports the shared `getFocusableElements` (dedupe; its 17 tests still pass).
- `ConnectionOverlay` is a non-dismissible **status** overlay → `role="status"` + `aria-live="polite"` (not a focus trap); decorative backdrop marked `aria-hidden`.

## Test plan

- [x] New `useModalA11y.test.tsx` (7 tests): focusable-element filtering, initial focus, Escape, Tab + Shift+Tab wrap, focus restore on close, closed no-op
- [x] `ConfirmDialog.test.tsx` — 17 pass (shared-helper refactor safe)
- [x] `npm run lint` / `npm run typecheck` — clean
- [x] `npx vitest run` — 139 passed, 1 pre-existing skip
- [x] `npm run build` — succeeds