### PR TITLE
perf(db): synchronous=NORMAL with WAL (was FULL)

### DIFF
--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -119,9 +119,12 @@ func configureSQLite(db *sql.DB) error {
 
 	// Non-critical pragmas - log failures but continue
 	optionalPragmas := []string{
-		// Synchronous FULL ensures durability even on power loss during checkpoint
-		// Slightly slower than NORMAL but prevents corruption on unexpected shutdown
-		"PRAGMA synchronous=FULL",
+		// synchronous=NORMAL is the recommended setting with WAL: it is fully
+		// corruption-safe (WAL guarantees database integrity at NORMAL), and only
+		// risks losing the last committed transaction(s) on an OS crash / power
+		// loss — recoverable here since scans re-run and the event store replays.
+		// It avoids the per-commit fsync that FULL pays on the write-heavy scan path.
+		"PRAGMA synchronous=NORMAL",
 		// Auto-vacuum in incremental mode - reclaims space automatically
 		"PRAGMA auto_vacuum=INCREMENTAL",
 		// Store temp tables in memory for performance

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -550,19 +550,20 @@ func TestRepository_BackupIntegrityCheck(t *testing.T) {
 	}
 }
 
-func TestRepository_SynchronousFullMode(t *testing.T) {
+func TestRepository_SynchronousNormalMode(t *testing.T) {
 	repo, cleanup := setupTestDB(t)
 	defer cleanup()
 
-	// Verify synchronous mode is FULL (value 2)
+	// Verify synchronous mode is NORMAL: corruption-safe under WAL, and avoids
+	// the per-commit fsync that FULL pays on the write-heavy scan path.
 	var synchronous int
 	err := repo.DB.QueryRow("PRAGMA synchronous").Scan(&synchronous)
 	if err != nil {
 		t.Fatalf("Failed to query synchronous mode: %v", err)
 	}
 	// FULL = 2, NORMAL = 1, OFF = 0
-	if synchronous != 2 {
-		t.Errorf("Expected synchronous=2 (FULL), got %d", synchronous)
+	if synchronous != 1 {
+		t.Errorf("Expected synchronous=1 (NORMAL), got %d", synchronous)
 	}
 }
 


### PR DESCRIPTION
## Summary

The DB used `PRAGMA synchronous=FULL` with a comment claiming it *prevents corruption on unexpected shutdown*. That's a misconception: under **WAL, `synchronous=NORMAL` is equally corruption-safe** (WAL guarantees integrity at NORMAL). FULL only adds **durability of the last committed transaction(s)** on an OS/power crash — at the cost of an fsync on *every* commit.

For a media-health monitor that re-scans on schedule and replays its event store, losing the last few events on a rare power cut is recoverable. Switching to `NORMAL` (SQLite's recommended WAL pairing) removes the per-commit fsync on the write-heavy scan path.

| | FULL (old) | NORMAL (new) |
|---|---|---|
| DB corruption on power loss | never | never |
| Lose last txn(s) on power cut | no | possible (recoverable) |
| Per-commit fsync | yes | no (only at checkpoint) |

## Change
- `synchronous=FULL` → `synchronous=NORMAL`; corrected the misleading comment.
- Updated the pragma test to assert NORMAL (1).

## Test plan
- [x] `go build ./...`; `golangci-lint run ./internal/db/...` — 0 issues
- [x] `go test ./internal/db/` — pass