### PR TITLE
feat(integration): add MarkReleaseAsFailed arr-client method (blocklist PR 1/3)

### DIFF
--- a/internal/api/handlers_arr_test.go
+++ b/internal/api/handlers_arr_test.go
@@ -84,6 +84,10 @@ func (m *mockArrClient) RemoveFromQueueByPath(_ string, _ int64, _, _ bool) erro
 	return nil
 }
 
+func (m *mockArrClient) MarkReleaseAsFailed(_ string, _ int64) error {
+	return nil
+}
+
 func (m *mockArrClient) RefreshMonitoredDownloadsByPath(_ string) error {
 	return nil
 }

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -29,7 +29,8 @@ const (
 	DownloadIgnored      EventType = "DownloadIgnored" // *arr marked download as ignored by user
 	RetryScheduled       EventType = "RetryScheduled"
 	MaxRetriesReached    EventType = "MaxRetriesReached"
-	SearchExhausted      EventType = "SearchExhausted" // No replacement found - arr search returned 0 results or item vanished
+	SearchExhausted      EventType = "SearchExhausted"    // No replacement found - arr search returned 0 results or item vanished
+	ReleaseBlocklisted   EventType = "ReleaseBlocklisted" // A specific corrupt release was marked-as-failed (blocklisted) in the *arr
 	ScanStarted          EventType = "ScanStarted"
 	ScanCompleted        EventType = "ScanCompleted"
 	ScanFailed           EventType = "ScanFailed"

--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -1353,6 +1353,25 @@ func (c *HTTPArrClient) RemoveFromQueue(instance *ArrInstance, queueID int64, re
 	return nil
 }
 
+// markReleaseAsFailed marks a grabbed history record as failed. The *arr then
+// blocklists that specific release (so its decision engine will not re-grab it)
+// and, when autoRedownloadFailed is enabled, automatically searches for the
+// next-best release. historyID is the ID of a "grabbed" history record.
+func (c *HTTPArrClient) markReleaseAsFailed(instance *ArrInstance, historyID int64) error {
+	endpoint := fmt.Sprintf("/api/v3/history/failed/%d", historyID)
+
+	resp, err := c.doRequest(instance, "POST", endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to mark release as failed (history %d): %s", historyID, resp.Status)
+	}
+	return nil
+}
+
 // RefreshMonitoredDownloads triggers a refresh of monitored downloads
 func (c *HTTPArrClient) RefreshMonitoredDownloads(instance *ArrInstance) error {
 	payload := map[string]interface{}{
@@ -1618,6 +1637,15 @@ func (c *HTTPArrClient) RemoveFromQueueByPath(arrPath string, queueID int64, rem
 		return err
 	}
 	return c.RemoveFromQueue(instance, queueID, removeFromClient, blocklist)
+}
+
+// MarkReleaseAsFailed implements ArrClient interface
+func (c *HTTPArrClient) MarkReleaseAsFailed(arrPath string, historyID int64) error {
+	instance, err := c.getInstanceForPath(arrPath)
+	if err != nil {
+		return err
+	}
+	return c.markReleaseAsFailed(instance, historyID)
 }
 
 // RefreshMonitoredDownloadsByPath implements ArrClient interface

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -6252,3 +6252,57 @@ func TestFindFileID(t *testing.T) {
 		}
 	})
 }
+
+func TestHTTPArrClient_MarkReleaseAsFailed_Success(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Sonarr', 'sonarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/tv', '/tv', 1, 0, 0)`)
+
+	if err := client.MarkReleaseAsFailed("/tv/Show/episode.mkv", 42); err != nil {
+		t.Fatalf("MarkReleaseAsFailed: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v3/history/failed/42" {
+		t.Errorf("path = %q, want /api/v3/history/failed/42", gotPath)
+	}
+}
+
+func TestHTTPArrClient_MarkReleaseAsFailed_HTTPError(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Sonarr', 'sonarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/tv', '/tv', 1, 0, 0)`)
+
+	if err := client.MarkReleaseAsFailed("/tv/Show/episode.mkv", 42); err == nil {
+		t.Fatal("expected an error when the *arr returns a non-2xx status")
+	}
+}
+
+func TestHTTPArrClient_MarkReleaseAsFailed_InstanceNotFound(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	// No instance/scan_path configured for this path, so routing must fail.
+	if err := client.MarkReleaseAsFailed("/unknown/path/file.mkv", 42); err == nil {
+		t.Fatal("expected an error when no instance owns the path")
+	}
+}

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -60,6 +60,10 @@ type ArrClient interface {
 	RemoveFromQueueByPath(arrPath string, queueID int64, removeFromClient, blocklist bool) error
 	RefreshMonitoredDownloadsByPath(arrPath string) error
 
+	// Blocklist - mark a specific grabbed release as failed so the *arr won't
+	// re-grab it. historyID is the *arr "grabbed" history record's ID.
+	MarkReleaseAsFailed(arrPath string, historyID int64) error
+
 	// Media details - fetch friendly titles for display
 	// Returns nil (not error) if media not found, to allow graceful degradation
 	GetMediaDetails(mediaID int64, arrPath string) (*MediaDetails, error)

--- a/internal/services/health_monitor_test.go
+++ b/internal/services/health_monitor_test.go
@@ -104,6 +104,10 @@ func (m *mockHealthArrClient) RemoveFromQueueByPath(_ string, _ int64, _, _ bool
 	return nil
 }
 
+func (m *mockHealthArrClient) MarkReleaseAsFailed(_ string, _ int64) error {
+	return nil
+}
+
 func (m *mockHealthArrClient) RefreshMonitoredDownloadsByPath(_ string) error {
 	return nil
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -214,6 +214,7 @@ type MockArrClient struct {
 	GetDownloadStatusForPathFunc        func(arrPath, downloadID string) (status string, progress float64, errMsg string, err error)
 	GetRecentHistoryForMediaByPathFunc  func(arrPath string, mediaID int64, limit int) ([]integration.HistoryItemInfo, error)
 	RemoveFromQueueByPathFunc           func(arrPath string, queueID int64, removeFromClient, blocklist bool) error
+	MarkReleaseAsFailedFunc             func(arrPath string, historyID int64) error
 	RefreshMonitoredDownloadsByPathFunc func(arrPath string) error
 	GetMediaDetailsFunc                 func(mediaID int64, arrPath string) (*integration.MediaDetails, error)
 
@@ -393,6 +394,15 @@ func (m *MockArrClient) RemoveFromQueueByPath(arrPath string, queueID int64, rem
 		return m.RemoveFromQueueByPathFunc(arrPath, queueID, removeFromClient, blocklist)
 	}
 	m.unconfigured("RemoveFromQueueByPath")
+	return nil
+}
+
+func (m *MockArrClient) MarkReleaseAsFailed(arrPath string, historyID int64) error {
+	m.recordCall("MarkReleaseAsFailed", arrPath, historyID)
+	if m.MarkReleaseAsFailedFunc != nil {
+		return m.MarkReleaseAsFailedFunc(arrPath, historyID)
+	}
+	m.unconfigured("MarkReleaseAsFailed")
 	return nil
 }
 


### PR DESCRIPTION
## Summary
First of three PRs implementing per-release, second-strike blocklisting on the corruption remediation path (see prior analysis: today Healarr deletes a corrupt file and re-searches without blocklisting, and the *arr decision engine re-grabs the same corrupt release because the only thing blocking it was the now-deleted file. Verified empirically against live Sonarr 4.0.17 / Radarr 6.1.1: with a file present, candidate releases are rejected *only* by the existing-file check, so deletion re-qualifies the same release).

This PR adds just the plumbing, no behavior change yet (no caller):
- `ArrClient.MarkReleaseAsFailed(arrPath string, historyID int64) error` -> `POST /api/v3/history/failed/{id}`, which blocklists a specific grabbed release. With `autoRedownloadFailed=true` (confirmed on all four of the user's instances) the *arr then auto-searches for the next-best release.
- `ReleaseBlocklisted` domain event constant (used by the later remediator wiring).
- `MockArrClient.MarkReleaseAsFailed` + updates to the two local `ArrClient` test doubles (`mockHealthArrClient`, `mockArrClient`) to satisfy the widened interface.

## Test plan
- `go build ./...`, `go vet ./...` clean
- `golangci-lint run ./...`: 0 issues
- New tests in `internal/integration`: `TestHTTPArrClient_MarkReleaseAsFailed_Success` (asserts `POST /api/v3/history/failed/42`), `_HTTPError` (non-2xx -> error), `_InstanceNotFound` (routing error)
- `go test ./internal/integration/ ./internal/services/ ./internal/api/ ./internal/testutil/ ./internal/domain/`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to mark grabbed releases as failed, preventing *arr instances from re-acquiring corrupt or problematic content.
  * New event type added to track blocklisted releases.

* **Tests**
  * Comprehensive test coverage for mark release as failed functionality, including success validation, error handling, and instance routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->