### PR TITLE
perf(scanner): parallelize detection with a bounded worker pool (Phase 6.3, Stage 2b)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -333,11 +334,43 @@ type ScannerService struct {
 	// set by NewScannerService) so tests — which construct &ScannerService{}
 	// directly and leave it at the 0 zero-value — don't pay 500ms per file.
 	sizeStabilityDelay time.Duration
+
+	// scanWorkers is the number of files whose detection (ffprobe / stat
+	// stability check) runs concurrently within a scan. Set by
+	// NewScannerService from HEALARR_SCANNER_WORKERS. The 0 zero-value left by
+	// &ScannerService{}-direct test fixtures means "sequential", so those tests
+	// keep the original single-file-at-a-time path.
+	scanWorkers int
 }
 
 // defaultSizeStabilityDelay is the production re-stat interval for
 // detecting files whose size is still changing (active download/copy).
 const defaultSizeStabilityDelay = 500 * time.Millisecond
+
+// defaultScanWorkers is the default detection concurrency. ffprobe is the
+// dominant per-file cost and is I/O/CPU bound on the media file, so a small
+// pool gives most of the speed-up without overwhelming storage or *arr.
+const defaultScanWorkers = 4
+
+// maxScanWorkers caps operator-configured concurrency to avoid thrashing
+// storage or spawning an unreasonable number of ffprobe processes.
+const maxScanWorkers = 32
+
+// scannerWorkers returns the operator-configured detection concurrency from
+// HEALARR_SCANNER_WORKERS (clamped to [1, maxScanWorkers]), or
+// defaultScanWorkers if unset/invalid.
+func scannerWorkers() int {
+	if v := os.Getenv("HEALARR_SCANNER_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			if n > maxScanWorkers {
+				return maxScanWorkers
+			}
+			return n
+		}
+		logger.Warnf("Invalid HEALARR_SCANNER_WORKERS %q; using default %d", v, defaultScanWorkers)
+	}
+	return defaultScanWorkers
+}
 
 // NewScannerService creates a new ScannerService with the given dependencies.
 func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.HealthChecker, pm integration.PathMapper) *ScannerService {
@@ -350,6 +383,7 @@ func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.H
 		filesInProgress:    make(map[string]bool),
 		shutdownCh:         make(chan struct{}),
 		sizeStabilityDelay: defaultSizeStabilityDelay,
+		scanWorkers:        scannerWorkers(),
 	}
 	s.initRepositories()
 	return s
@@ -1355,6 +1389,14 @@ func (s *ScannerService) scanFiles(ctx context.Context, progress *ScanProgress, 
 	// PERFORMANCE: Preload active corruptions in a single query to avoid N+1 problem
 	activeCorruptions := s.LoadActiveCorruptionsForPath(progress.Path)
 
+	// With a worker pool configured, run detection concurrently. The 0/1 case
+	// (default for &ScannerService{}-direct test fixtures) keeps the original
+	// single-file-at-a-time path untouched.
+	if s.scanWorkers > 1 {
+		s.scanFilesParallel(ctx, progress, cfg, activeCorruptions)
+		return
+	}
+
 	for i := cfg.StartIndex; i < len(cfg.Files); i++ {
 		action := s.processFileInScan(ctx, progress, cfg, i, activeCorruptions)
 		if action == scanReturn {
@@ -1363,6 +1405,143 @@ func (s *ScannerService) scanFiles(ctx context.Context, progress *ScanProgress, 
 	}
 
 	progress.Status = "completed"
+}
+
+// detectJobState is the outcome of a worker's attempt to detect one file.
+type detectJobState int
+
+const (
+	jobPending      detectJobState = iota // worker did not complete (e.g. panic)
+	jobDone                               // detection ran; result is populated
+	jobDedupSkipped                       // another scan already holds this file
+	jobStopped                            // scan was canceling/shutting down
+)
+
+// detectJob carries one file's detection work across the fan-out/fan-in boundary.
+type detectJob struct {
+	sfc    *scanFileContext
+	result detectionResult
+	state  detectJobState
+}
+
+// scanFilesParallel processes files in ordered batches of scanWorkers. Within a
+// batch, the read-only detection (detectFile: stat checks + ffprobe) runs
+// concurrently across workers (fan-out); results are then applied strictly in
+// index order by this single goroutine (fan-in: recording, corruption routing,
+// progress). Because the fan-in is sequential and in order, the periodic
+// progress checkpoint stays monotonic and resume-after-interruption keeps its
+// "everything before the saved index is done" guarantee. Cancellation and pause
+// are handled at batch boundaries (and workers bail before an expensive
+// detection if the scan is already stopping).
+func (s *ScannerService) scanFilesParallel(
+	ctx context.Context,
+	progress *ScanProgress,
+	cfg scanFilesConfig,
+	activeCorruptions map[string]bool,
+) {
+	files := cfg.Files
+	pathID := progress.PathID
+
+	for start := cfg.StartIndex; start < len(files); {
+		if s.checkScanCancellation(ctx, progress, progress.Path, start, len(files)) == scanReturn {
+			return
+		}
+		if s.handleScanPause(ctx, progress, progress.Path, start, cfg.ScanDBID) == scanReturn {
+			return
+		}
+
+		end := start + s.scanWorkers
+		if end > len(files) {
+			end = len(files)
+		}
+
+		// Fan-out: detect each file in the batch concurrently. detectFile is
+		// read-only; the only shared state a worker mutates is filesInProgress
+		// (mutex-guarded), and each worker writes only its own jobs[k] element.
+		jobs := make([]detectJob, end-start)
+		var wg sync.WaitGroup
+		for k := range jobs {
+			idx := start + k
+			wg.Add(1)
+			safego.Run("scan-detect-worker", func() {
+				defer wg.Done()
+				s.detectInWorker(ctx, &jobs[k], files[idx], pathID, cfg, activeCorruptions)
+			})
+		}
+		wg.Wait()
+
+		// Fan-in: apply outcomes in index order, single-threaded.
+		for k := range jobs {
+			idx := start + k
+			switch jobs[k].state {
+			case jobDedupSkipped:
+				logger.Debugf("Skipping file already being scanned: %s", files[idx])
+				s.markFileProcessed(progress, idx, cfg.ScanDBID)
+			case jobStopped:
+				// Scan is canceling/shutting down: record the terminal status and stop.
+				s.checkScanCancellation(ctx, progress, progress.Path, idx, len(files))
+				return
+			case jobDone:
+				progress.mu.Lock()
+				progress.CurrentFile = files[idx]
+				progress.mu.Unlock()
+				s.emitProgress(progress)
+				if s.handleDetection(ctx, progress, cfg, idx, jobs[k].sfc, jobs[k].result) == scanReturn {
+					return
+				}
+			default: // jobPending — worker panicked mid-file; count it and move on.
+				logger.Warnf("Scan worker did not complete for %s; skipping", files[idx])
+				s.markFileProcessed(progress, idx, cfg.ScanDBID)
+			}
+		}
+
+		start = end
+	}
+
+	progress.Status = "completed"
+}
+
+// detectInWorker runs the read-only detection for a single file inside a worker
+// goroutine, recording the outcome into job. It holds the file in
+// filesInProgress only for the duration of detection (the expensive part) so an
+// overlapping scan won't double-detect it; recording happens later in the fan-in.
+func (s *ScannerService) detectInWorker(
+	ctx context.Context,
+	job *detectJob,
+	filePath string,
+	pathID int64,
+	cfg scanFilesConfig,
+	activeCorruptions map[string]bool,
+) {
+	// Dedup against overlapping scans (e.g. a webhook scan and a bulk scan).
+	s.filesMu.Lock()
+	if s.filesInProgress[filePath] {
+		s.filesMu.Unlock()
+		job.state = jobDedupSkipped
+		return
+	}
+	s.filesInProgress[filePath] = true
+	s.filesMu.Unlock()
+	defer func() {
+		s.filesMu.Lock()
+		delete(s.filesInProgress, filePath)
+		s.filesMu.Unlock()
+	}()
+
+	// Don't start an expensive detection if the scan is already stopping.
+	select {
+	case <-ctx.Done():
+		job.state = jobStopped
+		return
+	case <-s.shutdownCh:
+		job.state = jobStopped
+		return
+	default:
+	}
+
+	job.sfc = s.buildScanFileContext(filePath, pathID, cfg, activeCorruptions)
+	job.result = s.detectFile(job.sfc, cfg)
+	job.state = jobDone
 }
 
 // processFileInScan handles all processing for a single file during a scan.
@@ -1504,8 +1683,22 @@ func (s *ScannerService) checkAndHandleFile(
 	fileIndex int,
 	sfc *scanFileContext,
 ) scanLoopAction {
-	result := s.detectFile(sfc, cfg)
+	return s.handleDetection(ctx, progress, cfg, fileIndex, sfc, s.detectFile(sfc, cfg))
+}
 
+// handleDetection applies a detection outcome: it records the scan_files row (or
+// routes corruption to remediation) and advances progress. It is the stateful,
+// sequential half of file processing — detectFile is the read-only half. Kept
+// separate so the worker pool can run detection concurrently and feed results
+// here in scan order, preserving the single-threaded semantics resume relies on.
+func (s *ScannerService) handleDetection(
+	ctx context.Context,
+	progress *ScanProgress,
+	cfg scanFilesConfig,
+	fileIndex int,
+	sfc *scanFileContext,
+	result detectionResult,
+) scanLoopAction {
 	switch result.outcome {
 	case outcomeSkippedRecentlyModified:
 		s.recordSkipped(sfc, "RecentlyModified", "File modified within last 2 minutes - likely still being written")

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4431,3 +4431,107 @@ func TestScannerService_DetectFile(t *testing.T) {
 		}
 	})
 }
+
+// TestScannerService_ScanFilesParallel exercises the bounded worker-pool path
+// (scanWorkers > 1): it must record every file exactly once, in any order,
+// finish with an accurate FilesDone, and be free of data races. Run under
+// `go test -race` this guards the fan-out detection / ordered fan-in design.
+func TestScannerService_ScanFilesParallel(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckWithConfigFunc: func(string, integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+			return true, nil
+		},
+	}
+
+	scanner := &ScannerService{
+		db:              db,
+		eventBus:        eb,
+		detector:        mockHC,
+		activeScans:     make(map[string]*ScanProgress),
+		filesInProgress: make(map[string]bool),
+		shutdownCh:      make(chan struct{}),
+		scanWorkers:     4, // enable the parallel path
+	}
+
+	tmpDir := t.TempDir()
+	const n = 50
+	files := make([]string, n)
+	oldTime := time.Now().Add(-10 * time.Minute)
+	for i := 0; i < n; i++ {
+		f := filepath.Join(tmpDir, fmt.Sprintf("f%02d.mkv", i))
+		if err := os.WriteFile(f, []byte("content"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if err := os.Chtimes(f, oldTime, oldTime); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		files[i] = f
+	}
+
+	result, err := db.Exec(`
+		INSERT INTO scans (path, path_id, status, total_files, files_scanned)
+		VALUES (?, 1, 'running', ?, 0)
+	`, tmpDir, n)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	scanDBID, _ := result.LastInsertId()
+
+	progress := &ScanProgress{
+		ID:         "parallel-scan",
+		Type:       "path",
+		Path:       tmpDir,
+		PathID:     1,
+		TotalFiles: n,
+		ScanDBID:   scanDBID,
+		resumeChan: make(chan struct{}),
+	}
+
+	scanner.scanFiles(context.Background(), progress, scanFilesConfig{
+		Files:           files,
+		StartIndex:      0,
+		DetectionConfig: integration.DetectionConfig{Method: "ffprobe", Mode: "quick"},
+		ScanDBID:        scanDBID,
+	})
+
+	if progress.Status != "completed" {
+		t.Errorf("Status = %q, want completed", progress.Status)
+	}
+	if progress.FilesDone != n {
+		t.Errorf("FilesDone = %d, want %d", progress.FilesDone, n)
+	}
+
+	var healthy int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE scan_id = ? AND status = 'healthy'`, scanDBID).Scan(&healthy); err != nil {
+		t.Fatalf("count healthy: %v", err)
+	}
+	if healthy != n {
+		t.Errorf("healthy scan_files rows = %d, want %d", healthy, n)
+	}
+
+	// Each file recorded exactly once — no drops, no duplicates from the pool.
+	var distinct int
+	if err := db.QueryRow(`SELECT COUNT(DISTINCT file_path) FROM scan_files WHERE scan_id = ?`, scanDBID).Scan(&distinct); err != nil {
+		t.Fatalf("count distinct: %v", err)
+	}
+	if distinct != n {
+		t.Errorf("distinct files recorded = %d, want %d", distinct, n)
+	}
+
+	// filesInProgress must be fully drained after the scan.
+	scanner.filesMu.Lock()
+	leaked := len(scanner.filesInProgress)
+	scanner.filesMu.Unlock()
+	if leaked != 0 {
+		t.Errorf("filesInProgress leaked %d entries", leaked)
+	}
+}


### PR DESCRIPTION
## Summary

Stage 2b — the headline scanner-performance win. ffprobe (1–3s/file) ran strictly sequentially, so a large library took hours. This runs detection **concurrently** while keeping every stateful operation single-threaded.

## Design — fan-out detection, ordered fan-in handling

`scanFilesParallel` processes files in **ordered batches of `scanWorkers`**:
1. **Fan-out**: within a batch, the pure `detectFile` (stat skips + ffprobe, from Stage 2a) runs on one worker per file.
2. **Fan-in**: results are applied **strictly in index order** by the scan goroutine — record `scan_files`, route corruption, advance progress.

Because the fan-in is sequential and in order, the periodic progress checkpoint stays monotonic, so **resume-after-interruption keeps its "everything before the saved index is done" guarantee with zero extra bookkeeping**. Workers only touch `filesInProgress` (mutex-guarded) and read-only data, and each writes only its own job slot — minimal race surface.

## Safety

- **Concurrency**: `go test -race` on the new parallel test + the scan/pause/detect suite is clean.
- **Cancellation/pause**: handled at batch boundaries; workers also bail before an expensive detection if `ctx`/shutdown already fired. Pause is safe because the previous batch's workers have joined (`wg.Wait`) before the boundary check (and resume is the close-based broadcast from #225).
- **Opt-out**: `HEALARR_SCANNER_WORKERS` (default 4, clamped `[1,32]`). `0`/`1` keeps the **original sequential path verbatim** — which is also what `&ScannerService{}`-direct test fixtures get (zero-value), so existing tests are unchanged.
- **filesInProgress** is released per file after detection and verified fully drained post-scan.

## Test plan

- [x] `go build ./...`; `golangci-lint run ./internal/services/...` — 0 issues
- [x] `go test ./internal/services/` — pass
- [x] `go test -race` over scan/pause/detect paths — clean
- [x] New `TestScannerService_ScanFilesParallel` (workers=4, 50 files, `-race`): completed status, `FilesDone==50`, every file recorded exactly once (no drops/dups), `filesInProgress` drained

## Phase 6 status

Completes the scanner-perf series: 6.1 volatile events (#224), 6.2 resume broadcast (#225), 6.3 Stage 2a pure detectFile (#226) + Stage 2b worker pool (this).