### PR TITLE
ci: re-enable -race (fix db pool-stats test race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
         run: go mod download
 
       - name: Run tests with coverage
-        # Note: -race disabled due to pre-existing race conditions in test harness
-        # TODO: Fix race conditions in handlers_config_test.go, handlers_scans_test.go, handlers_webhook_test.go
-        run: go test -coverprofile=coverage.txt -covermode=atomic ./...
+        # -race guards the concurrent paths (scanner worker pool, event bus,
+        # background services). The previously-noted harness races are fixed.
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -4226,8 +4227,11 @@ func TestRepository_GetDatabaseStats_TableCounts(t *testing.T) {
 // Metrics tests
 // =============================================================================
 
-// mockMetricsRecorder is a test implementation of DBMetricsRecorder
+// mockMetricsRecorder is a test implementation of DBMetricsRecorder.
+// RecordDBPoolStats is invoked from StartPeriodicPoolStats' background goroutine
+// while tests read the counters, so all access is guarded by mu.
 type mockMetricsRecorder struct {
+	mu             sync.Mutex
 	queryCount     int
 	lastOperation  string
 	lastDuration   float64
@@ -4238,16 +4242,28 @@ type mockMetricsRecorder struct {
 }
 
 func (m *mockMetricsRecorder) RecordDBQuery(operation string, duration float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.queryCount++
 	m.lastOperation = operation
 	m.lastDuration = duration
 }
 
 func (m *mockMetricsRecorder) RecordDBPoolStats(openConns, inUse, idle int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.poolStatsCalls++
 	m.lastOpenConns = openConns
 	m.lastInUse = inUse
 	m.lastIdle = idle
+}
+
+// poolStatsCallCount returns poolStatsCalls under the lock, safe to call while
+// the background pool-stats goroutine is still recording.
+func (m *mockMetricsRecorder) poolStatsCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.poolStatsCalls
 }
 
 func TestRepository_SetMetrics(t *testing.T) {
@@ -4379,8 +4395,8 @@ func TestRepository_StartPeriodicPoolStats_WithMetrics(t *testing.T) {
 	// Wait for at least one report
 	time.Sleep(50 * time.Millisecond)
 
-	if mock.poolStatsCalls < 1 {
-		t.Errorf("Expected at least 1 pool stats call, got %d", mock.poolStatsCalls)
+	if got := mock.poolStatsCallCount(); got < 1 {
+		t.Errorf("Expected at least 1 pool stats call, got %d", got)
 	}
 }
 
@@ -4404,15 +4420,15 @@ func TestRepository_StartPeriodicPoolStats_Stop(t *testing.T) {
 
 	// Wait for at least one report
 	time.Sleep(30 * time.Millisecond)
-	initialCalls := mock.poolStatsCalls
+	initialCalls := mock.poolStatsCallCount()
 
 	// Stop and wait
 	stop()
 	time.Sleep(50 * time.Millisecond)
 
 	// Calls should stop increasing after stop()
-	if mock.poolStatsCalls > initialCalls+1 {
+	if got := mock.poolStatsCallCount(); got > initialCalls+1 {
 		t.Errorf("Pool stats calls should stop after stop(), got %d calls after %d initial",
-			mock.poolStatsCalls, initialCalls)
+			got, initialCalls)
 	}
 }


### PR DESCRIPTION
## Summary

CI ran `go test ./...` **without `-race`**, behind a stale TODO claiming pre-existing harness races in `handlers_config/scans/webhook`. Those were fixed in earlier phases. A package-by-package `-race` sweep is clean **everywhere except one real race** in the `db` package:

`mockMetricsRecorder`'s counters are written by `StartPeriodicPoolStats`' background goroutine (via `RecordDBPoolStats`) while the tests read `poolStatsCalls` directly — an unsynchronized mock.

## Change

- Guard `mockMetricsRecorder` with a `sync.Mutex`; tests read via a `poolStatsCallCount()` accessor.
- Re-enable `-race` in `ci.yml`: `go test -race -coverprofile=... ./...`.

Now CI catches concurrency regressions in the **scanner worker pool (#227)**, event bus, and background services — none of which were race-tested before.

## Test plan

- [x] `go build ./...`; `golangci-lint run ./internal/db/...` — 0 issues
- [x] Per-package `go test -race` **clean across the whole tree** (api, db, services, eventbus, integration, notifier, metrics, repository, auth, clock, domain, logger, safego, web)
- [x] **This PR's own CI run** is the definitive check — it executes `go test -race ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added race condition detection to the test suite for improved reliability.
  * Enhanced concurrency safety in test infrastructure to ensure robust testing across concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->