### PR TITLE
perf(scanner): make ScanProgress events volatile (Phase 6.1)

### DIFF
--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -70,27 +70,45 @@ func (eb *EventBus) Publish(event domain.Event) error {
 	}
 	event.ID = id
 
-	// 2. Publish to in-memory subscribers
+	// 2. Publish to in-memory subscribers. A dropped delivery here is not lost:
+	// the event is persisted, and the EventReplayService catches unprocessed
+	// CorruptionDetected events on restart (RecoveryService handles other stale items).
+	eb.dispatch(event)
+
+	return nil
+}
+
+// dispatch delivers an event to all in-memory subscribers for its type using a
+// non-blocking send. If a subscriber's buffer is full the delivery is dropped
+// (callers that persist first treat this as recoverable; volatile callers treat
+// a dropped ephemeral event as benign). Does not touch the database.
+func (eb *EventBus) dispatch(event domain.Event) {
 	eb.mu.RLock()
 	defer eb.mu.RUnlock()
 
-	if subscribers, ok := eb.subscribers[event.EventType]; ok {
-		for _, ch := range subscribers {
-			select {
-			case ch <- event:
-			default:
-				// Non-blocking send failed - buffer is full
-				// This is a warning condition: the event IS persisted to DB (so not lost),
-				// but the in-memory subscriber won't process it immediately.
-				// The EventReplayService will catch unprocessed CorruptionDetected events on restart.
-				// For other event types, RecoveryService handles stale items.
-				logger.Warnf("EventBus: subscriber buffer full for %s (%s) - event persisted to DB but in-memory delivery skipped",
-					event.AggregateID, event.EventType)
-			}
+	for _, ch := range eb.subscribers[event.EventType] {
+		select {
+		case ch <- event:
+		default:
+			logger.Warnf("EventBus: subscriber buffer full for %s (%s) - in-memory delivery skipped",
+				event.AggregateID, event.EventType)
 		}
 	}
+}
 
-	return nil
+// PublishVolatile delivers a high-frequency, in-memory-only event to subscribers
+// WITHOUT persisting it to the event store. Use it for ephemeral UI signals such
+// as ScanProgress that are never replayed or queried back: persisting one per
+// scanned file would add a synchronous, fsync'd INSERT to the scan hot path for
+// no durable benefit. Durable scan state still lives in the scans table.
+func (eb *EventBus) PublishVolatile(event domain.Event) {
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+	if event.EventVersion == 0 {
+		event.EventVersion = 1
+	}
+	eb.dispatch(event)
 }
 
 // PublishWithRetry publishes an event with retry logic for transient failures.
@@ -154,18 +172,7 @@ func (eb *EventBus) Subscribe(eventType domain.EventType, handler func(domain.Ev
 // without re-persisting to the database. Used by the event replay service to
 // deliver events that were persisted but not processed before a restart.
 func (eb *EventBus) RepublishToSubscribers(event domain.Event) error {
-	eb.mu.RLock()
-	defer eb.mu.RUnlock()
-
-	if subscribers, ok := eb.subscribers[event.EventType]; ok {
-		for _, ch := range subscribers {
-			select {
-			case ch <- event:
-			default:
-				logger.Warnf("Subscriber buffer full for replayed event %s (%s)", event.AggregateID, event.EventType)
-			}
-		}
-	}
+	eb.dispatch(event)
 	return nil
 }
 

--- a/internal/eventbus/eventbus_test.go
+++ b/internal/eventbus/eventbus_test.go
@@ -960,3 +960,46 @@ func TestRepublishToSubscribers_NoSubscribers(t *testing.T) {
 		t.Errorf("RepublishToSubscribers should not error with no subscribers: %v", err)
 	}
 }
+
+// TestEventBus_PublishVolatile_DeliversWithoutPersisting verifies that a volatile
+// event reaches in-memory subscribers but is never written to the event store.
+func TestEventBus_PublishVolatile_DeliversWithoutPersisting(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	eb := NewEventBus(db)
+	defer eb.Shutdown()
+
+	received := make(chan domain.Event, 1)
+	eb.Subscribe(domain.ScanProgress, func(e domain.Event) {
+		received <- e
+	})
+
+	eb.PublishVolatile(domain.Event{
+		AggregateType: "scan",
+		AggregateID:   "scan-1",
+		EventType:     domain.ScanProgress,
+		EventData:     map[string]interface{}{"files_done": 5},
+	})
+
+	// Delivered in-memory, with defaults filled in.
+	select {
+	case e := <-received:
+		if e.AggregateID != "scan-1" {
+			t.Errorf("AggregateID = %q, want scan-1", e.AggregateID)
+		}
+		if e.CreatedAt.IsZero() {
+			t.Error("expected CreatedAt to be set")
+		}
+		if e.EventVersion != 1 {
+			t.Errorf("EventVersion = %d, want 1", e.EventVersion)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber did not receive volatile event")
+	}
+
+	// But not persisted to the event store.
+	if n := countEventsByType(t, db, domain.ScanProgress); n != 0 {
+		t.Errorf("persisted ScanProgress events = %d, want 0", n)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1543,7 +1543,11 @@ func (s *ScannerService) emitProgress(p *ScanProgress) {
 	// event sees a consistent state; the publish happens outside the lock
 	// because Publish does I/O.
 	view := p.Snapshot()
-	if err := s.eventBus.Publish(domain.Event{
+	// Volatile: ScanProgress is an ephemeral UI signal consumed only by the
+	// WebSocket hub and the Prometheus gauge (both in-memory subscribers). It is
+	// never replayed or queried back, so we skip the per-file event-store INSERT.
+	// Durable progress is persisted separately via the scans row (UpdateProgress).
+	s.eventBus.PublishVolatile(domain.Event{
 		AggregateType: "scan",
 		AggregateID:   view.ID,
 		EventType:     domain.ScanProgress,
@@ -1558,9 +1562,7 @@ func (s *ScannerService) emitProgress(p *ScanProgress) {
 			"start_time":   view.StartTime,
 			"scan_db_id":   view.ScanDBID, // Database ID for frontend navigation
 		},
-	}); err != nil {
-		logger.Debugf("Failed to emit scan progress: %v", err)
-	}
+	})
 }
 
 // GetActiveScans returns race-free snapshots of all currently active scans.


### PR DESCRIPTION
## Summary

First of the Phase 6 scanner-performance series. `emitProgress` published a `ScanProgress` event **per scanned file** through `eventBus.Publish`, which persists to the `events` table first — a synchronous, `synchronous=FULL` fsync'd INSERT, on the scan's hot path. A 50k-file scan = 50k+ such INSERTs for state that's never read back.

`ScanProgress` has exactly two consumers, **both in-memory subscribers**:
- the WebSocket hub (`websocket.go:99`) — live UI push
- the Prometheus gauge (`metrics.go:241`)

It is **not** replayed (`EventReplayService` replays only `CorruptionDetected`) and **not** queried from the `events` table. Durable scan progress already lives in the `scans` row via `UpdateProgress`. Persisting `ScanProgress` was pure waste — and it inflated the `events` table that `LoadActiveCorruptionsForPath` correlation-scans at every scan start.

## Change

- Add `EventBus.PublishVolatile(event)` — delivers to in-memory subscribers **without** the DB write.
- Route `emitProgress` through it.
- Extract the subscriber fan-out into a shared `dispatch()` (now used by `Publish`, `PublishVolatile`, and `RepublishToSubscribers` — dedupes two copies of the non-blocking-send loop).

Live UI and metrics behavior unchanged; only the redundant persistence is removed.

## Impact

Eliminates ~1 fsync'd INSERT per file during scans (the dominant per-file DB write alongside the `scan_files` row). Also slows the growth of the `events` table, which compounds into faster `LoadActiveCorruptionsForPath` at scan start.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./internal/eventbus/... ./internal/services/...` — 0 issues
- [x] `go test ./internal/eventbus/ ./internal/services/` — pass
- [x] New `TestEventBus_PublishVolatile_DeliversWithoutPersisting`: subscriber receives the event (with defaults filled), `events` table count stays 0