### PR TITLE
docs: scanner config + v1.3.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-27
+
+### Added
+- **Parallel scanning**: file detection now runs across a small worker pool, so large libraries scan substantially faster. Tunable via `HEALARR_SCANNER_WORKERS` (default 4, range 1–32).
+- Configurable shutdown grace period for in-flight scans via `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` (default 30s).
+- Defense-in-depth HTTP security headers on all responses (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
+
+### Changed
+- Faster database writes during scans: SQLite now uses `synchronous=NORMAL` under WAL (still corruption-safe), and per-file scan-progress updates no longer hit the durable event store.
+
+### Fixed
+- **Files on a temporarily-unavailable mount or network share are no longer mistaken for corruption** — preventing deletion of healthy files when a mount drops mid-scan. Mount/network errors are now classified by OS error code, so this also holds on non-English systems.
+- Live log and scan-progress updates no longer drop messages under load (WebSocket delivery rework).
+- A paused scan could fail to resume if the resume signal raced with the scan loop; resume is now reliable.
+
+### Security
+- The authentication token is no longer written to the browser console on WebSocket connect.
+
 ## [1.3.0] - 2026-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ All configuration options can be set via environment variables or command-line f
 | `--stale-threshold` | `HEALARR_STALE_THRESHOLD` | `24h` | Auto-fix items Healarr lost track of |
 | `--arr-rate-limit` | `HEALARR_ARR_RATE_LIMIT_RPS` | `5` | Max requests/second to *arr APIs |
 | `--arr-rate-burst` | `HEALARR_ARR_RATE_LIMIT_BURST` | `10` | Burst size for rate limiting |
+| - | `HEALARR_SCANNER_WORKERS` | `4` | Files scanned in parallel per scan, clamped to 1–32 (env only) |
+| - | `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` | `30s` | Grace period for in-flight scans to finish on shutdown (env only) |
 | `--version` / `-v` | - | - | Print version and exit |
 
 **Examples:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       # - HEALARR_VERIFICATION_TIMEOUT=72h   # How long to wait for re-download
       # - HEALARR_DEFAULT_MAX_RETRIES=3      # Max remediation attempts
       # - HEALARR_TRUSTED_PROXIES=172.18.0.0/16  # Your reverse proxy subnet
+      # - HEALARR_SCANNER_WORKERS=4          # Files scanned in parallel (1-32)
+      # - HEALARR_SCANNER_SHUTDOWN_TIMEOUT=30s  # Grace period for in-flight scans on shutdown
 
       # Custom binary paths (optional - for newer ffmpeg/mediainfo/handbrake):
       # - HEALARR_FFPROBE_PATH=/config/tools/ffprobe


### PR DESCRIPTION
Documents HEALARR_SCANNER_WORKERS and HEALARR_SCANNER_SHUTDOWN_TIMEOUT (README + docker-compose), and adds the `## [1.3.1]` CHANGELOG section (user-facing changes since 1.3.0: parallel scanning, security headers, faster DB writes, mount-loss-not-corruption safety fix, WebSocket delivery fix, resume fix, token-not-logged). Docs only. CHANGELOG heading matches release.yml's extractor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel file scanning with configurable worker pool
  * Configurable scan shutdown timeout
  * Additional HTTP security headers

* **Changed**
  * Improved SQLite scan write performance
  * Reduced event-store pressure for per-file progress tracking

* **Bug Fixes**
  * Fixed incorrect file deletion from mount/network availability misclassification
  * Fixed WebSocket update delivery under load
  * Fixed scan resume reliability

* **Security**
  * Removed authentication token logging from browser console

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->