### PR TITLE
fix(monitor): count download timeouts toward the retry budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Re-search now refuses to fall back to a whole-series search.** When the specific episode cannot be identified, Healarr no longer issues a series-wide search that could re-download every missing episode; the attempt is surfaced instead.
 - **Active-corruption lookups no longer collide across sibling library roots.** A path like `/media/TV` previously matched `/media/TV-Archive`; lookups now require a path boundary.
 - **A verified-corrupt replacement is now actually re-remediated.** Previously, a retry after a failed verification only re-searched without removing the corrupt file; because the *arr will not replace a file that is still present, the item could stall. The retry now deletes the corrupt replacement before re-searching.
+- **A replacement that never finishes downloading no longer retries forever.** Repeated download timeouts now count toward the path's retry limit, so an item that can never be satisfied escalates to a needs-attention state instead of re-searching indefinitely. (The retry count shown in the UI still reflects corruption failures only.)
 - Live log and scan-progress updates no longer drop messages under load (WebSocket delivery rework).
 - A paused scan could fail to resume if the resume signal raced with the scan loop; resume is now reliable.
 

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -297,16 +297,26 @@ func (m *MonitorService) getCorruptionContextWithRetry(corruptionID string, maxR
 	return "", 0, lastErr
 }
 
+// getRetryCount returns the number of attempts so far and the path's retry
+// limit, used to decide when to give up (MaxRetriesReached) and to size the
+// backoff. The attempt count here intentionally includes DownloadTimeout as
+// well as the '%Failed' events that back the displayed retry_count: a download
+// that never completes (e.g. a dead release) emits only DownloadTimeout, so
+// counting those is what bounds an otherwise-infinite re-search loop and lets
+// the item escalate to NeedsAttention. The view's retry_count column (shown in
+// the UI / notifications) is deliberately left as failures-only.
 func (m *MonitorService) getRetryCount(corruptionID string) (int, int, error) {
 	var count int
 	var maxRetries sql.NullInt64
 	defaultMaxRetries := config.Get().DefaultMaxRetries
 
-	// Get retry count and max_retries from view and scan_paths
-	// We use a LEFT JOIN to handle cases where path_id is missing or scan path is deleted
+	// Count failures and timeouts directly from the event stream; join scan_paths
+	// (LEFT JOIN, so a missing/deleted path falls back to the default limit).
 	query := `
-		SELECT 
-			cs.retry_count,
+		SELECT
+			(SELECT COUNT(*) FROM events e
+			 WHERE e.aggregate_id = cs.corruption_id
+			   AND (e.event_type LIKE '%Failed' OR e.event_type = 'DownloadTimeout')),
 			sp.max_retries
 		FROM corruption_status cs
 		LEFT JOIN scan_paths sp ON sp.id = cs.path_id

--- a/internal/services/monitor_test.go
+++ b/internal/services/monitor_test.go
@@ -319,6 +319,74 @@ func TestMonitorService_EmitsMaxRetriesReached(t *testing.T) {
 	mu.Unlock()
 }
 
+// TestMonitorService_DownloadTimeoutsCountTowardMaxRetries verifies that
+// repeated DownloadTimeout events (with no '%Failed' events at all) eventually
+// trip MaxRetriesReached, so a download that never completes escalates to
+// NeedsAttention instead of re-searching forever.
+func TestMonitorService_DownloadTimeoutsCountTowardMaxRetries(t *testing.T) {
+	config.SetForTesting(config.NewTestConfig())
+
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	testutil.SeedScanPath(db, 1, "/media/movies", "/movies", true, false)
+	_, _ = db.Exec(`UPDATE scan_paths SET max_retries = 2 WHERE id = 1`)
+
+	corruptionID := "test-timeout-budget"
+	testutil.SeedEvent(db, domain.Event{
+		AggregateType: "corruption",
+		AggregateID:   corruptionID,
+		EventType:     domain.CorruptionDetected,
+		EventData:     map[string]interface{}{"file_path": "/movies/Test/movie.mkv", "path_id": int64(1)},
+	})
+	// Two DownloadTimeout events (and zero '%Failed' events) reach the limit.
+	for i := 0; i < 2; i++ {
+		testutil.SeedEvent(db, domain.Event{
+			AggregateType: "corruption",
+			AggregateID:   corruptionID,
+			EventType:     domain.DownloadTimeout,
+			EventData:     map[string]interface{}{"reason": "elapsed"},
+		})
+	}
+
+	mockClock := testutil.NewMockClock()
+	monitor := NewMonitorService(eb, db, mockClock)
+	monitor.Start()
+
+	var mu sync.Mutex
+	var maxRetriesEvents []domain.Event
+	eb.Subscribe(domain.MaxRetriesReached, func(e domain.Event) {
+		mu.Lock()
+		maxRetriesEvents = append(maxRetriesEvents, e)
+		mu.Unlock()
+	})
+
+	// A third timeout must trip MaxRetriesReached, not schedule another retry.
+	eb.Publish(domain.Event{
+		AggregateID:   corruptionID,
+		AggregateType: "corruption",
+		EventType:     domain.DownloadTimeout,
+		EventData:     map[string]interface{}{"reason": "elapsed"},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if mockClock.PendingCount() != 0 {
+		t.Errorf("Expected no pending retry timer once timeouts exhaust the budget, got %d", mockClock.PendingCount())
+	}
+	mu.Lock()
+	if len(maxRetriesEvents) != 1 {
+		t.Errorf("Expected 1 MaxRetriesReached event from repeated timeouts, got %d", len(maxRetriesEvents))
+	}
+	mu.Unlock()
+}
+
 func TestMonitorService_HandlesMultipleFailureTypes(t *testing.T) {
 	config.SetForTesting(config.NewTestConfig())
 


### PR DESCRIPTION
## Summary
Closes an unbounded-retry gap found while digging into the remediation loop.

`retry_count` is defined as `COUNT(event_type LIKE '%Failed')` (view in 001, trigger in 004, runtime projection in db/repository.go). `DownloadTimeout` does not end in "Failed", so a replacement that never finishes downloading - a dead torrent, no seeders, usenet not retained - emits only `DownloadTimeout` and never advances the count. `MonitorService.handleFailure` only emits `MaxRetriesReached` when `retryCount >= maxRetries`, so such an item re-searched roughly every `VerificationTimeout` window (default 72h) **forever**, never reaching a terminal state and never escalating to needs-attention. The stuck-item detector only re-retries it, and after 7 days the scanner can even spawn duplicate aggregates for the same file.

**Fix:** `getRetryCount` now counts `DownloadTimeout` alongside `%Failed` events (from the event stream) when deciding whether the retry budget is exhausted. So repeated timeouts give up after `max_retries` and surface the item. Shared budget with corruption failures, per maintainer decision (3 × 72h ≈ 9 days before giving up - a reasonable "tell a human" threshold).

The `corruption_status` view's `retry_count` column (UI / notifications / API) is intentionally left failures-only, so displayed semantics don't change. The change is contained to the monitor's internal cap/backoff decision.

A follow-up will additionally blocklist the stalled release on timeout (reusing the `MarkReleaseAsFailed` machinery) so the re-search grabs a different release rather than re-pulling the dead one.

## Test plan
- `go build ./...`, `go vet` clean; `golangci-lint run ./internal/services/...`: 0 issues
- New `TestMonitorService_DownloadTimeoutsCountTowardMaxRetries`: three DownloadTimeout events with zero `%Failed` events now trip `MaxRetriesReached` and schedule no further retry
- Existing monitor tests (incl. `HandlesMultipleFailureTypes`, `EmitsMaxRetriesReached`) still pass; full `go test ./internal/services/` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Download timeouts for replacements that never complete now count toward the configured per-path retry limit, ensuring items properly escalate to a needs-attention state instead of retrying indefinitely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->