### PR TITLE
feat(api): security response headers (Phase 8 — P2)

### DIFF
--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -304,3 +304,22 @@ func TestGetRequestID_EmptyContext(t *testing.T) {
 	id := GetRequestID(context.Background())
 	assert.Empty(t, id)
 }
+
+// securityHeadersMiddleware tests
+
+func TestSecurityHeadersMiddleware_SetsHeaders(t *testing.T) {
+	router := gin.New()
+	router.Use(securityHeadersMiddleware())
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "SAMEORIGIN", w.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "no-referrer", w.Header().Get("Referrer-Policy"))
+}

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -164,6 +164,21 @@ func corsMiddleware(corsOrigins string, allowedOrigins map[string]bool) gin.Hand
 	}
 }
 
+// securityHeadersMiddleware sets defense-in-depth response headers on every
+// response (API and the served web UI):
+//   - X-Content-Type-Options: nosniff   — stop MIME-sniffing of responses
+//   - X-Frame-Options: SAMEORIGIN        — block cross-origin framing (clickjacking)
+//   - Referrer-Policy: no-referrer       — don't leak URLs to third parties
+func securityHeadersMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h := c.Writer.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "SAMEORIGIN")
+		h.Set("Referrer-Policy", "no-referrer")
+		c.Next()
+	}
+}
+
 // recoveryMiddleware handles panics with enhanced logging.
 func recoveryMiddleware() gin.HandlerFunc {
 	return gin.CustomRecovery(func(c *gin.Context, recovered interface{}) {
@@ -200,6 +215,7 @@ func NewRESTServer(deps ServerDeps) *RESTServer {
 
 	// Apply middleware
 	r.Use(requestIDMiddleware())
+	r.Use(securityHeadersMiddleware())
 	r.Use(metricsMiddleware(deps.Metrics))
 	r.Use(recoveryMiddleware())
 


### PR DESCRIPTION
## Summary

Adds a \`securityHeadersMiddleware\` setting defense-in-depth headers on every response (API + served web UI):
- \`X-Content-Type-Options: nosniff\`
- \`X-Frame-Options: SAMEORIGIN\`
- \`Referrer-Policy: no-referrer\`

Additive, non-breaking, registered early in the middleware chain.

## Why this is the only change

The P2 audit found the backend **solid after Phases 1–7**. Security headers were the one genuine, clean win. The other candidates were verified and deliberately **not** changed:

- **arr instance-name "precedence bug"** — intentional: the `Contains("-") && len>15` check detects auto-generated timestamp names (e.g. `sonarr-1234567890`) to regenerate them (see inline comment). Not a bug.
- **pagination reset-to-default on over-limit** — an established, **tested** API contract (3 handler tests assert `limit>max → default`). Changing it to cap-at-max would alter public behavior for marginal benefit. Left as-is.
- **request body size limit** — deferred: a blanket cap risks breaking the authenticated DB-restore upload; needs per-route nuance for low real risk.

## Test plan
- [x] `go build ./...`; `golangci-lint run ./internal/api/...` — 0 issues
- [x] `go test ./internal/api/` — pass
- [x] New `TestSecurityHeadersMiddleware_SetsHeaders`