### PR TITLE
feat(scanner): memory-aware default worker count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] - 2026-05-27
 
 ### Added
-- **Parallel scanning**: file detection now runs across a small worker pool, so large libraries scan substantially faster. Tunable via `HEALARR_SCANNER_WORKERS` (default 4, range 1–32).
+- **Parallel scanning**: file detection now runs across a worker pool, so large libraries scan substantially faster. The default worker count is tuned to the memory available to the container so a constrained host won't be pushed into an out-of-memory kill; override with `HEALARR_SCANNER_WORKERS` (1 to 32).
 - Configurable shutdown grace period for in-flight scans via `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` (default 30s).
 - Defense-in-depth HTTP security headers on all responses (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Faster database writes during scans: SQLite now uses `synchronous=NORMAL` under WAL (still corruption-safe), and per-file scan-progress updates no longer hit the durable event store.
 
 ### Fixed
-- **Files on a temporarily-unavailable mount or network share are no longer mistaken for corruption** — preventing deletion of healthy files when a mount drops mid-scan. Mount/network errors are now classified by OS error code, so this also holds on non-English systems.
+- **Files on a temporarily-unavailable mount or network share are no longer mistaken for corruption**, preventing deletion of healthy files when a mount drops mid-scan. Mount/network errors are now classified by OS error code, so this also holds on non-English systems.
 - Live log and scan-progress updates no longer drop messages under load (WebSocket delivery rework).
 - A paused scan could fail to resume if the resume signal raced with the scan loop; resume is now reliable.
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ All configuration options can be set via environment variables or command-line f
 | `--stale-threshold` | `HEALARR_STALE_THRESHOLD` | `24h` | Auto-fix items Healarr lost track of |
 | `--arr-rate-limit` | `HEALARR_ARR_RATE_LIMIT_RPS` | `5` | Max requests/second to *arr APIs |
 | `--arr-rate-burst` | `HEALARR_ARR_RATE_LIMIT_BURST` | `10` | Burst size for rate limiting |
-| - | `HEALARR_SCANNER_WORKERS` | `4` | Files scanned in parallel per scan, clamped to 1–32 (env only) |
+| - | `HEALARR_SCANNER_WORKERS` | auto | Files scanned in parallel per scan. Default is tuned to available memory; set explicitly to override (1-32). env only |
 | - | `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` | `30s` | Grace period for in-flight scans to finish on shutdown (env only) |
 | `--version` / `-v` | - | - | Print version and exit |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # - HEALARR_VERIFICATION_TIMEOUT=72h   # How long to wait for re-download
       # - HEALARR_DEFAULT_MAX_RETRIES=3      # Max remediation attempts
       # - HEALARR_TRUSTED_PROXIES=172.18.0.0/16  # Your reverse proxy subnet
-      # - HEALARR_SCANNER_WORKERS=4          # Files scanned in parallel (1-32)
+      # - HEALARR_SCANNER_WORKERS=4          # Files scanned in parallel; default auto-tunes to memory (1-32)
       # - HEALARR_SCANNER_SHUTDOWN_TIMEOUT=30s  # Grace period for in-flight scans on shutdown
 
       # Custom binary paths (optional - for newer ffmpeg/mediainfo/handbrake):

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -347,18 +348,24 @@ type ScannerService struct {
 // detecting files whose size is still changing (active download/copy).
 const defaultSizeStabilityDelay = 500 * time.Millisecond
 
-// defaultScanWorkers is the default detection concurrency. ffprobe is the
-// dominant per-file cost and is I/O/CPU bound on the media file, so a small
-// pool gives most of the speed-up without overwhelming storage or *arr.
-const defaultScanWorkers = 4
+// fallbackScanWorkers is used only when available memory can't be determined.
+const fallbackScanWorkers = 4
 
 // maxScanWorkers caps operator-configured concurrency to avoid thrashing
 // storage or spawning an unreasonable number of ffprobe processes.
 const maxScanWorkers = 32
 
-// scannerWorkers returns the operator-configured detection concurrency from
-// HEALARR_SCANNER_WORKERS (clamped to [1, maxScanWorkers]), or
-// defaultScanWorkers if unset/invalid.
+// perWorkerMemoryBudget is the RAM we assume each concurrent detection worker may
+// need. ffprobe (quick mode) is light, but a thorough-mode ffmpeg decode of a
+// large file can use a few hundred MB. Budgeting generously means a small
+// container won't be pushed into an OOM kill by the default concurrency — each
+// extra worker is an extra subprocess counted against the container's cgroup limit.
+const perWorkerMemoryBudget = 512 * 1024 * 1024 // 512 MB
+
+// scannerWorkers returns the detection concurrency. HEALARR_SCANNER_WORKERS wins
+// if set (clamped to [1, maxScanWorkers]); otherwise the default is tuned to the
+// memory available to the process so a memory-constrained container doesn't OOM
+// from running several ffmpeg/ffprobe subprocesses at once.
 func scannerWorkers() int {
 	if v := os.Getenv("HEALARR_SCANNER_WORKERS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
@@ -367,9 +374,73 @@ func scannerWorkers() int {
 			}
 			return n
 		}
-		logger.Warnf("Invalid HEALARR_SCANNER_WORKERS %q; using default %d", v, defaultScanWorkers)
+		logger.Warnf("Invalid HEALARR_SCANNER_WORKERS %q; using a memory-aware default", v)
 	}
-	return defaultScanWorkers
+	return workersForMemory(availableMemoryBytes(), runtime.NumCPU())
+}
+
+// workersForMemory derives the worker count from a memory budget and CPU count.
+// Roughly memBytes/perWorkerMemoryBudget, capped by CPU count and maxScanWorkers,
+// floored at 1. If memBytes is 0 (unknown) it returns fallbackScanWorkers. Pure
+// function for testability.
+func workersForMemory(memBytes uint64, cpus int) int {
+	if cpus < 1 {
+		cpus = 1
+	}
+	if memBytes == 0 {
+		n := fallbackScanWorkers
+		if n > cpus {
+			n = cpus
+		}
+		return n
+	}
+	n := int(memBytes / perWorkerMemoryBudget)
+	if n > cpus {
+		n = cpus
+	}
+	if n > maxScanWorkers {
+		n = maxScanWorkers
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// availableMemoryBytes best-effort reports the memory ceiling the process runs
+// under: the container's cgroup memory limit when present, else total system
+// memory. Returns 0 when it can't be determined (e.g. non-Linux), so callers
+// fall back to a fixed default. Linux-specific paths simply don't exist
+// elsewhere, so this stays portable without build tags.
+func availableMemoryBytes() uint64 {
+	// cgroup v2: a single limit file, "max" means unlimited.
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
+		if s := strings.TrimSpace(string(b)); s != "max" {
+			if v, err := strconv.ParseUint(s, 10, 64); err == nil && v > 0 {
+				return v
+			}
+		}
+	}
+	// cgroup v1: "unlimited" is a near-max sentinel, so ignore implausibly large values.
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
+		if v, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil && v > 0 && v < (1<<62) {
+			return v
+		}
+	}
+	// Fallback: total system memory from /proc/meminfo (kB).
+	if b, err := os.ReadFile("/proc/meminfo"); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if kb, ok := strings.CutPrefix(line, "MemTotal:"); ok {
+				fields := strings.Fields(kb)
+				if len(fields) >= 1 {
+					if v, err := strconv.ParseUint(fields[0], 10, 64); err == nil {
+						return v * 1024
+					}
+				}
+			}
+		}
+	}
+	return 0
 }
 
 // NewScannerService creates a new ScannerService with the given dependencies.

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4535,3 +4535,56 @@ func TestScannerService_ScanFilesParallel(t *testing.T) {
 		t.Errorf("filesInProgress leaked %d entries", leaked)
 	}
 }
+
+// TestWorkersForMemory covers the memory-aware default worker count derivation.
+func TestWorkersForMemory(t *testing.T) {
+	const mb = 1024 * 1024
+	const gb = 1024 * mb
+	tests := []struct {
+		name string
+		mem  uint64
+		cpus int
+		want int
+	}{
+		{"unknown memory falls back (capped by cpu)", 0, 8, fallbackScanWorkers},
+		{"unknown memory capped by low cpu", 0, 2, 2},
+		{"512MB -> 1 worker", 512 * mb, 8, 1},
+		{"under one budget floors at 1", 256 * mb, 8, 1},
+		{"1GB -> 2 workers", 1 * gb, 8, 2},
+		{"2GB -> 4 workers", 2 * gb, 8, 4},
+		{"cpu count caps it", 64 * gb, 4, 4},
+		{"max caps very large boxes", 1024 * gb, 128, maxScanWorkers},
+		{"zero cpus treated as one", 8 * gb, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workersForMemory(tt.mem, tt.cpus); got != tt.want {
+				t.Errorf("workersForMemory(%d, %d) = %d, want %d", tt.mem, tt.cpus, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestScannerWorkers_EnvOverride verifies the env var wins over the memory-aware
+// default and is clamped, while invalid/unset values use the memory-aware path.
+func TestScannerWorkers_EnvOverride(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_WORKERS", "8")
+	if got := scannerWorkers(); got != 8 {
+		t.Errorf("explicit 8 = %d, want 8", got)
+	}
+
+	t.Setenv("HEALARR_SCANNER_WORKERS", "100")
+	if got := scannerWorkers(); got != maxScanWorkers {
+		t.Errorf("over-max = %d, want %d (clamped)", got, maxScanWorkers)
+	}
+
+	t.Setenv("HEALARR_SCANNER_WORKERS", "garbage")
+	if got := scannerWorkers(); got < 1 || got > maxScanWorkers {
+		t.Errorf("invalid value should fall back to a sane memory-aware default, got %d", got)
+	}
+
+	os.Unsetenv("HEALARR_SCANNER_WORKERS")
+	if got := scannerWorkers(); got < 1 || got > maxScanWorkers {
+		t.Errorf("unset should yield a sane memory-aware default, got %d", got)
+	}
+}


### PR DESCRIPTION
The parallel scan worker pool defaulted to a fixed **4** workers. Each worker can run an ffmpeg/ffprobe subprocess that, in thorough mode on a large file, uses a few hundred MB. On a memory-constrained container that fixed default can push the host into an OOM kill (the failure mode in #144), and it would have made that scenario worse than the old single-threaded scanner.

**Change:** derive the default from the memory available to the process. Read the cgroup memory limit (v2 then v1), fall back to `/proc/meminfo` total, and allow roughly one worker per 512 MB, capped by CPU count and 32, floored at 1. If memory can't be determined (e.g. non-Linux) fall back to 4. An explicit `HEALARR_SCANNER_WORKERS` still overrides.

Examples: 512 MB container -> 1 worker; 1 GB -> 2; 2 GB -> 4; large box -> capped by CPUs then 32.

`workersForMemory` is a pure function (fully unit-tested); `availableMemoryBytes` is best-effort and portable without build tags.

Docs (README, docker-compose, CHANGELOG) updated for the memory-aware default.

Test plan: build + lint clean; `go test ./internal/services/` passes; new `TestWorkersForMemory` and `TestScannerWorkers_EnvOverride`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel file scanning now automatically tunes worker count based on available container memory (configurable via `HEALARR_SCANNER_WORKERS`, range 1–32).

* **Bug Fixes**
  * Temporarily unavailable mounts and network shares are no longer incorrectly treated as corruption.
  * Added HTTP security headers.

* **Tests**
  * Added unit tests for memory-aware worker sizing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->