### PR TITLE
feat(remediator): blocklist stalled downloads on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable shutdown grace period for in-flight scans via `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` (default 30s).
 - Defense-in-depth HTTP security headers on all responses (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
 - **Corrupt releases are now blocklisted instead of re-grabbed.** When a downloaded replacement is itself corrupt, Healarr deletes it, marks that specific release as failed in Sonarr/Radarr so the same release is not grabbed again, and lets the *arr fetch the next-best release. The original corruption still gets one grace re-search first (a single bad download is not always the release's fault); blocklisting kicks in only once a replacement comes back corrupt. Bounded by the path's retry limit, after which the item is flagged for attention.
+- **Stalled downloads are now blocklisted too.** When a replacement never finishes downloading and times out, Healarr removes it from the download client and blocklists that release, so the re-search grabs a different release instead of waiting on the same dead one. Honors per-path auto-remediate / dry-run and is bounded by the retry limit.
 
 ### Changed
 - Faster database writes during scans: SQLite now uses `synchronous=NORMAL` under WAL (still corruption-safe), and per-file scan-progress updates no longer hit the durable event store.

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -223,6 +223,12 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 		// is blocklisted the *arr triggers its own re-download
 		// (autoRedownloadFailed), so the explicit search below is skipped.
 		blocklisted := r.handleCorruptReplacementBeforeSearch(corruptionID, pathID, mediaID, metadata)
+		// Otherwise, if a download stalled in the *arr queue (timed out, never
+		// imported), remove and blocklist it so the re-search grabs a different
+		// release rather than waiting on the same dead one.
+		if !blocklisted {
+			blocklisted = r.handleStalledDownloadBeforeSearch(corruptionID, pathID, mediaID, arrPath)
+		}
 
 		// Extract episode IDs from metadata first - validates data before announcing search
 		episodeIDs := extractEpisodeIDs(metadata)
@@ -400,6 +406,85 @@ func (r *RemediatorService) handleCorruptReplacementBeforeSearch(corruptionID st
 	}
 	logger.Infof("Blocklisted corrupt release %q (history %d) for %s; the *arr will grab the next-best release", sourceTitle, grabbedID, corruptionID)
 	return true
+}
+
+// lastFailureWasDownloadTimeout reports whether the most recent failure-class
+// event for an aggregate is a DownloadTimeout. This identifies a retry that
+// was triggered because a download never completed (as opposed to a corrupt
+// replacement or a search failure), so we only act on a genuinely stalled
+// download and never disturb an in-progress one.
+func (r *RemediatorService) lastFailureWasDownloadTimeout(corruptionID string) bool {
+	if r.db == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	var eventType string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT event_type FROM events
+		WHERE aggregate_id = ?
+		  AND event_type IN ('DownloadTimeout', 'VerificationFailed', 'SearchFailed', 'DeletionFailed', 'DownloadFailed')
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, corruptionID).Scan(&eventType)
+	if err != nil {
+		return false
+	}
+	return eventType == string(domain.DownloadTimeout)
+}
+
+// handleStalledDownloadBeforeSearch removes and blocklists a download that
+// stalled in the *arr queue (a DownloadTimeout fired and the item is still
+// queued, not imported), so the re-search grabs a different release instead of
+// waiting on the same dead one. It returns true only when it blocklisted at
+// least one queue item - the *arr then re-downloads the next-best release, so
+// the caller must NOT issue a duplicate search. On any inability to proceed
+// (not a timeout retry, nothing queued, non-auto path, dry-run, API error) it
+// returns false so the caller performs a normal search.
+func (r *RemediatorService) handleStalledDownloadBeforeSearch(corruptionID string, pathID, mediaID int64, arrPath string) bool {
+	if !r.lastFailureWasDownloadTimeout(corruptionID) {
+		return false
+	}
+
+	queueItems, err := r.arrClient.FindQueueItemsByMediaIDForPath(arrPath, mediaID)
+	if err != nil || len(queueItems) == 0 {
+		return false
+	}
+
+	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, true, false)
+	if !autoRemediate {
+		logger.Infof("Stalled download for %s but path is not auto-remediate; leaving for manual handling", corruptionID)
+		return false
+	}
+	if dryRun {
+		logger.Infof("[DRY-RUN] Would remove and blocklist %d stalled queue item(s) for %s", len(queueItems), corruptionID)
+		return false
+	}
+
+	blocklistedAny := false
+	for _, qi := range queueItems {
+		if err := r.arrClient.RemoveFromQueueByPath(arrPath, qi.ID, true, true); err != nil {
+			logger.Warnf("Stalled download for %s: failed to remove+blocklist queue item %d (%q): %v", corruptionID, qi.ID, qi.Title, err)
+			continue
+		}
+		blocklistedAny = true
+		if err := r.eventBus.Publish(domain.Event{
+			AggregateID:   corruptionID,
+			AggregateType: "corruption",
+			EventType:     domain.ReleaseBlocklisted,
+			EventData: map[string]interface{}{
+				"media_id":     mediaID,
+				"arr_path":     arrPath,
+				"queue_id":     qi.ID,
+				"source_title": qi.Title,
+				"reason":       "download_timeout",
+			},
+		}); err != nil {
+			logger.Errorf("Failed to publish ReleaseBlocklisted event for %s: %v", corruptionID, err)
+		}
+		logger.Infof("Removed and blocklisted stalled download %q (queue %d) for %s; the *arr will grab the next-best release", qi.Title, qi.ID, corruptionID)
+	}
+	return blocklistedAny
 }
 
 func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -2053,3 +2053,144 @@ func TestRemediator_LatestGrabbedRelease_PicksNewest(t *testing.T) {
 		t.Errorf("got (%d, %q), want (2, New-GRP)", id, title)
 	}
 }
+
+// insertEventAt appends a minimal event with an explicit created_at so tests can
+// control which failure is the most recent.
+func insertEventAt(t *testing.T, db *sql.DB, aggregateID, eventType, createdAt string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', ?, ?, '{}', 1, ?)`, aggregateID, eventType, createdAt)
+	if err != nil {
+		t.Fatalf("insert %s: %v", eventType, err)
+	}
+}
+
+func stalledQueueFunc() func(string, int64) ([]integration.QueueItemInfo, error) {
+	return func(string, int64) ([]integration.QueueItemInfo, error) {
+		return []integration.QueueItemInfo{{ID: 7, Title: "Show.S01E01.STALLED-GRP"}}, nil
+	}
+}
+
+func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
+	t.Run("stalled timeout removes and blocklists the queue item", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		insertEventAt(t, db, "agg1", "DownloadTimeout", "2026-05-27 10:00:00")
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		eb := testutil.NewMockEventBus()
+		removed := 0
+		arr := &testutil.MockArrClient{
+			FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc(),
+			RemoveFromQueueByPathFunc: func(_ string, qid int64, removeFromClient, blocklist bool) error {
+				if qid == 7 && removeFromClient && blocklist {
+					removed++
+				}
+				return nil
+			},
+		}
+		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
+
+		if !r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+			t.Fatal("expected blocklisted=true")
+		}
+		if removed != 1 {
+			t.Errorf("RemoveFromQueueByPath(remove+blocklist) calls = %d, want 1", removed)
+		}
+		if eb.EventCount(domain.ReleaseBlocklisted) != 1 {
+			t.Errorf("ReleaseBlocklisted events = %d, want 1", eb.EventCount(domain.ReleaseBlocklisted))
+		}
+	})
+
+	t.Run("non-timeout retry does nothing", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		// Latest failure is a VerificationFailed, not a DownloadTimeout.
+		insertEventAt(t, db, "agg1", "DownloadTimeout", "2026-05-27 10:00:00")
+		insertEventAt(t, db, "agg1", "VerificationFailed", "2026-05-27 11:00:00")
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+			t.Fatal("expected false when the latest failure is not a download timeout")
+		}
+		if arr.CallCount("RemoveFromQueueByPath") != 0 {
+			t.Error("must not touch the queue when the retry is not from a timeout")
+		}
+	})
+
+	t.Run("no queue item falls through", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		insertEventAt(t, db, "agg1", "DownloadTimeout", "2026-05-27 10:00:00")
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, false)
+
+		// No FindQueueItemsByMediaIDForPathFunc -> empty queue.
+		arr := &testutil.MockArrClient{}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+			t.Fatal("expected false when nothing is queued")
+		}
+		if arr.CallCount("RemoveFromQueueByPath") != 0 {
+			t.Error("must not remove anything when the queue is empty")
+		}
+	})
+
+	t.Run("dry-run does not remove or blocklist", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		insertEventAt(t, db, "agg1", "DownloadTimeout", "2026-05-27 10:00:00")
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", true, true) // dry-run
+
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
+		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+			t.Fatal("expected false in dry-run")
+		}
+		if arr.CallCount("RemoveFromQueueByPath") != 0 || eb.EventCount(domain.ReleaseBlocklisted) != 0 {
+			t.Error("dry-run must not remove from queue or blocklist")
+		}
+	})
+
+	t.Run("non-auto path does nothing", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		insertEventAt(t, db, "agg1", "DownloadTimeout", "2026-05-27 10:00:00")
+		pathID := makeScanPath(t, db, "/media/tv", "/data/tv", false, false) // auto off
+
+		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
+		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+			t.Fatal("expected false on non-auto path")
+		}
+		if arr.CallCount("RemoveFromQueueByPath") != 0 {
+			t.Error("non-auto path must not remove from queue")
+		}
+	})
+}


### PR DESCRIPTION
Closes #248. Follow-up to the corrupt-replacement blocklist (#246) and the timeout-budget fix (#247).

## Summary
When a replacement never finishes downloading, the verifier emits `DownloadTimeout` and the item is re-searched. Because the dead release wasn't blocklisted, the *arr re-grabbed the same release that would never complete, wasting every retry cycle until the budget ran out.

`retrySearchOnly` now, after the corrupt-replacement check, detects a retry triggered by a stalled download and removes + blocklists it before re-searching:
- **Trigger:** the most recent failure-class event for the aggregate is a `DownloadTimeout` (gated this way so an in-progress/slow download is never disturbed; a timeout is already a full `VerificationTimeout` wait, default 72h).
- **Action:** if the release is still in the *arr queue, `RemoveFromQueueByPath(removeFromClient=true, blocklist=true)` - the first production caller of that existing client method. The *arr re-downloads the next-best release (default redownload-on-blocklist), so the explicit search is skipped to avoid a double grab; if no auto-redownload happens, the next retry cycle's plain search recovers.
- **Safety:** honors the path's current `auto_remediate` / dry-run policy via `resolveRemediationPolicy`; emits `ReleaseBlocklisted`; bounded by `max_retries` (timeouts count toward the budget as of #247).

Per the maintainer decision on #248: no extra grace pass for timeouts - a single 72h timeout is strong enough evidence the release is dead, and a second would mean ~6 days before moving on.

## Test plan
- `go build ./...`, `go vet` clean; `golangci-lint run ./internal/services/...`: 0 issues
- New `TestRemediator_HandleStalledDownloadBeforeSearch` (5 subtests: stalled timeout removes+blocklists, non-timeout retry is a no-op, empty queue falls through, dry-run no-op, non-auto no-op)
- Full `go test ./internal/services/`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for stalled downloads. When a download times out and fails to import, it is now removed from the download client and blocklisted, allowing re-search to proceed with an alternative release while respecting auto-remediate settings and retry limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->