### PR TITLE
fix(notifications): surface real error on failed test (issue #143)

### DIFF
--- a/frontend/src/pages/config/NotificationsSection.tsx
+++ b/frontend/src/pages/config/NotificationsSection.tsx
@@ -176,7 +176,9 @@ const NotificationsSection = () => {
                 enabled: true,
                 throttle_seconds: 0,
             });
-            setTestResult(result);
+            // The failure reason comes back in `error`; surface it as `message`
+            // so the result box (which renders message) isn't blank on failure.
+            setTestResult({ success: result.success, message: result.message || result.error });
             if (result.success) {
                 toast.success('Test notification sent successfully!');
             } else {

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -130,10 +130,13 @@ func (s *RESTServer) testNotification(c *gin.Context) {
 	}
 
 	if err := s.notifier.SendTestNotification(&req); err != nil {
-		logger.Debugf("Test notification failed for provider %s: %v", req.ProviderType, err)
+		// Surface the real reason (e.g. "application token is invalid") so the
+		// admin can diagnose. This is an authenticated test of the user's own
+		// config; the shoutrrr error carries the provider's response, not secrets.
+		logger.Warnf("Test notification failed for provider %s: %v", req.ProviderType, err)
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
-			"error":   "Test notification failed",
+			"error":   err.Error(),
 		})
 		return
 	}


### PR DESCRIPTION
Fixes #143 (the actionable part).

**Bug:** Testing a notification (e.g. Pushover) fails with an empty error box — the user can't see *why*.

**Cause:** two layers swallowed the reason:
- Backend test handler logged the real error at `Debug` and returned a generic `"Test notification failed"`.
- Frontend stored the failure under `error` but the result box renders `message` → blank box.

**Fix:**
- Backend returns `err.Error()` (the shoutrrr/provider reason, e.g. "application token is invalid") and logs at `Warn`. It's an authenticated test of the user's own config; the error carries the provider response, not secrets.
- Frontend maps the failure `error` into `message` so the box renders it.

**Not fixed here:** the separate "priority/sound won't stick" report — those fields are defined and the URL builder applies them, so it needs reproduction; left noted on the issue.

Test plan: backend build+lint+tests pass; frontend typecheck/lint/build clean.