### PR TITLE
feat(repository): add LatestDeletionGrabInfo (blocklist PR 2/3)

### DIFF
--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -223,6 +223,38 @@ func (r *CorruptionRepository) CorruptionDetectedFileInfo(ctx context.Context, a
 	return fp.String, pathID, nil
 }
 
+// LatestDeletionGrabInfo extracts the source_title and grabbed_history_id that
+// the remediator records on the most recent DeletionCompleted event for an
+// aggregate. These identify the release that produced the file just deleted, so
+// a later retry can tell whether the *arr re-grabbed the same release (and
+// should blocklist it). Returns ErrNotFound if there is no such event or it has
+// no source_title (e.g. events written before this field existed, or when the
+// grab record could not be resolved at deletion time). The history ID may be 0
+// even when a source_title is present; callers must guard before using it.
+func (r *CorruptionRepository) LatestDeletionGrabInfo(ctx context.Context, aggregateID string) (sourceTitle string, historyID int64, err error) {
+	var st sql.NullString
+	var hid sql.NullInt64
+	err = r.db.QueryRowContext(ctx, `
+		SELECT
+			json_extract(event_data, '$.source_title'),
+			json_extract(event_data, '$.grabbed_history_id')
+		FROM events
+		WHERE aggregate_id = ? AND event_type = 'DeletionCompleted'
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, aggregateID).Scan(&st, &hid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", 0, ErrNotFound
+	}
+	if err != nil {
+		return "", 0, fmt.Errorf("query latest deletion grab info: %w", err)
+	}
+	if !st.Valid || st.String == "" {
+		return "", 0, ErrNotFound
+	}
+	return st.String, hid.Int64, nil
+}
+
 // DeleteEvents removes all events for an aggregate and returns the row count.
 func (r *CorruptionRepository) DeleteEvents(ctx context.Context, aggregateID string) (int64, error) {
 	res, err := r.db.ExecContext(ctx, `DELETE FROM events WHERE aggregate_id = ?`, aggregateID)

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -358,6 +358,42 @@ func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
 	}
 }
 
+func TestCorruptionRepository_LatestDeletionGrabInfo(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+
+	// Two DeletionCompleted events: the latest (by created_at) must win.
+	appendEvent(t, db, "agg1", "DeletionCompleted", `{"source_title":"Old.Release-GRP","grabbed_history_id":11}`, now)
+	appendEvent(t, db, "agg1", "DeletionCompleted", `{"source_title":"New.Release-GRP","grabbed_history_id":42}`, now.Add(time.Minute))
+
+	st, hid, err := repo.LatestDeletionGrabInfo(context.Background(), "agg1")
+	if err != nil {
+		t.Fatalf("LatestDeletionGrabInfo: %v", err)
+	}
+	if st != "New.Release-GRP" || hid != 42 {
+		t.Errorf("got (%q, %d), want (New.Release-GRP, 42)", st, hid)
+	}
+
+	// A source_title present but history_id absent: still returns the title, id 0.
+	appendEvent(t, db, "agg-noid", "DeletionCompleted", `{"source_title":"Only.Title-GRP"}`, now)
+	if st, hid, err := repo.LatestDeletionGrabInfo(context.Background(), "agg-noid"); err != nil || st != "Only.Title-GRP" || hid != 0 {
+		t.Errorf("no-id case: got (%q, %d, %v), want (Only.Title-GRP, 0, nil)", st, hid, err)
+	}
+
+	// DeletionCompleted without source_title (old-format event) -> ErrNotFound.
+	appendEvent(t, db, "agg2", "DeletionCompleted", `{"deleted_path":"/x.mkv"}`, now)
+	if _, _, err := repo.LatestDeletionGrabInfo(context.Background(), "agg2"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing source_title: got %v, want ErrNotFound", err)
+	}
+
+	// No DeletionCompleted event at all -> ErrNotFound.
+	if _, _, err := repo.LatestDeletionGrabInfo(context.Background(), "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("no event: got %v, want ErrNotFound", err)
+	}
+}
+
 func TestCorruptionRepository_CountDetectedByDay(t *testing.T) {
 	t.Parallel()
 	db := newCorruptionTestDB(t)


### PR DESCRIPTION
## Summary
Second of three PRs for per-release second-strike blocklisting. Read-only repository helper, no behavior change.

`CorruptionRepository.LatestDeletionGrabInfo(ctx, aggregateID) (sourceTitle string, historyID int64, err error)` extracts `source_title` and `grabbed_history_id` from the most recent `DeletionCompleted` event of an aggregate (via `json_extract`, ordered by `created_at DESC`).

PR 3 (the remediator) will record the grabbed release onto `DeletionCompleted`; on a retry it calls this to decide whether the *arr re-grabbed the same release (compare current grab's `source_title` to the stored one) and should be blocklisted.

Fail-safe by design: returns `ErrNotFound` when there is no `DeletionCompleted` event or it lacks a `source_title` (events from before this field existed, or when the grab record couldn't be resolved at deletion time), so the feature is additive and never forces a blocklist on ambiguous data.

## Test plan
- `go build ./...` clean, `golangci-lint run ./internal/repository/...`: 0 issues
- New `TestCorruptionRepository_LatestDeletionGrabInfo` covers: latest-of-two wins, source_title-without-id returns id 0, missing source_title -> ErrNotFound, no event -> ErrNotFound
- `go test ./internal/repository/`: pass