### PR TITLE
refactor(services): depend on eventbus.Publisher, not *EventBus (Phase 7.2)

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -367,9 +367,12 @@ func GetEventGroups() []EventGroup {
 
 // Notifier handles sending notifications based on events
 type Notifier struct {
-	db         *sql.DB
-	repo       *repository.NotificationRepository
-	eb         *eventbus.EventBus
+	db   *sql.DB
+	repo *repository.NotificationRepository
+	// eb is the Publisher interface, not *eventbus.EventBus: the notifier only
+	// subscribes and publishes, so depending on the interface keeps it decoupled
+	// from the concrete bus and testable with a mock publisher.
+	eb         eventbus.Publisher
 	configs    map[int64]*NotificationConfig
 	lastSent   map[int64]time.Time // Per-provider throttling
 	mu         sync.RWMutex
@@ -379,7 +382,7 @@ type Notifier struct {
 }
 
 // NewNotifier creates a new notifier service
-func NewNotifier(db *sql.DB, eb *eventbus.EventBus) *Notifier {
+func NewNotifier(db *sql.DB, eb eventbus.Publisher) *Notifier {
 	n := &Notifier{
 		db:         db,
 		repo:       repository.NewNotificationRepository(db),

--- a/internal/services/health_monitor.go
+++ b/internal/services/health_monitor.go
@@ -21,7 +21,7 @@ const queryTimeout = 10 * time.Second
 // HealthMonitorService monitors system health and detects stuck remediations
 type HealthMonitorService struct {
 	db         *sql.DB
-	eventBus   *eventbus.EventBus
+	eventBus   eventbus.Publisher
 	arrClient  integration.ArrClient
 	shutdownCh chan struct{}
 	wg         sync.WaitGroup
@@ -39,7 +39,7 @@ type HealthMonitorService struct {
 }
 
 // NewHealthMonitorService creates a new health monitoring service
-func NewHealthMonitorService(db *sql.DB, eb *eventbus.EventBus, arrClient integration.ArrClient, staleThreshold time.Duration) *HealthMonitorService {
+func NewHealthMonitorService(db *sql.DB, eb eventbus.Publisher, arrClient integration.ArrClient, staleThreshold time.Duration) *HealthMonitorService {
 	if staleThreshold <= 0 {
 		staleThreshold = 24 * time.Hour
 	}

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -16,7 +16,7 @@ import (
 
 // MonitorService handles failure events and schedules retries with exponential backoff.
 type MonitorService struct {
-	eventBus      *eventbus.EventBus
+	eventBus      eventbus.Publisher
 	db            *sql.DB
 	clk           clock.Clock
 	wg            sync.WaitGroup         // Tracks in-flight timer callbacks
@@ -28,7 +28,7 @@ type MonitorService struct {
 
 // NewMonitorService creates a new MonitorService.
 // An optional Clock can be provided for testing; if none is provided, RealClock is used.
-func NewMonitorService(eb *eventbus.EventBus, db *sql.DB, clocks ...clock.Clock) *MonitorService {
+func NewMonitorService(eb eventbus.Publisher, db *sql.DB, clocks ...clock.Clock) *MonitorService {
 	var c clock.Clock = clock.NewRealClock()
 	if len(clocks) > 0 && clocks[0] != nil {
 		c = clocks[0]

--- a/internal/services/recovery.go
+++ b/internal/services/recovery.go
@@ -21,7 +21,7 @@ const recoveryQueryTimeout = 30 * time.Second
 // with the actual state in *arr applications.
 type RecoveryService struct {
 	db         *sql.DB
-	eventBus   *eventbus.EventBus
+	eventBus   eventbus.Publisher
 	arrClient  integration.ArrClient
 	pathMapper integration.PathMapper
 	detector   integration.HealthChecker
@@ -30,7 +30,7 @@ type RecoveryService struct {
 }
 
 // NewRecoveryService creates a new recovery service.
-func NewRecoveryService(db *sql.DB, eb *eventbus.EventBus, arrClient integration.ArrClient, pathMapper integration.PathMapper, detector integration.HealthChecker, staleThreshold time.Duration) *RecoveryService {
+func NewRecoveryService(db *sql.DB, eb eventbus.Publisher, arrClient integration.ArrClient, pathMapper integration.PathMapper, detector integration.HealthChecker, staleThreshold time.Duration) *RecoveryService {
 	if staleThreshold <= 0 {
 		staleThreshold = 24 * time.Hour
 	}

--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -64,7 +64,7 @@ type VerificationMeta struct {
 
 // VerifierService monitors downloads and verifies replacement files after remediation.
 type VerifierService struct {
-	eventBus   *eventbus.EventBus
+	eventBus   eventbus.Publisher
 	detector   integration.HealthChecker
 	pathMapper integration.PathMapper
 	arrClient  integration.ArrClient
@@ -101,7 +101,7 @@ type VerifierService struct {
 
 // NewVerifierService creates a new VerifierService with the given dependencies.
 // An optional clock.Clock can be passed for testing; defaults to clock.RealClock.
-func NewVerifierService(eb *eventbus.EventBus, detector integration.HealthChecker, pm integration.PathMapper, arrClient integration.ArrClient, db *sql.DB, clocks ...clock.Clock) *VerifierService {
+func NewVerifierService(eb eventbus.Publisher, detector integration.HealthChecker, pm integration.PathMapper, arrClient integration.ArrClient, db *sql.DB, clocks ...clock.Clock) *VerifierService {
 	var c clock.Clock = clock.NewRealClock()
 	if len(clocks) > 0 && clocks[0] != nil {
 		c = clocks[0]


### PR DESCRIPTION
## Summary

Five services held a concrete `*eventbus.EventBus` but only ever called `Publish` / `PublishWithRetry` / `Subscribe` — all on the existing `eventbus.Publisher` interface. Depend on the interface instead (matching `RemediatorService`, which already does), decoupling them from the concrete bus and making them unit-testable with a mock publisher (`testutil.MockEventBus`).

**Converted:** `VerifierService`, `HealthMonitorService`, `MonitorService`, `RecoveryService`, `Notifier`.

Constructor signatures change `*eventbus.EventBus` → `eventbus.Publisher`; **call sites are unchanged** because `*EventBus` satisfies `Publisher`.

**Left concrete by necessity:** `EventReplayService` (`RepublishToSubscribers`) and `ScannerService` (`PublishVolatile`) call methods not on the `Publisher` interface.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run ./internal/services/... ./internal/notifier/...` — 0 issues
- [x] `go test ./internal/services/ ./internal/notifier/` — pass