### PR TITLE
fix(remediation): never delete a healthy file; honor per-path auto_remediate/dry_run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Files on a temporarily-unavailable mount or network share are no longer mistaken for corruption**, preventing deletion of healthy files when a mount drops mid-scan. Mount/network errors are now classified by OS error code, so this also holds on non-English systems.
+- **Deletion now refuses to act on an ambiguous match.** If the corrupt file can't be identified unambiguously in the *arr media (for example two files share a name), or the owning *arr instance is misconfigured, the remediation fails and is retried instead of risking deletion of a healthy file. An exact path match is preferred, with a unique-basename match as the only fallback.
+- **Per-path `auto_remediate` and dry-run settings are now honored on retries and on startup recovery.** Previously a corruption re-triggered after a restart could delete a file on a path configured as manual or dry-run; the remediator now re-reads the path's current settings before acting.
 - Live log and scan-progress updates no longer drop messages under load (WebSocket delivery rework).
 - A paused scan could fail to resume if the resume signal raced with the scan loop; resume is now reliable.
 

--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -336,36 +337,35 @@ func (c *HTTPArrClient) getInstanceForPath(arrPath string) (*ArrInstance, error)
 		return nil, fmt.Errorf("failed to query instances: %w", err)
 	}
 
-	var bestMatch *ArrInstance
-	var longestPrefixLen int
-
-	for _, row := range rows {
+	// Pick the row with the longest matching path prefix: that instance is the
+	// rightful owner of this file. Validity is checked AFTER selecting, so an
+	// invalid best match errors out instead of silently routing the delete to a
+	// different (shorter-prefix) instance that does not own the file.
+	bestIdx := -1
+	longestPrefixLen := -1
+	for i, row := range rows {
 		if !isValidPathMatch(row.ArrPath, arrPath) {
 			continue
 		}
-
-		instance, err := arrInstanceFromRepo(row.ArrInstance)
-		if err != nil {
-			// Surfaces a bad row (typically a manual SQL insert with a
-			// typo'd type, or an undecryptable key) rather than silently
-			// producing "no instance found" downstream.
-			logger.Errorf("getInstanceForPath: skipping invalid instance: %v", err)
-			continue
-		}
-
-		pathLen := normalizedPathLength(row.ArrPath)
-		if pathLen > longestPrefixLen {
-			longestPrefixLen = pathLen
-			matched := instance
-			bestMatch = &matched
+		if l := normalizedPathLength(row.ArrPath); l > longestPrefixLen {
+			longestPrefixLen = l
+			bestIdx = i
 		}
 	}
 
-	if bestMatch == nil {
+	if bestIdx == -1 {
 		return nil, fmt.Errorf("no instance found for path: %s", arrPath)
 	}
 
-	return bestMatch, nil
+	instance, err := arrInstanceFromRepo(rows[bestIdx].ArrInstance)
+	if err != nil {
+		// The owning instance is misconfigured (e.g. undecryptable key). Refuse
+		// rather than route to a different instance, which could act on the
+		// wrong file.
+		return nil, fmt.Errorf("scan path for %s maps to a misconfigured *arr instance: %w", arrPath, err)
+	}
+
+	return &instance, nil
 }
 
 // isRetryableError checks if an error is a transient network error worth retrying
@@ -689,15 +689,46 @@ func (c *HTTPArrClient) getFilesForMedia(instance *ArrInstance, mediaID int64) (
 	return files, nil
 }
 
-// findFileIDByBasename finds a file ID by matching the basename of the path
-func findFileIDByBasename(files []genericFile, path string) int64 {
-	targetBase := filepath.Base(path)
+// errAmbiguousFileMatch is returned when more than one of an *arr media's files
+// share the target basename, so the correct file can't be identified with
+// confidence. The caller must NOT delete in that case.
+var errAmbiguousFileMatch = errors.New("ambiguous file match in *arr media; refusing to delete to avoid removing a healthy file")
+
+// findFileID resolves which of an *arr media's files corresponds to path. It is
+// deliberately conservative because a wrong answer deletes a healthy file:
+//   - First it requires an exact full-path match (unambiguous).
+//   - Failing that it accepts a UNIQUE basename match, which covers container
+//     path-mapping (Healarr's mount prefix differs from the *arr's) where the
+//     full paths differ but the filename is the same.
+//   - If multiple files share the basename it returns errAmbiguousFileMatch so
+//     the caller refuses to delete rather than guess.
+//
+// Returns (0, nil) when nothing matches (the file isn't tracked in this media).
+func findFileID(files []genericFile, path string) (int64, error) {
+	// 1. Exact full-path match.
 	for _, f := range files {
-		if filepath.Base(f.Path) == targetBase {
-			return f.ID
+		if f.Path == path {
+			return f.ID, nil
 		}
 	}
-	return 0
+	// 2. Unique basename match.
+	targetBase := filepath.Base(path)
+	var id int64
+	matches := 0
+	for _, f := range files {
+		if filepath.Base(f.Path) == targetBase {
+			id = f.ID
+			matches++
+		}
+	}
+	switch {
+	case matches == 1:
+		return id, nil
+	case matches > 1:
+		return 0, fmt.Errorf("%w: %d files share basename %q", errAmbiguousFileMatch, matches, targetBase)
+	default:
+		return 0, nil
+	}
 }
 
 // collectEpisodeMetadata fetches episode IDs for a given file ID in Sonarr/Whisparr
@@ -808,8 +839,12 @@ func (c *HTTPArrClient) DeleteFile(mediaID int64, path string) (map[string]inter
 		return nil, err
 	}
 
-	// Find file ID by basename
-	fileID := findFileIDByBasename(files, path)
+	// Resolve which file to delete. Refuse on an ambiguous match: deleting the
+	// wrong file would remove a healthy one and leave the corrupt file in place.
+	fileID, err := findFileID(files, path)
+	if err != nil {
+		return nil, err
+	}
 	if fileID == 0 {
 		return c.handleFileNotInArr(instance, mediaID, path)
 	}

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -4805,20 +4805,19 @@ func TestHTTPArrClient_GetFilePath_UnsupportedType(t *testing.T) {
 	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/other', '/other', 1, 0, 0)`)
 
 	_, err := client.GetFilePath(0, nil, "/other/file.mkv")
-	// With ArrType being a validated typed enum, the DB row with type='unknown'
-	// is now rejected at row-scan time by ArrType.Scan (visible in the Errorf
-	// log line we added). The row is skipped, so the caller sees "no instance
-	// found" rather than reaching the unsupported-type switch downstream.
-	// This is a stronger guarantee: invalid types never reach business logic.
+	// The scan path maps to instance 1, whose type is invalid. getInstanceForPath
+	// now selects the longest-prefix-matching instance and validates it, so an
+	// invalid owning instance surfaces as a "misconfigured" error (wrapping the
+	// "unknown ArrType" reason) rather than silently being skipped and routed
+	// elsewhere or reported as "no instance found". Invalid types never reach
+	// business logic, and we never act on a different instance.
 	if err == nil {
 		t.Error("Expected error for unknown arr type")
 	} else {
 		msg := err.Error()
-		// Accept either the new "no instance found" (post-scan-rejection) or
-		// the historical "unsupported" message if the path is ever refactored
-		// to validate type later instead of at scan.
-		if !strings.Contains(msg, "unsupported") && !strings.Contains(msg, "no instance found") {
-			t.Errorf("expected error indicating unknown ArrType (either pre-scan reject or post-switch), got: %v", err)
+		if !strings.Contains(msg, "misconfigured") && !strings.Contains(msg, "unknown ArrType") &&
+			!strings.Contains(msg, "unsupported") && !strings.Contains(msg, "no instance found") {
+			t.Errorf("expected error indicating the unknown/misconfigured ArrType, got: %v", err)
 		}
 	}
 }
@@ -6278,4 +6277,54 @@ func TestHTTPArrClient_GetSeriesDetails_InvalidJSON(t *testing.T) {
 	if details != nil {
 		t.Error("Expected nil details for invalid JSON")
 	}
+}
+
+// TestFindFileID covers the deletion-safety matching: it must never resolve to a
+// file ambiguously, since a wrong match deletes a healthy file.
+func TestFindFileID(t *testing.T) {
+	files := []genericFile{
+		{ID: 1, Path: "/data/tv/Show/Season 01/ep01.mkv"},
+		{ID: 2, Path: "/data/tv/Show/Season 01/ep02.mkv"},
+		{ID: 3, Path: "/data/tv/Show/Season 02/ep01.mkv"}, // basename collides with ID 1
+	}
+
+	t.Run("exact full-path match", func(t *testing.T) {
+		id, err := findFileID(files, "/data/tv/Show/Season 01/ep02.mkv")
+		if err != nil || id != 2 {
+			t.Fatalf("got (%d, %v), want (2, nil)", id, err)
+		}
+	})
+
+	t.Run("unique basename match across a different mount prefix", func(t *testing.T) {
+		// Healarr's path differs from the *arr's by mount prefix; ep02.mkv is unique.
+		id, err := findFileID(files, "/mnt/media/tv/Show/Season 01/ep02.mkv")
+		if err != nil || id != 2 {
+			t.Fatalf("got (%d, %v), want (2, nil)", id, err)
+		}
+	})
+
+	t.Run("ambiguous basename refuses (no exact match)", func(t *testing.T) {
+		// ep01.mkv exists in two seasons; with no exact path match this must refuse.
+		id, err := findFileID(files, "/mnt/media/tv/Show/Season 01/ep01.mkv")
+		if !errors.Is(err, errAmbiguousFileMatch) {
+			t.Fatalf("got (%d, %v), want errAmbiguousFileMatch", id, err)
+		}
+		if id != 0 {
+			t.Errorf("ambiguous match must return id 0 (no deletion), got %d", id)
+		}
+	})
+
+	t.Run("exact match wins over a colliding basename", func(t *testing.T) {
+		id, err := findFileID(files, "/data/tv/Show/Season 02/ep01.mkv")
+		if err != nil || id != 3 {
+			t.Fatalf("got (%d, %v), want (3, nil)", id, err)
+		}
+	})
+
+	t.Run("no match returns zero, no error", func(t *testing.T) {
+		id, err := findFileID(files, "/data/tv/Other/ep99.mkv")
+		if err != nil || id != 0 {
+			t.Fatalf("got (%d, %v), want (0, nil)", id, err)
+		}
+	})
 }

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -32,6 +32,7 @@ type RemediatorService struct {
 	pathMapper  integration.PathMapper
 	db          *sql.DB
 	corruptions *repository.CorruptionRepository
+	scanPaths   *repository.ScanPathRepository
 	semaphore   chan struct{} // limits concurrent remediations
 	// Lifecycle management
 	wg         sync.WaitGroup
@@ -52,8 +53,35 @@ func NewRemediatorService(eb eventbus.Publisher, arr integration.ArrClient, pm i
 	}
 	if db != nil {
 		r.corruptions = repository.NewCorruptionRepository(db)
+		r.scanPaths = repository.NewScanPathRepository(db)
 	}
 	return r
+}
+
+// remediatorQueryTimeout bounds the scan-path config lookup done before remediating.
+const remediatorQueryTimeout = 10 * time.Second
+
+// resolveRemediationPolicy returns the AUTHORITATIVE auto-remediate and dry-run
+// settings for a corruption, read from the scan path's current config rather than
+// the triggering event. The event payload is not trustworthy for this decision:
+// recovery and monitor retries hardcode auto_remediate=true (and omit dry_run),
+// and an operator may have flipped a path to manual or dry-run since the scan was
+// queued. On any doubt (no path id, path deleted, lookup error) it refuses to
+// auto-remediate, so we never delete a file without a clear, current opt-in.
+func (r *RemediatorService) resolveRemediationPolicy(pathID int64, evtAuto, evtDry bool) (autoRemediate, dryRun bool) {
+	if pathID <= 0 || r.scanPaths == nil {
+		// Legacy/edge events without a path id: honor only what the event itself
+		// claimed (never invent consent), and keep dry-run if it asked for it.
+		return evtAuto, evtDry
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	sp, err := r.scanPaths.GetByID(ctx, pathID)
+	if err != nil {
+		logger.Warnf("Remediation: cannot load scan path %d; refusing to auto-remediate (safe default): %v", pathID, err)
+		return false, evtDry
+	}
+	return sp.AutoRemediate, sp.DryRun
 }
 
 // Start subscribes to corruption and retry events to begin remediation handling.
@@ -267,13 +295,20 @@ func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {
 		logger.Errorf("Failed to publish RemediationQueued event: %v", err)
 	}
 
+	// Re-read the path's CURRENT auto-remediate / dry-run from the database. The
+	// event payload is not authoritative (recovery/monitor retries hardcode
+	// auto_remediate=true and drop dry_run, and the operator may have changed the
+	// setting), so deciding deletion from it could delete files on a manual-mode
+	// or dry-run path. This is the single enforcement point for both.
+	autoRemediate, dryRun := r.resolveRemediationPolicy(data.PathID, data.AutoRemediate, data.DryRun)
+
 	// Check for auto-remediation
-	if !data.AutoRemediate {
+	if !autoRemediate {
 		return
 	}
 
 	// Check for global dry-run mode override
-	dryRun := data.DryRun || config.Get().DryRunMode
+	dryRun = dryRun || config.Get().DryRunMode
 
 	if dryRun {
 		logger.Infof("Auto-remediation enabled for %s, but DRY-RUN mode is set for this path", data.FilePath)

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"os"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/integration"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/testutil"
 )
 
@@ -1758,5 +1760,57 @@ func TestRemediatorService_ExecuteDryRun_PublishesQueuedEvent(t *testing.T) {
 		if !ok || !dryRun {
 			t.Error("Expected dry_run=true in event data")
 		}
+	}
+}
+
+// TestRemediator_ResolveRemediationPolicy_RespectsCurrentPathConfig verifies the
+// consent/dry-run fix: the remediator decides auto-remediate and dry-run from the
+// scan path's CURRENT config, not the event payload. This is what prevents a
+// recovery/monitor retry (which hardcodes auto_remediate=true and drops dry_run)
+// from deleting a file on a manual-mode or dry-run path.
+func TestRemediator_ResolveRemediationPolicy_RespectsCurrentPathConfig(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test DB: %v", err)
+	}
+	defer db.Close()
+
+	repo := repository.NewScanPathRepository(db)
+	ctx := context.Background()
+	manualID, err := repo.Create(ctx, repository.ScanPathFields{
+		LocalPath: "/media/manual", ArrPath: "/data/manual", Enabled: true,
+		AutoRemediate: false, DryRun: false,
+		DetectionMethod: "ffprobe", DetectionMode: "quick", MaxRetries: 3,
+	})
+	if err != nil {
+		t.Fatalf("create manual path: %v", err)
+	}
+	dryID, err := repo.Create(ctx, repository.ScanPathFields{
+		LocalPath: "/media/dry", ArrPath: "/data/dry", Enabled: true,
+		AutoRemediate: true, DryRun: true,
+		DetectionMethod: "ffprobe", DetectionMode: "quick", MaxRetries: 3,
+	})
+	if err != nil {
+		t.Fatalf("create dry path: %v", err)
+	}
+
+	r := NewRemediatorService(testutil.NewMockEventBus(), &testutil.MockArrClient{}, &testutil.MockPathMapper{}, db)
+
+	// Manual path: event claims auto_remediate=true (as recovery hardcodes), but the
+	// live config says false, so we must NOT auto-remediate.
+	if auto, _ := r.resolveRemediationPolicy(manualID, true, false); auto {
+		t.Error("manual-mode path must not auto-remediate even when the event claims true")
+	}
+	// Dry-run path: live dry_run=true wins even though the (retry) event omits it.
+	if auto, dry := r.resolveRemediationPolicy(dryID, true, false); !auto || !dry {
+		t.Errorf("dry-run path: got auto=%v dry=%v, want auto=true dry=true", auto, dry)
+	}
+	// Unknown/deleted path: refuse to auto-remediate (safe default).
+	if auto, _ := r.resolveRemediationPolicy(999999, true, false); auto {
+		t.Error("unknown path must not auto-remediate")
+	}
+	// Legacy event without a path id: fall back to what the event claimed.
+	if auto, dry := r.resolveRemediationPolicy(0, true, true); !auto || !dry {
+		t.Errorf("pathID=0 fallback: got auto=%v dry=%v, want true/true", auto, dry)
 	}
 }


### PR DESCRIPTION
Two safety fixes to the destructive remediation path, prompted by reviewing whether standard remediation can misfire.

## 1. Never delete on an ambiguous match
`DeleteFile` matched the *arr file by **basename, first hit**, so a basename collision (two files named the same in different seasons/editions) or `FindMediaByPath` resolving to the wrong media could make *arr delete a **healthy** file. `findFileID` now:
- prefers an **exact full-path match**,
- accepts a **unique basename match** (covers Docker path-mapping where Healarr's mount prefix differs from the *arr's),
- **refuses** (errors, surfaced as a retry) when the basename is ambiguous.

`getInstanceForPath` no longer silently routes a deletion to a different (shorter-prefix) instance when the rightful owner is misconfigured; it errors.

Note: Healarr never deletes media from the filesystem itself; deletion is always via the *arr API. A path-mapping mismatch makes a delete **fail safe** (no-op or error), it cannot make us `unlink` a file directly.

## 2. Consent / dry-run bypass on retry & recovery
`handleCorruptionDetected` trusted `auto_remediate`/`dry_run` from the event, but recovery and monitor **hardcode `auto_remediate: true`** and drop `dry_run` on retries. So a corruption on a **manual-mode or dry-run** path could be auto-deleted after a restart. The remediator now re-reads the path's **current** settings from `scan_paths` by `PathID` and refuses to auto-remediate if the path is gone/unreadable.

## Test plan
- build + lint (integration+services) clean
- integration + services tests pass; `-race` on the remediator clean
- new `TestFindFileID` (exact / unique / ambiguous-refuses / none) and `TestRemediator_ResolveRemediationPolicy_RespectsCurrentPathConfig`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.3.1

* **Bug Fixes**
  * Deletion now safely refuses to proceed when multiple files match, preventing accidental deletion of incorrect files.
  * Auto-remediation and dry-run settings are now properly re-honored during retries and startup recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->