### PR TITLE
feat(remediator): blocklist corrupt replacement releases (blocklist PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Parallel scanning**: file detection now runs across a worker pool, so large libraries scan substantially faster. The default worker count is tuned to the memory available to the container so a constrained host won't be pushed into an out-of-memory kill; override with `HEALARR_SCANNER_WORKERS` (1 to 32).
 - Configurable shutdown grace period for in-flight scans via `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` (default 30s).
 - Defense-in-depth HTTP security headers on all responses (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
+- **Corrupt releases are now blocklisted instead of re-grabbed.** When a downloaded replacement is itself corrupt, Healarr deletes it, marks that specific release as failed in Sonarr/Radarr so the same release is not grabbed again, and lets the *arr fetch the next-best release. The original corruption still gets one grace re-search first (a single bad download is not always the release's fault); blocklisting kicks in only once a replacement comes back corrupt. Bounded by the path's retry limit, after which the item is flagged for attention.
 
 ### Changed
 - Faster database writes during scans: SQLite now uses `synchronous=NORMAL` under WAL (still corruption-safe), and per-file scan-progress updates no longer hit the durable event store.
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Startup recovery of an interrupted deletion now uses a thorough (stream-level) health check** instead of a quick header-only check, so a file with stream corruption is no longer prematurely marked resolved.
 - **Re-search now refuses to fall back to a whole-series search.** When the specific episode cannot be identified, Healarr no longer issues a series-wide search that could re-download every missing episode; the attempt is surfaced instead.
 - **Active-corruption lookups no longer collide across sibling library roots.** A path like `/media/TV` previously matched `/media/TV-Archive`; lookups now require a path boundary.
+- **A verified-corrupt replacement is now actually re-remediated.** Previously, a retry after a failed verification only re-searched without removing the corrupt file; because the *arr will not replace a file that is still present, the item could stall. The retry now deletes the corrupt replacement before re-searching.
 - Live log and scan-progress updates no longer drop messages under load (WebSocket delivery rework).
 - A paused scan could fail to resume if the resume signal raced with the scan loop; resume is now reliable.
 

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -223,38 +223,6 @@ func (r *CorruptionRepository) CorruptionDetectedFileInfo(ctx context.Context, a
 	return fp.String, pathID, nil
 }
 
-// LatestDeletionGrabInfo extracts the source_title and grabbed_history_id that
-// the remediator records on the most recent DeletionCompleted event for an
-// aggregate. These identify the release that produced the file just deleted, so
-// a later retry can tell whether the *arr re-grabbed the same release (and
-// should blocklist it). Returns ErrNotFound if there is no such event or it has
-// no source_title (e.g. events written before this field existed, or when the
-// grab record could not be resolved at deletion time). The history ID may be 0
-// even when a source_title is present; callers must guard before using it.
-func (r *CorruptionRepository) LatestDeletionGrabInfo(ctx context.Context, aggregateID string) (sourceTitle string, historyID int64, err error) {
-	var st sql.NullString
-	var hid sql.NullInt64
-	err = r.db.QueryRowContext(ctx, `
-		SELECT
-			json_extract(event_data, '$.source_title'),
-			json_extract(event_data, '$.grabbed_history_id')
-		FROM events
-		WHERE aggregate_id = ? AND event_type = 'DeletionCompleted'
-		ORDER BY created_at DESC
-		LIMIT 1
-	`, aggregateID).Scan(&st, &hid)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", 0, ErrNotFound
-	}
-	if err != nil {
-		return "", 0, fmt.Errorf("query latest deletion grab info: %w", err)
-	}
-	if !st.Valid || st.String == "" {
-		return "", 0, ErrNotFound
-	}
-	return st.String, hid.Int64, nil
-}
-
 // DeleteEvents removes all events for an aggregate and returns the row count.
 func (r *CorruptionRepository) DeleteEvents(ctx context.Context, aggregateID string) (int64, error) {
 	res, err := r.db.ExecContext(ctx, `DELETE FROM events WHERE aggregate_id = ?`, aggregateID)

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -358,42 +358,6 @@ func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
 	}
 }
 
-func TestCorruptionRepository_LatestDeletionGrabInfo(t *testing.T) {
-	t.Parallel()
-	db := newCorruptionTestDB(t)
-	repo := NewCorruptionRepository(db)
-	now := time.Now().UTC()
-
-	// Two DeletionCompleted events: the latest (by created_at) must win.
-	appendEvent(t, db, "agg1", "DeletionCompleted", `{"source_title":"Old.Release-GRP","grabbed_history_id":11}`, now)
-	appendEvent(t, db, "agg1", "DeletionCompleted", `{"source_title":"New.Release-GRP","grabbed_history_id":42}`, now.Add(time.Minute))
-
-	st, hid, err := repo.LatestDeletionGrabInfo(context.Background(), "agg1")
-	if err != nil {
-		t.Fatalf("LatestDeletionGrabInfo: %v", err)
-	}
-	if st != "New.Release-GRP" || hid != 42 {
-		t.Errorf("got (%q, %d), want (New.Release-GRP, 42)", st, hid)
-	}
-
-	// A source_title present but history_id absent: still returns the title, id 0.
-	appendEvent(t, db, "agg-noid", "DeletionCompleted", `{"source_title":"Only.Title-GRP"}`, now)
-	if st, hid, err := repo.LatestDeletionGrabInfo(context.Background(), "agg-noid"); err != nil || st != "Only.Title-GRP" || hid != 0 {
-		t.Errorf("no-id case: got (%q, %d, %v), want (Only.Title-GRP, 0, nil)", st, hid, err)
-	}
-
-	// DeletionCompleted without source_title (old-format event) -> ErrNotFound.
-	appendEvent(t, db, "agg2", "DeletionCompleted", `{"deleted_path":"/x.mkv"}`, now)
-	if _, _, err := repo.LatestDeletionGrabInfo(context.Background(), "agg2"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("missing source_title: got %v, want ErrNotFound", err)
-	}
-
-	// No DeletionCompleted event at all -> ErrNotFound.
-	if _, _, err := repo.LatestDeletionGrabInfo(context.Background(), "nope"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("no event: got %v, want ErrNotFound", err)
-	}
-}
-
 func TestCorruptionRepository_CountDetectedByDay(t *testing.T) {
 	t.Parallel()
 	db := newCorruptionTestDB(t)

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"sync"
 	"time"
 
@@ -216,6 +217,13 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 			return
 		}
 
+		// If a verified-corrupt replacement is still on disk, delete it and
+		// blocklist the release that produced it before re-searching, so the
+		// *arr does not simply re-grab the same corrupt release. When a release
+		// is blocklisted the *arr triggers its own re-download
+		// (autoRedownloadFailed), so the explicit search below is skipped.
+		blocklisted := r.handleCorruptReplacementBeforeSearch(corruptionID, pathID, mediaID, metadata)
+
 		// Extract episode IDs from metadata first - validates data before announcing search
 		episodeIDs := extractEpisodeIDs(metadata)
 
@@ -234,14 +242,14 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 			logger.Errorf("Failed to publish SearchStarted event: %v", err)
 		}
 
-		err := r.arrClient.TriggerSearch(mediaID, arrPath, episodeIDs)
-		if err != nil {
-			logger.Errorf("Retry search failed for media %d: %v", mediaID, err)
-			r.publishError(corruptionID, domain.SearchFailed, err.Error())
-			return
+		if !blocklisted {
+			if err := r.arrClient.TriggerSearch(mediaID, arrPath, episodeIDs); err != nil {
+				logger.Errorf("Retry search failed for media %d: %v", mediaID, err)
+				r.publishError(corruptionID, domain.SearchFailed, err.Error())
+				return
+			}
+			logger.Infof("Retry search triggered successfully for %s (media ID: %d)", filePath, mediaID)
 		}
-
-		logger.Infof("Retry search triggered successfully for %s (media ID: %d)", filePath, mediaID)
 
 		// Publish search completed with enriched event data - critical event, use retry
 		eventData := r.buildSearchEventData(filePath, arrPath, mediaID, pathID, metadata, true)
@@ -254,6 +262,144 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 			logger.Errorf("Failed to publish SearchCompleted event after retries: %v", err)
 		}
 	})
+}
+
+// corruptReplacementPaths returns the local paths of a verified-corrupt
+// replacement that is still on disk for this corruption, or nil. A corrupt
+// replacement exists when the latest VerificationFailed event lists failed
+// paths that still exist on disk. This distinguishes a corrupt re-download
+// (which we must delete and blocklist) from a search or download failure where
+// no replacement file is present (a plain search retry is correct there).
+func (r *RemediatorService) corruptReplacementPaths(corruptionID string) []string {
+	if r.corruptions == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	raw, err := r.corruptions.LatestEventData(ctx, corruptionID, string(domain.VerificationFailed), "DESC")
+	if err != nil {
+		return nil
+	}
+	var data struct {
+		FailedPaths []string `json:"failed_paths"`
+	}
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil
+	}
+	var present []string
+	for _, p := range data.FailedPaths {
+		if p == "" {
+			continue
+		}
+		if _, statErr := os.Stat(p); statErr == nil {
+			present = append(present, p)
+		}
+	}
+	return present
+}
+
+// latestGrabbedRelease returns the *arr history record ID and source title of
+// the most recent grabbed release for a media item - the release that produced
+// the file currently on disk. GetRecentHistoryForMediaByPath already filters to
+// "grabbed" events; we pick the newest by date. Returns (0, "") if it cannot be
+// resolved, which callers treat as "cannot blocklist, fall back to a search".
+func (r *RemediatorService) latestGrabbedRelease(arrPath string, mediaID int64) (int64, string) {
+	items, err := r.arrClient.GetRecentHistoryForMediaByPath(arrPath, mediaID, 10)
+	if err != nil || len(items) == 0 {
+		return 0, ""
+	}
+	newest := items[0]
+	newestTime, _ := time.Parse(time.RFC3339, newest.Date)
+	for _, item := range items[1:] {
+		if t, perr := time.Parse(time.RFC3339, item.Date); perr == nil && t.After(newestTime) {
+			newest, newestTime = item, t
+		}
+	}
+	return newest.ID, newest.SourceTitle
+}
+
+// handleCorruptReplacementBeforeSearch deletes a verified-corrupt replacement
+// that is still on disk and blocklists the *arr release that produced it, so the
+// re-search does not grab the same corrupt release again. It returns true only
+// when it blocklisted a release - in that case the *arr triggers its own
+// re-download (autoRedownloadFailed) and the caller must NOT issue a duplicate
+// search. On any inability to proceed (no corrupt replacement, non-auto path,
+// dry-run, unresolvable release, delete/blocklist error) it returns false so the
+// caller performs a normal search, never leaving a destructive half-state.
+func (r *RemediatorService) handleCorruptReplacementBeforeSearch(corruptionID string, pathID, mediaID int64, _ map[string]interface{}) bool {
+	paths := r.corruptReplacementPaths(corruptionID)
+	if len(paths) == 0 {
+		return false
+	}
+
+	// Re-read the authoritative auto-remediate / dry-run policy for this path.
+	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, true, false)
+	if !autoRemediate {
+		logger.Infof("Corrupt replacement present for %s but path is not auto-remediate; leaving for manual handling", corruptionID)
+		return false
+	}
+
+	localPath := paths[0]
+	arrPath, err := r.pathMapper.ToArrPath(localPath)
+	if err != nil {
+		logger.Errorf("Corrupt replacement for %s: cannot map path %s: %v", corruptionID, localPath, err)
+		return false
+	}
+
+	grabbedID, sourceTitle := r.latestGrabbedRelease(arrPath, mediaID)
+	if grabbedID <= 0 {
+		logger.Warnf("Corrupt replacement for %s: could not resolve grabbed release for %s; falling back to a plain search", corruptionID, arrPath)
+		return false
+	}
+
+	if dryRun {
+		logger.Infof("[DRY-RUN] Would delete corrupt replacement %s and blocklist release %q (history %d) for %s", localPath, sourceTitle, grabbedID, corruptionID)
+		return false
+	}
+
+	// Delete the corrupt replacement via the *arr API.
+	if _, err := r.arrClient.DeleteFile(mediaID, arrPath); err != nil {
+		logger.Errorf("Corrupt replacement for %s: failed to delete %s: %v", corruptionID, arrPath, err)
+		r.publishError(corruptionID, domain.DeletionFailed, err.Error())
+		return false
+	}
+	if err := r.eventBus.PublishWithRetry(domain.Event{
+		AggregateID:   corruptionID,
+		AggregateType: "corruption",
+		EventType:     domain.DeletionCompleted,
+		EventData: map[string]interface{}{
+			"media_id":            mediaID,
+			"file_path":           localPath,
+			"source_title":        sourceTitle,
+			"grabbed_history_id":  grabbedID,
+			"corrupt_replacement": true,
+		},
+	}); err != nil {
+		logger.Errorf("Failed to publish DeletionCompleted for corrupt replacement %s: %v", corruptionID, err)
+	}
+
+	// Blocklist the release so the *arr grabs a different one. markAsFailed also
+	// triggers the *arr's own re-download when autoRedownloadFailed is enabled.
+	if err := r.arrClient.MarkReleaseAsFailed(arrPath, grabbedID); err != nil {
+		logger.Warnf("Corrupt replacement for %s: blocklist of release %q (history %d) failed: %v; falling back to a plain search", corruptionID, sourceTitle, grabbedID, err)
+		return false
+	}
+	if err := r.eventBus.Publish(domain.Event{
+		AggregateID:   corruptionID,
+		AggregateType: "corruption",
+		EventType:     domain.ReleaseBlocklisted,
+		EventData: map[string]interface{}{
+			"media_id":     mediaID,
+			"file_path":    localPath,
+			"arr_path":     arrPath,
+			"source_title": sourceTitle,
+			"history_id":   grabbedID,
+		},
+	}); err != nil {
+		logger.Errorf("Failed to publish ReleaseBlocklisted event for %s: %v", corruptionID, err)
+	}
+	logger.Infof("Blocklisted corrupt release %q (history %d) for %s; the *arr will grab the next-best release", sourceTitle, grabbedID, corruptionID)
+	return true
 }
 
 func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -2,8 +2,11 @@ package services
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -1812,5 +1815,241 @@ func TestRemediator_ResolveRemediationPolicy_RespectsCurrentPathConfig(t *testin
 	// Legacy event without a path id: fall back to what the event claimed.
 	if auto, dry := r.resolveRemediationPolicy(0, true, true); !auto || !dry {
 		t.Errorf("pathID=0 fallback: got auto=%v dry=%v, want true/true", auto, dry)
+	}
+}
+
+// insertVerificationFailed appends a VerificationFailed event carrying failed_paths.
+func insertVerificationFailed(t *testing.T, db *sql.DB, aggregateID string, failedPaths []string) {
+	t.Helper()
+	data, _ := json.Marshal(map[string]interface{}{
+		"failed_paths": failedPaths,
+		"failed_count": len(failedPaths),
+	})
+	_, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', ?, 'VerificationFailed', ?, 1, datetime('now'))`, aggregateID, string(data))
+	if err != nil {
+		t.Fatalf("insert VerificationFailed: %v", err)
+	}
+}
+
+func newReplacementFile(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "replacement.mkv")
+	if err := os.WriteFile(p, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return p
+}
+
+func grabbedHistoryFunc(id int64, title string) func(string, int64, int) ([]integration.HistoryItemInfo, error) {
+	return func(string, int64, int) ([]integration.HistoryItemInfo, error) {
+		return []integration.HistoryItemInfo{
+			{ID: id, EventType: "grabbed", Date: "2026-05-27T10:00:00Z", SourceTitle: title},
+		}, nil
+	}
+}
+
+func makeScanPath(t *testing.T, db *sql.DB, local, arr string, auto, dry bool) int64 {
+	t.Helper()
+	id, err := repository.NewScanPathRepository(db).Create(context.Background(), repository.ScanPathFields{
+		LocalPath: local, ArrPath: arr, Enabled: true,
+		AutoRemediate: auto, DryRun: dry,
+		DetectionMethod: "ffprobe", DetectionMode: "quick", MaxRetries: 3,
+	})
+	if err != nil {
+		t.Fatalf("create scan path: %v", err)
+	}
+	return id
+}
+
+func TestRemediator_HandleCorruptReplacementBeforeSearch(t *testing.T) {
+	t.Run("same-release corrupt replacement is deleted and blocklisted", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		replPath := newReplacementFile(t)
+		insertVerificationFailed(t, db, "agg1", []string{replPath})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{
+			GetRecentHistoryForMediaByPathFunc: grabbedHistoryFunc(42, "Show.S01E01-GRP"),
+			DeleteFileFunc: func(int64, string) (map[string]interface{}, error) {
+				return map[string]interface{}{}, nil
+			},
+			MarkReleaseAsFailedFunc: func(string, int64) error { return nil },
+		}
+		pm := &testutil.MockPathMapper{ToArrPathFunc: func(string) (string, error) { return "/data/tv/repl.mkv", nil }}
+		r := NewRemediatorService(eb, arr, pm, db)
+
+		if !r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected blocklisted=true")
+		}
+		if arr.CallCount("DeleteFile") != 1 {
+			t.Errorf("DeleteFile calls = %d, want 1", arr.CallCount("DeleteFile"))
+		}
+		if arr.CallCount("MarkReleaseAsFailed") != 1 {
+			t.Errorf("MarkReleaseAsFailed calls = %d, want 1", arr.CallCount("MarkReleaseAsFailed"))
+		}
+		if eb.EventCount(domain.ReleaseBlocklisted) != 1 {
+			t.Errorf("ReleaseBlocklisted events = %d, want 1", eb.EventCount(domain.ReleaseBlocklisted))
+		}
+	})
+
+	t.Run("dry-run logs but does not delete or blocklist", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		replPath := newReplacementFile(t)
+		insertVerificationFailed(t, db, "agg1", []string{replPath})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, true) // dry-run
+
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{
+			GetRecentHistoryForMediaByPathFunc: grabbedHistoryFunc(42, "Show.S01E01-GRP"),
+		}
+		pm := &testutil.MockPathMapper{ToArrPathFunc: func(string) (string, error) { return "/data/tv/repl.mkv", nil }}
+		r := NewRemediatorService(eb, arr, pm, db)
+
+		if r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected false in dry-run")
+		}
+		if arr.CallCount("DeleteFile") != 0 || arr.CallCount("MarkReleaseAsFailed") != 0 {
+			t.Error("dry-run must not delete or blocklist")
+		}
+		if eb.EventCount(domain.ReleaseBlocklisted) != 0 {
+			t.Error("dry-run must not publish ReleaseBlocklisted")
+		}
+	})
+
+	t.Run("non-auto path does nothing", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		replPath := newReplacementFile(t)
+		insertVerificationFailed(t, db, "agg1", []string{replPath})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", false, false) // auto off
+
+		arr := &testutil.MockArrClient{}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected false on non-auto path")
+		}
+		if arr.CallCount("DeleteFile") != 0 {
+			t.Error("non-auto path must not delete")
+		}
+	})
+
+	t.Run("no corrupt replacement on disk falls through", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		// VerificationFailed references a file that does not exist.
+		insertVerificationFailed(t, db, "agg1", []string{"/nonexistent/x.mkv"})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		arr := &testutil.MockArrClient{}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected false when no corrupt replacement is on disk")
+		}
+		if arr.CallCount("DeleteFile") != 0 {
+			t.Error("must not delete when no corrupt replacement is present")
+		}
+	})
+
+	t.Run("unresolved grabbed release falls back without deleting", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		replPath := newReplacementFile(t)
+		insertVerificationFailed(t, db, "agg1", []string{replPath})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		// No GetRecentHistoryForMediaByPathFunc -> empty history -> grab id 0.
+		arr := &testutil.MockArrClient{}
+		pm := &testutil.MockPathMapper{ToArrPathFunc: func(string) (string, error) { return "/data/tv/repl.mkv", nil }}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, pm, db)
+
+		if r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected false when the grabbed release cannot be resolved")
+		}
+		if arr.CallCount("DeleteFile") != 0 || arr.CallCount("MarkReleaseAsFailed") != 0 {
+			t.Error("must not delete or blocklist when the release is unknown")
+		}
+	})
+
+	t.Run("blocklist failure deletes but does not mark blocklisted", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		replPath := newReplacementFile(t)
+		insertVerificationFailed(t, db, "agg1", []string{replPath})
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{
+			GetRecentHistoryForMediaByPathFunc: grabbedHistoryFunc(42, "Show.S01E01-GRP"),
+			DeleteFileFunc: func(int64, string) (map[string]interface{}, error) {
+				return map[string]interface{}{}, nil
+			},
+			MarkReleaseAsFailedFunc: func(string, int64) error { return errors.New("arr 500") },
+		}
+		pm := &testutil.MockPathMapper{ToArrPathFunc: func(string) (string, error) { return "/data/tv/repl.mkv", nil }}
+		r := NewRemediatorService(eb, arr, pm, db)
+
+		if r.handleCorruptReplacementBeforeSearch("agg1", pathID, 123, nil) {
+			t.Fatal("expected false when blocklist fails (fall back to plain search)")
+		}
+		if arr.CallCount("DeleteFile") != 1 {
+			t.Errorf("DeleteFile calls = %d, want 1", arr.CallCount("DeleteFile"))
+		}
+		if eb.EventCount(domain.ReleaseBlocklisted) != 0 {
+			t.Error("must not publish ReleaseBlocklisted when blocklist fails")
+		}
+	})
+}
+
+func TestRemediator_LatestGrabbedRelease_PicksNewest(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	arr := &testutil.MockArrClient{
+		GetRecentHistoryForMediaByPathFunc: func(string, int64, int) ([]integration.HistoryItemInfo, error) {
+			return []integration.HistoryItemInfo{
+				{ID: 1, EventType: "grabbed", Date: "2026-05-20T10:00:00Z", SourceTitle: "Old-GRP"},
+				{ID: 2, EventType: "grabbed", Date: "2026-05-27T10:00:00Z", SourceTitle: "New-GRP"},
+				{ID: 3, EventType: "grabbed", Date: "2026-05-25T10:00:00Z", SourceTitle: "Mid-GRP"},
+			}, nil
+		},
+	}
+	r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+	id, title := r.latestGrabbedRelease("/data/tv/x.mkv", 123)
+	if id != 2 || title != "New-GRP" {
+		t.Errorf("got (%d, %q), want (2, New-GRP)", id, title)
 	}
 }


### PR DESCRIPTION
## Summary
Final PR of the per-release blocklist work. This is the behavior change; PR 1 added the `MarkReleaseAsFailed` client method.

**Problem (verified against live Sonarr 4.0.17 / Radarr 6.1.1):** when a downloaded replacement is itself corrupt, the retry path called `retrySearchOnly` - a search with no delete. The *arr won't replace a file that's still present, so the item stalled; and once the corrupt file was eventually re-detected, the *arr re-grabbed the same corrupt release (with the file gone, the same release re-qualifies as the top candidate - confirmed via the read-only `release` endpoint).

**Change:** the corrupt-replacement retry now deletes the corrupt replacement and calls `MarkReleaseAsFailed` on that specific grabbed release, so the *arr blocklists it and (via `autoRedownloadFailed`, confirmed enabled on all four instances) grabs the next-best release.

Policy (decided with maintainer): the original corruption gets one plain re-search first (a single bad download isn't always the release's fault); blocklisting kicks in only once a *replacement* comes back corrupt. Per-release scope - the exact release is failed, not the group.

Design notes:
- Detection: a corrupt replacement is present iff the latest `VerificationFailed` lists `failed_paths` that still exist on disk (`os.Stat`). That separates a corrupt re-download from a search/download failure where no file is present (still a plain `retrySearchOnly`).
- Safety: acts on the verifier's corruption determination (same authority as the scanner's `CorruptionDetected`); `DeleteFile` only removes the *arr-tracked file with the #243 ambiguity guard; honors `resolveRemediationPolicy` (auto_remediate / dry-run). Bounded by `max_retries` -> NeedsAttention.
- Fail-safe: if the grabbed release can't be resolved or `MarkReleaseAsFailed` errors, it falls back to a plain search rather than a destructive half-state.
- Emits a new `ReleaseBlocklisted` event.
- Removes the unused `LatestDeletionGrabInfo` helper from PR 2 (an earlier per-aggregate approach this design supersedes).

## Test plan
- `go build ./...`, `go vet ./...` clean; `golangci-lint run` on changed packages: 0 issues
- New `TestRemediator_HandleCorruptReplacementBeforeSearch` (6 subtests: same-release delete+blocklist, dry-run no-op, non-auto no-op, no-replacement-on-disk fall-through, unresolved-release fallback, blocklist-failure fallback) and `TestRemediator_LatestGrabbedRelease_PicksNewest`
- `go test ./internal/services/ ./internal/repository/`: pass