### PR TITLE
fix(integration): detector-error fail-safe — re-check accessibility before deleting

### DIFF
--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -437,11 +437,13 @@ func (hc *CmdHealthChecker) classifyOSError(err error, path string, isParent boo
 // This catches cases where files disappear between accessibility check and detector execution (race condition),
 // or where the detector sees different paths than Go's os.Stat (e.g., symlink resolution differences).
 //
-// Unlike classifyOSError, this MUST match on strings: the error here wraps a
-// subprocess's stderr text (ffprobe/mediainfo), not a Go syscall error, so there
-// is no errno to match. ffmpeg/ffprobe emit these messages in English regardless
-// of the host locale.
-func (hc *CmdHealthChecker) classifyDetectorError(err error, _ string) *HealthCheckError {
+// The known-infra cases are matched on strings: the error wraps a subprocess's
+// stderr text (ffprobe/mediainfo), not a Go syscall error, so there is no errno
+// to match. To stay locale-robust where it matters most, the fallthrough does
+// NOT blindly assume corruption (which would route to deletion) — it re-checks
+// accessibility first, so a mount that dropped mid-probe or any unrecognized
+// infra error is classified recoverable rather than as a corrupt file.
+func (hc *CmdHealthChecker) classifyDetectorError(err error, path string) *HealthCheckError {
 	errStr := err.Error()
 
 	// Check for path-related errors (file disappeared, wrong path, symlink issues)
@@ -482,7 +484,18 @@ func (hc *CmdHealthChecker) classifyDetectorError(err error, _ string) *HealthCh
 		}
 	}
 
-	// Default: treat as header/container corruption (the detector ran but found issues with the file content)
+	// Fallthrough: the detector exited non-zero but the message matched no known
+	// infra pattern. Before concluding the file is corrupt — which routes to the
+	// destructive remediation path — re-verify the file is actually accessible.
+	// If a mount dropped mid-probe (or the message was localized/unrecognized),
+	// accessibility now fails and we return that recoverable classification
+	// (errno-based, locale-independent) instead of deleting a healthy file.
+	if accessErr := hc.checkAccessibility(path); accessErr != nil {
+		return accessErr
+	}
+
+	// File is still accessible, so the detector's failure is about its content:
+	// treat as container/header corruption.
 	return &HealthCheckError{
 		Type:    ErrorTypeCorruptHeader,
 		Message: errStr,

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -312,6 +312,14 @@ func TestCmdHealthChecker_ClassifyOSError(t *testing.T) {
 func TestCmdHealthChecker_ClassifyDetectorError(t *testing.T) {
 	hc := NewHealthChecker()
 
+	// The generic/corruption fallthrough re-checks accessibility before
+	// concluding corruption, so use a real, accessible file as the path.
+	tmpDir := t.TempDir()
+	accessible := filepath.Join(tmpDir, "file.mkv")
+	if err := os.WriteFile(accessible, []byte("data"), 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
 	tests := []struct {
 		name         string
 		errorMsg     string
@@ -329,11 +337,29 @@ func TestCmdHealthChecker_ClassifyDetectorError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := &testDetectorError{msg: tt.errorMsg}
-			result := hc.classifyDetectorError(err, "/test/path")
+			result := hc.classifyDetectorError(err, accessible)
 			if result.Type != tt.expectedType {
 				t.Errorf("Expected %s, got %s", tt.expectedType, result.Type)
 			}
 		})
+	}
+}
+
+// TestCmdHealthChecker_ClassifyDetectorError_FailsafeOnInaccessible verifies the
+// safety property: an unrecognized detector error against a file that is no
+// longer accessible (e.g. a mount that dropped mid-probe) must NOT be classified
+// as corruption — corruption routes to the destructive remediation/deletion path.
+func TestCmdHealthChecker_ClassifyDetectorError_FailsafeOnInaccessible(t *testing.T) {
+	hc := NewHealthChecker()
+
+	err := &testDetectorError{msg: "some unrecognized ffprobe failure"}
+	result := hc.classifyDetectorError(err, "/nonexistent/path/file.mkv")
+
+	if result.Type == ErrorTypeCorruptHeader {
+		t.Fatalf("inaccessible file must not be classified as corruption (would delete a healthy file); got %s", result.Type)
+	}
+	if !result.IsRecoverable() {
+		t.Errorf("expected a recoverable classification for an inaccessible file, got %s (recoverable=%v)", result.Type, result.IsRecoverable())
 	}
 }
 


### PR DESCRIPTION
## Summary

`classifyDetectorError` defaulted **any unrecognized** ffprobe/mediainfo error to `ErrorTypeCorruptHeader` → `CategoryTrueCorruption` → the **destructive remediation/deletion path**. Fail-unsafe for a file-deleting app: a mount dropping mid-probe (or a stderr message matching none of the infra string patterns) would make a **healthy file eligible for deletion**.

## Change

Before concluding corruption, re-verify the file is accessible via `checkAccessibility` (errno-based, locale-independent — hardened in #228). If it's now inaccessible, return that **recoverable** classification (MountLost/PathNotFound) instead of CorruptHeader. The `path` arg (previously ignored as `_`) is now used. Genuine corruption — file still readable, bad content — is unchanged.

## Test plan
- [x] `go build ./...`; `golangci-lint run ./internal/integration/...` — 0 issues
- [x] `go test ./internal/integration/` — pass
- [x] New `FailsafeOnInaccessible` test: unrecognized error + missing path → recoverable, never CorruptHeader
- [x] Existing classify test updated to use a real accessible file for the corruption case