### PR TITLE
refactor(scanner): extract pure detectFile (Phase 6.3, Stage 2a)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -328,7 +328,7 @@ type ScannerService struct {
 	scanPathCacheMu   sync.RWMutex
 	scanPathCacheTime time.Time
 
-	// sizeStabilityDelay is how long shouldSkipChangingSize waits before
+	// sizeStabilityDelay is how long isSizeChanging waits before
 	// re-stat'ing a file to detect an in-progress download. A field (default
 	// set by NewScannerService) so tests — which construct &ScannerService{}
 	// directly and leave it at the 0 zero-value — don't pay 500ms per file.
@@ -1113,52 +1113,43 @@ func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProg
 	}
 }
 
-// shouldSkipRecentlyModified checks if a file was modified too recently and should be skipped.
-// Returns true if file should be skipped (likely still being written).
-func (s *ScannerService) shouldSkipRecentlyModified(sfc *scanFileContext) bool {
-	if time.Since(sfc.fileMtime) < 2*time.Minute {
-		logger.Infof("Skipping recently modified file (mtime %v ago): %s",
-			time.Since(sfc.fileMtime).Round(time.Second), sfc.filePath)
-		if sfc.scanDBID > 0 {
-			if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
-				FilePath:       sfc.filePath,
-				Status:         "skipped",
-				CorruptionType: "RecentlyModified",
-				ErrorDetails:   "File modified within last 2 minutes - likely still being written",
-				FileSize:       sfc.fileSize,
-			}); err != nil {
-				logger.Debugf("Failed to record skipped file (recently modified): %v", err)
-			}
-		}
-		return true
-	}
-	return false
+// recentlyModifiedWindow is how fresh a file's mtime must be for the scanner to
+// treat it as "likely still being written" and skip it.
+const recentlyModifiedWindow = 2 * time.Minute
+
+// isRecentlyModified reports whether the file was modified within
+// recentlyModifiedWindow (likely still being written). Pure: no side effects.
+func isRecentlyModified(sfc *scanFileContext) bool {
+	return time.Since(sfc.fileMtime) < recentlyModifiedWindow
 }
 
-// shouldSkipChangingSize checks if file size is actively changing (download in progress).
-// Returns true if file should be skipped.
-func (s *ScannerService) shouldSkipChangingSize(sfc *scanFileContext) bool {
+// isSizeChanging reports whether the file's size changes across sizeStabilityDelay
+// — an active download/copy, even when the mtime is preserved (e.g. rsync
+// --times). Aside from the delay and a re-stat it has no side effects: no
+// database writes, no progress mutation, so it is safe to run concurrently.
+func (s *ScannerService) isSizeChanging(sfc *scanFileContext) bool {
 	time.Sleep(s.sizeStabilityDelay)
-	if info2, err := os.Stat(sfc.filePath); err == nil {
-		if info2.Size() != sfc.fileSize {
-			logger.Infof("Skipping file with changing size (download in progress?): %s", sfc.filePath)
-			if sfc.scanDBID > 0 {
-				if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
-					FilePath:       sfc.filePath,
-					Status:         "skipped",
-					CorruptionType: "SizeChanging",
-					ErrorDetails:   "File size changed during scan - active download/copy",
-					FileSize:       sfc.fileSize,
-				}); err != nil {
-					// scan_files rows drive the UI scan-detail screen; losing
-					// writes silently produces empty scan reports. Log loud.
-					logger.Errorf("Failed to record skipped file (size changing): %v", err)
-				}
-			}
-			return true
-		}
+	info2, err := os.Stat(sfc.filePath)
+	return err == nil && info2.Size() != sfc.fileSize
+}
+
+// recordSkipped writes a "skipped" row to scan_files. It is separated from the
+// skip decision (isRecentlyModified / isSizeChanging) so detection can run
+// concurrently — workers decide, the coordinator records sequentially. scan_files
+// rows drive the UI scan-detail screen, so a failed write is logged loudly.
+func (s *ScannerService) recordSkipped(sfc *scanFileContext, corruptionType, details string) {
+	if sfc.scanDBID <= 0 {
+		return
 	}
-	return false
+	if err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
+		FilePath:       sfc.filePath,
+		Status:         "skipped",
+		CorruptionType: corruptionType,
+		ErrorDetails:   details,
+		FileSize:       sfc.fileSize,
+	}); err != nil {
+		logger.Errorf("Failed to record skipped file (%s): %v", corruptionType, err)
+	}
 }
 
 // recordHealthyFile records a healthy file in the scan_files table.
@@ -1455,6 +1446,57 @@ func (s *ScannerService) buildScanFileContext(
 }
 
 // checkAndHandleFile performs safety checks and health verification for a file.
+// fileOutcome is the read-only verdict produced by detectFile.
+type fileOutcome int
+
+const (
+	outcomeHealthy fileOutcome = iota
+	outcomeUnhealthy
+	outcomeSkippedRecentlyModified
+	outcomeSkippedSizeChanging
+)
+
+// detectionResult is the read-only result of detecting one file.
+type detectionResult struct {
+	outcome   fileOutcome
+	healthErr *integration.HealthCheckError // populated only when outcomeUnhealthy
+}
+
+// detectFile performs all READ-ONLY detection for a single file: the stat-based
+// safety skips (recently modified, actively changing size) and health
+// verification (ffprobe, plus a content-analysis pass in thorough mode). It
+// performs no database writes and mutates no scan progress, so it is safe to run
+// concurrently across files — the seam the scan worker pool will parallelize.
+// The caller records the outcome and advances progress sequentially.
+func (s *ScannerService) detectFile(sfc *scanFileContext, cfg scanFilesConfig) detectionResult {
+	// SAFETY: recently modified files are likely still being written.
+	if isRecentlyModified(sfc) {
+		logger.Infof("Skipping recently modified file (mtime %v ago): %s",
+			time.Since(sfc.fileMtime).Round(time.Second), sfc.filePath)
+		return detectionResult{outcome: outcomeSkippedRecentlyModified}
+	}
+
+	// SAFETY: a file whose size is still changing is an active download/copy.
+	if s.isSizeChanging(sfc) {
+		logger.Infof("Skipping file with changing size (download in progress?): %s", sfc.filePath)
+		return detectionResult{outcome: outcomeSkippedSizeChanging}
+	}
+
+	healthy, healthErr := s.detector.CheckWithConfig(sfc.filePath, cfg.DetectionConfig)
+	if healthy && cfg.DetectionConfig.Mode == integration.ModeThorough {
+		// Thorough mode: structurally-healthy files get a content-analysis pass.
+		healthy, healthErr = s.detector.AnalyzeContent(sfc.filePath)
+	}
+	if healthy {
+		return detectionResult{outcome: outcomeHealthy}
+	}
+	return detectionResult{outcome: outcomeUnhealthy, healthErr: healthErr}
+}
+
+// checkAndHandleFile runs detection for a file and applies the outcome: it
+// records the scan_files row (or routes corruption to remediation) and advances
+// progress. Detection (detectFile) is read-only; the recording/handling here is
+// the sequential, stateful half.
 func (s *ScannerService) checkAndHandleFile(
 	ctx context.Context,
 	progress *ScanProgress,
@@ -1462,36 +1504,22 @@ func (s *ScannerService) checkAndHandleFile(
 	fileIndex int,
 	sfc *scanFileContext,
 ) scanLoopAction {
-	// SAFETY: Skip recently modified files (likely being written)
-	if s.shouldSkipRecentlyModified(sfc) {
-		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
-		return scanContinue
-	}
+	result := s.detectFile(sfc, cfg)
 
-	// SAFETY: Skip files with changing size (download in progress)
-	if s.shouldSkipChangingSize(sfc) {
-		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
-		return scanContinue
-	}
-
-	// Run health check
-	healthy, healthErr := s.detector.CheckWithConfig(sfc.filePath, cfg.DetectionConfig)
-
-	if healthy {
-		// In thorough mode, run content analysis on structurally healthy files
-		if cfg.DetectionConfig.Mode == integration.ModeThorough {
-			healthy, healthErr = s.detector.AnalyzeContent(sfc.filePath)
-			if !healthy {
-				return s.handleHealthCheckResult(ctx, progress, cfg, fileIndex, sfc, healthErr)
-			}
-		}
+	switch result.outcome {
+	case outcomeSkippedRecentlyModified:
+		s.recordSkipped(sfc, "RecentlyModified", "File modified within last 2 minutes - likely still being written")
+	case outcomeSkippedSizeChanging:
+		s.recordSkipped(sfc, "SizeChanging", "File size changed during scan - active download/copy")
+	case outcomeHealthy:
 		s.recordHealthyFile(sfc)
-		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
-		return scanContinue
+	case outcomeUnhealthy:
+		// handleHealthCheckResult marks the file processed itself and returns the action.
+		return s.handleHealthCheckResult(ctx, progress, cfg, fileIndex, sfc, result.healthErr)
 	}
 
-	// Handle the health check result
-	return s.handleHealthCheckResult(ctx, progress, cfg, fileIndex, sfc, healthErr)
+	s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
+	return scanContinue
 }
 
 // handleHealthCheckResult processes the result of a failed health check.

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -210,24 +210,11 @@ func TestScannerService_CheckScanCancellation(t *testing.T) {
 }
 
 func TestScannerService_ShouldSkipRecentlyModified(t *testing.T) {
-	db, err := testutil.NewTestDB()
-	if err != nil {
-		t.Fatalf("Failed to create test database: %v", err)
-	}
-	defer db.Close()
-
 	// Create a temp file
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.mkv")
 	if err := os.WriteFile(testFile, []byte("test content"), 0644); err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
-	}
-
-	scanner := &ScannerService{
-		db:              db,
-		activeScans:     make(map[string]*ScanProgress),
-		filesInProgress: make(map[string]bool),
-		shutdownCh:      make(chan struct{}),
 	}
 
 	t.Run("skips recently modified file", func(t *testing.T) {
@@ -238,7 +225,7 @@ func TestScannerService_ShouldSkipRecentlyModified(t *testing.T) {
 			scanDBID:  0,          // No DB recording for this test
 		}
 
-		if !scanner.shouldSkipRecentlyModified(sfc) {
+		if !isRecentlyModified(sfc) {
 			t.Error("Expected to skip recently modified file")
 		}
 	})
@@ -251,7 +238,7 @@ func TestScannerService_ShouldSkipRecentlyModified(t *testing.T) {
 			scanDBID:  0,
 		}
 
-		if scanner.shouldSkipRecentlyModified(sfc) {
+		if isRecentlyModified(sfc) {
 			t.Error("Expected not to skip old file")
 		}
 	})
@@ -1611,7 +1598,7 @@ func TestScannerService_ShouldSkipChangingSize(t *testing.T) {
 		}
 
 		// File is stable (not changing)
-		if scanner.shouldSkipChangingSize(sfc) {
+		if scanner.isSizeChanging(sfc) {
 			t.Error("Stable file should not be skipped")
 		}
 	})
@@ -3040,10 +3027,11 @@ func TestScannerService_ShouldSkipRecentlyModified_WithDBRecording(t *testing.T)
 			scanDBID:  scanDBID,
 		}
 
-		skipped := scanner.shouldSkipRecentlyModified(sfc)
+		skipped := isRecentlyModified(sfc)
 		if !skipped {
 			t.Error("Expected file to be skipped")
 		}
+		scanner.recordSkipped(sfc, "RecentlyModified", "File modified within last 2 minutes - likely still being written")
 
 		// Verify record was created in scan_files
 		var count int
@@ -3102,7 +3090,7 @@ func TestScannerService_ShouldSkipChangingSize_WithDBRecording(t *testing.T) {
 			scanDBID: scanDBID,
 		}
 
-		skipped := scanner.shouldSkipChangingSize(sfc)
+		skipped := scanner.isSizeChanging(sfc)
 		if skipped {
 			t.Error("Stable file should not be skipped")
 		}
@@ -3127,7 +3115,7 @@ func TestScannerService_ShouldSkipChangingSize_WithDBRecording(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			time.Sleep(200 * time.Millisecond)
-			// Append to file during the sleep period in shouldSkipChangingSize
+			// Append to file during the sleep period in isSizeChanging
 			f, err := os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
 			if err != nil {
 				return
@@ -3136,10 +3124,11 @@ func TestScannerService_ShouldSkipChangingSize_WithDBRecording(t *testing.T) {
 			f.Close()
 		}()
 
-		skipped := scanner.shouldSkipChangingSize(sfc)
+		skipped := scanner.isSizeChanging(sfc)
 		wg.Wait()
 
 		if skipped {
+			scanner.recordSkipped(sfc, "SizeChanging", "File size changed during scan - active download/copy")
 			// Verify record was created in scan_files
 			var count int
 			err := db.QueryRow(`
@@ -4372,4 +4361,73 @@ func TestScannerService_ResumeScan_ClosesChannelForBroadcast(t *testing.T) {
 	default:
 		// Expected: open channel with no value yet.
 	}
+}
+
+// TestScannerService_DetectFile covers the pure detection seam the scan worker
+// pool parallelizes: stat-based skips and health verification, with no DB writes
+// or progress mutation.
+func TestScannerService_DetectFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldMtime := time.Now().Add(-10 * time.Minute)
+	makeOldFile := func(name string) (string, int64) {
+		p := filepath.Join(tmpDir, name)
+		if err := os.WriteFile(p, []byte("content"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if err := os.Chtimes(p, oldMtime, oldMtime); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		info, _ := os.Stat(p)
+		return p, info.Size()
+	}
+
+	t.Run("recently modified is skipped before any health check", func(t *testing.T) {
+		// detector is nil: detectFile must return before reaching it.
+		s := &ScannerService{}
+		sfc := &scanFileContext{filePath: filepath.Join(tmpDir, "x.mkv"), fileMtime: time.Now(), fileSize: 7}
+		if got := s.detectFile(sfc, scanFilesConfig{}); got.outcome != outcomeSkippedRecentlyModified {
+			t.Errorf("outcome = %d, want outcomeSkippedRecentlyModified", got.outcome)
+		}
+	})
+
+	t.Run("changing size is skipped before any health check", func(t *testing.T) {
+		p, _ := makeOldFile("changing.mkv")
+		s := &ScannerService{} // sizeStabilityDelay zero; detector nil
+		// Recorded size differs from on-disk size => treated as still changing.
+		sfc := &scanFileContext{filePath: p, fileMtime: oldMtime, fileSize: 999999}
+		if got := s.detectFile(sfc, scanFilesConfig{}); got.outcome != outcomeSkippedSizeChanging {
+			t.Errorf("outcome = %d, want outcomeSkippedSizeChanging", got.outcome)
+		}
+	})
+
+	t.Run("healthy file", func(t *testing.T) {
+		p, size := makeOldFile("healthy.mkv")
+		s := &ScannerService{detector: &testutil.MockHealthChecker{
+			CheckWithConfigFunc: func(string, integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+				return true, nil
+			},
+		}}
+		sfc := &scanFileContext{filePath: p, fileMtime: oldMtime, fileSize: size}
+		if got := s.detectFile(sfc, scanFilesConfig{}); got.outcome != outcomeHealthy {
+			t.Errorf("outcome = %d, want outcomeHealthy", got.outcome)
+		}
+	})
+
+	t.Run("unhealthy file propagates the health error", func(t *testing.T) {
+		p, size := makeOldFile("corrupt.mkv")
+		wantErr := &integration.HealthCheckError{Type: "Corrupted", Message: "bad stream"}
+		s := &ScannerService{detector: &testutil.MockHealthChecker{
+			CheckWithConfigFunc: func(string, integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+				return false, wantErr
+			},
+		}}
+		sfc := &scanFileContext{filePath: p, fileMtime: oldMtime, fileSize: size}
+		got := s.detectFile(sfc, scanFilesConfig{})
+		if got.outcome != outcomeUnhealthy {
+			t.Errorf("outcome = %d, want outcomeUnhealthy", got.outcome)
+		}
+		if got.healthErr != wantErr {
+			t.Errorf("healthErr = %v, want the error returned by the detector", got.healthErr)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Stage 2a of the staged scanner worker pool: split per-file work into a **read-only detection half** and a **stateful recording half**, so detection can later run concurrently while recording/progress stays sequential. **No behavior change.**

## Change

- **`detectFile(sfc, cfg) -> detectionResult`**: runs the stat-based safety skips and health verification (ffprobe, + content-analysis pass in thorough mode) with **no DB writes and no progress mutation**. This is the seam the worker pool (Stage 2b) will parallelize.
- Extracted decision predicates **`isRecentlyModified`** / **`isSizeChanging`** and the **`recordSkipped`** helper. Removed the old `shouldSkipRecentlyModified` / `shouldSkipChangingSize`, which coupled decision + logging + recording.
- `checkAndHandleFile` now calls `detectFile` and applies the outcome (record skipped/healthy row, or route to `handleHealthCheckResult`) then `markFileProcessed`. Same control flow and side effects as before.

## Behavior preservation

Every path maps 1:1 to the old code: recently-modified → record skip + mark + continue; size-changing → record skip + mark + continue; healthy (incl. thorough analyze) → record healthy + mark + continue; unhealthy → `handleHealthCheckResult` (unchanged). Minor improvement: a failed skip-record now logs at error level for both skip types (was debug for one).

## Test plan

- [x] `go build ./...`; `golangci-lint run ./internal/services/...` — 0 issues
- [x] `go test ./internal/services/` — pass
- [x] Skip-path tests migrated to the pure predicates + `recordSkipped`
- [x] New `TestScannerService_DetectFile` covers all four outcomes (recently-modified, size-changing, healthy, unhealthy-with-error-propagation)

## Next

Stage 2b: bounded parallel worker pool around `detectFile`, with contiguous-prefix resume tracking and a configurable worker count (`-race` tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal file scanning and skip detection logic to separate detection from database recording operations.
  * Updated test suite to validate new detection components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->