### PR TITLE
fix(scanner): broadcast scan resume by closing the channel (Phase 6.2)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1064,6 +1064,7 @@ func (s *ScannerService) checkScanCancellation(ctx context.Context, progress *Sc
 func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProgress, localPath string, fileIndex int, scanDBID int64) scanLoopAction {
 	s.mu.Lock()
 	isPaused := progress.isPaused
+	resumeCh := progress.resumeChan
 	s.mu.Unlock()
 
 	if !isPaused {
@@ -1081,9 +1082,10 @@ func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProg
 		pauseCancel()
 	}
 
-	// Wait for resume or cancel
+	// Wait for resume or cancel. resumeCh was captured under the lock above;
+	// ResumeScan closes it to wake every waiter at once.
 	select {
-	case <-progress.resumeChan:
+	case <-resumeCh:
 		logger.Infof("Scan resumed: %s", localPath)
 		s.mu.Lock()
 		progress.Status = ScanStatusScanning
@@ -1626,6 +1628,12 @@ func (s *ScannerService) PauseScan(scanID string) error {
 		return fmt.Errorf("scan is not in scanning state: %s", scan.Status)
 	}
 
+	// Allocate a fresh resume channel for this pause. ResumeScan closes it to
+	// broadcast the wake-up; a previously-closed channel must not be reused (a
+	// closed channel would let handleScanPause fall straight through without
+	// pausing). A fresh channel per pause also lets multiple waiters (the future
+	// scan worker pool) all wake from one close.
+	scan.resumeChan = make(chan struct{})
 	scan.isPaused = true
 	scan.Status = "paused"
 	return nil
@@ -1645,13 +1653,16 @@ func (s *ScannerService) ResumeScan(scanID string) error {
 		return nil // Not paused
 	}
 
-	// Signal the scan goroutine to resume
-	select {
-	case scan.resumeChan <- struct{}{}:
-		// Successfully sent resume signal
-	default:
-		// Channel not ready, scan might already be resuming
-	}
+	// Clear paused state and broadcast resume by closing the channel. Closing
+	// (vs a non-blocking send) can't be "missed" if the scan goroutine has not
+	// yet reached handleScanPause — the old send-with-default could silently drop
+	// the signal and hang the scan paused — and it wakes every waiter at once.
+	// Setting isPaused here also makes a concurrent ResumeScan a no-op, so the
+	// channel is closed exactly once. Status is reset so a not-yet-blocked
+	// goroutine (which will skip handleScanPause) still reflects "scanning".
+	scan.isPaused = false
+	scan.Status = ScanStatusScanning
+	close(scan.resumeChan)
 
 	return nil
 }

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4295,3 +4295,81 @@ func TestScannerShutdownTimeout_NegativeFallsBackToDefault(t *testing.T) {
 		t.Errorf("scannerShutdownTimeout() with negative env = %v, want default %v", got, defaultShutdownTimeout)
 	}
 }
+
+// TestScannerService_ResumeScan_ClosesChannelForBroadcast verifies that resume
+// signals by CLOSING the channel rather than sending a single value. A close
+// wakes every current and future waiter at once and can't be missed — the
+// guarantee the parallel scan worker pool will depend on (the old send-based
+// signal woke only one waiter and could be silently dropped). It also checks
+// that each pause allocates a fresh, open channel so cycles work repeatedly.
+func TestScannerService_ResumeScan_ClosesChannelForBroadcast(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	scanner := &ScannerService{
+		db:              db,
+		activeScans:     make(map[string]*ScanProgress),
+		filesInProgress: make(map[string]bool),
+		shutdownCh:      make(chan struct{}),
+	}
+
+	progress := &ScanProgress{ID: "scan-bc", Path: "/media", Status: "scanning"}
+	scanner.mu.Lock()
+	scanner.activeScans["scan-bc"] = progress
+	scanner.mu.Unlock()
+
+	// First pause/resume cycle.
+	if err := scanner.PauseScan("scan-bc"); err != nil {
+		t.Fatalf("PauseScan: %v", err)
+	}
+	scanner.mu.Lock()
+	ch1 := progress.resumeChan
+	scanner.mu.Unlock()
+
+	if err := scanner.ResumeScan("scan-bc"); err != nil {
+		t.Fatalf("ResumeScan: %v", err)
+	}
+
+	// The channel must be CLOSED (broadcast), not merely sent-to: a receive
+	// returns immediately with ok=false. A send-based resume would yield ok=true
+	// once and then block any further waiter.
+	select {
+	case _, ok := <-ch1:
+		if ok {
+			t.Error("resume channel should be closed (broadcast), got a sent value")
+		}
+	default:
+		t.Error("resume channel was not closed by ResumeScan")
+	}
+
+	scanner.mu.Lock()
+	if progress.isPaused {
+		t.Error("isPaused should be false after resume")
+	}
+	if progress.Status != ScanStatusScanning {
+		t.Errorf("Status = %q, want scanning", progress.Status)
+	}
+	scanner.mu.Unlock()
+
+	// Second cycle: pause must allocate a FRESH, open channel (not reuse the
+	// closed one), otherwise a subsequent pause would never actually block.
+	if err := scanner.PauseScan("scan-bc"); err != nil {
+		t.Fatalf("second PauseScan: %v", err)
+	}
+	scanner.mu.Lock()
+	ch2 := progress.resumeChan
+	scanner.mu.Unlock()
+
+	if ch2 == ch1 {
+		t.Error("PauseScan reused the closed channel; expected a fresh one")
+	}
+	select {
+	case <-ch2:
+		t.Error("fresh resume channel should be open (block), but a receive succeeded")
+	default:
+		// Expected: open channel with no value yet.
+	}
+}


### PR DESCRIPTION
## Summary

Stage 1 of the staged scanner worker pool. `ResumeScan` signalled resume with a non-blocking send + `default` fallthrough:

```go
select {
case scan.resumeChan <- struct{}{}:
default: // signal dropped
}
```

Two problems:
1. **Lossy** — if the signal arrives before the scan goroutine reaches `handleScanPause`'s receive, it hits `default` and is silently dropped → the scan can hang paused.
2. **Single-waiter** — a send wakes only one goroutine. The upcoming parallel worker pool will have N workers each parked in `handleScanPause`; a send would wake one and deadlock the rest.

## Change

Close-based broadcast:
- `PauseScan` allocates a **fresh** `resumeChan` each pause (a closed channel can't be reused).
- `ResumeScan` clears `isPaused` and **closes** the channel — can't be missed, wakes every current and future waiter, and clearing the flag makes a concurrent `ResumeScan` a no-op so the close happens exactly once.
- `handleScanPause` captures the channel under the same lock that reads `isPaused`, avoiding a data race with `PauseScan` reallocating the field.

No behavior change for the current sequential scan (one waiter); it also fixes the latent lost-signal hang.

## Test plan

- [x] `go build ./...`; `golangci-lint run ./internal/services/...` — 0 issues
- [x] `go test -race` over the pause/resume suite — clean
- [x] `go test ./internal/services/` — pass
- [x] New `TestScannerService_ResumeScan_ClosesChannelForBroadcast`: asserts the channel is **closed** (`ok=false`), not sent-to, and that each pause allocates a fresh open channel

## Next in series

Stage 2: extract a pure `detectFile` function and add the bounded parallel worker pool with contiguous-prefix resume tracking + configurable worker count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanner pause and resume operation reliability with enhanced state management during scanning cycles.

* **Tests**
  * Added test coverage for scanner resume functionality to verify correct state transitions across multiple pause/resume cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->