### PR TITLE
refactor(integration): classify connection-lost mount errors by errno (Phase 7.1)

### DIFF
--- a/internal/integration/errno_unix.go
+++ b/internal/integration/errno_unix.go
@@ -32,6 +32,10 @@ func classifySyscallError(err error) (errorType string, message string) {
 		return ErrorTypeIOError, "I/O error"
 	case syscall.EHOSTDOWN, syscall.EHOSTUNREACH, syscall.ENETDOWN, syscall.ENETUNREACH:
 		return ErrorTypeMountLost, "network/host unreachable"
+	case syscall.ECONNREFUSED, syscall.ENOTCONN, syscall.ESHUTDOWN:
+		// "connection refused" / "transport endpoint is not connected" — a
+		// network filesystem (NFS/SMB/SSHFS) whose backing connection dropped.
+		return ErrorTypeMountLost, "connection lost (mount endpoint down)"
 	}
 
 	return "", ""

--- a/internal/integration/errno_unix_test.go
+++ b/internal/integration/errno_unix_test.go
@@ -118,6 +118,36 @@ func TestClassifySyscallError(t *testing.T) {
 			wantMessage: "network/host unreachable",
 		},
 		{
+			name: "ECONNREFUSED returns MountLost",
+			err: &fs.PathError{
+				Op:   "stat",
+				Path: "/test/path",
+				Err:  syscall.ECONNREFUSED,
+			},
+			wantType:    ErrorTypeMountLost,
+			wantMessage: "connection lost (mount endpoint down)",
+		},
+		{
+			name: "ENOTCONN returns MountLost",
+			err: &fs.PathError{
+				Op:   "read",
+				Path: "/test/path",
+				Err:  syscall.ENOTCONN,
+			},
+			wantType:    ErrorTypeMountLost,
+			wantMessage: "connection lost (mount endpoint down)",
+		},
+		{
+			name: "ESHUTDOWN returns MountLost",
+			err: &fs.PathError{
+				Op:   "read",
+				Path: "/test/path",
+				Err:  syscall.ESHUTDOWN,
+			},
+			wantType:    ErrorTypeMountLost,
+			wantMessage: "connection lost (mount endpoint down)",
+		},
+		{
 			name: "unknown syscall error returns empty",
 			err: &fs.PathError{
 				Op:   "stat",

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -408,7 +408,11 @@ func (hc *CmdHealthChecker) classifyOSError(err error, path string, isParent boo
 		}
 	}
 
-	// Check for common mount-related error messages
+	// Last-resort string match. classifySyscallError above already covers these
+	// conditions by errno (locale-independent); this catches the rare case where
+	// the error isn't a *fs.PathError wrapping a syscall.Errno (e.g. an error
+	// that lost its syscall identity through wrapping). Substring matching is
+	// locale-fragile, so it must remain the fallback, not the primary path.
 	errStr := strings.ToLower(err.Error())
 	if strings.Contains(errStr, "transport endpoint") ||
 		strings.Contains(errStr, "stale") ||
@@ -432,6 +436,11 @@ func (hc *CmdHealthChecker) classifyOSError(err error, path string, isParent boo
 // classifyDetectorError analyzes errors from ffprobe/mediainfo and classifies them appropriately.
 // This catches cases where files disappear between accessibility check and detector execution (race condition),
 // or where the detector sees different paths than Go's os.Stat (e.g., symlink resolution differences).
+//
+// Unlike classifyOSError, this MUST match on strings: the error here wraps a
+// subprocess's stderr text (ffprobe/mediainfo), not a Go syscall error, so there
+// is no errno to match. ffmpeg/ffprobe emit these messages in English regardless
+// of the host locale.
 func (hc *CmdHealthChecker) classifyDetectorError(err error, _ string) *HealthCheckError {
 	errStr := err.Error()
 


### PR DESCRIPTION
## Summary

First Phase 7 (architecture refinements) PR — robust, locale-independent error classification.

`classifyOSError` already prefers errno classification (`classifySyscallError`) over substring matching, but two network-filesystem conditions still fell through to the **locale-fragile string fallback**:
- `ECONNREFUSED` → `"connection refused"`
- `ENOTCONN` / `ESHUTDOWN` → `"transport endpoint is not connected"`

On a non-English host those substrings don't match, so a mount-lost condition (NFS/SMB/SSHFS connection dropped) would be **misclassified as a generic I/O error** — and routed differently (recoverable vs. mount-lost handling).

## Change

- Map `ECONNREFUSED` / `ENOTCONN` / `ESHUTDOWN` → `ErrorTypeMountLost` in `classifySyscallError` (errno-based, locale-independent).
- The string fallback in `classifyOSError` stays as a true last resort (for errors that lost their syscall identity through wrapping) — now documented as such.
- Documents why `classifyDetectorError` must remain string-based: it wraps ffprobe/mediainfo **subprocess stderr**, not a Go syscall error (no errno to match).

No behavior change on English hosts; correctness improvement elsewhere.

## Test plan

- [x] `go build ./...`; `golangci-lint run ./internal/integration/...` — 0 issues
- [x] `go test ./internal/integration/` — pass
- [x] New `classifySyscallError` cases for `ECONNREFUSED` / `ENOTCONN` / `ESHUTDOWN`

## Phase 7 plan

Next: same-package file splits for the god-files (`scanner.go` 2.2k lines, `notifier.go` 1.4k, `health_checker.go` 1k) and optional service-interface extraction — each zero-public-API-risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification and messaging for mount endpoint connectivity issues, providing clearer feedback when connection loss occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->