### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth HTTP security headers on all responses (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).
 - **Corrupt releases are now blocklisted instead of re-grabbed.** When a downloaded replacement is itself corrupt, Healarr deletes it, marks that specific release as failed in Sonarr/Radarr so the same release is not grabbed again, and lets the *arr fetch the next-best release. The original corruption still gets one grace re-search first (a single bad download is not always the release's fault); blocklisting kicks in only once a replacement comes back corrupt. Bounded by the path's retry limit, after which the item is flagged for attention.
 - **Stalled downloads are now blocklisted too.** When a replacement never finishes downloading and times out, Healarr removes it from the download client and blocklists that release, so the re-search grabs a different release instead of waiting on the same dead one. Honors per-path auto-remediate / dry-run and is bounded by the retry limit.
+- Modal dialogs now trap keyboard focus and expose proper ARIA roles, improving keyboard and screen-reader navigation.
 
 ### Changed
 - Faster database writes during scans: SQLite now uses `synchronous=NORMAL` under WAL (still corruption-safe), and per-file scan-progress updates no longer hit the durable event store.


### PR DESCRIPTION
Finalizes the v1.3.1 release. Adds the modal-accessibility (#223) line to the [1.3.1] CHANGELOG section; all other notes were merged with their respective PRs. Tagging `v1.3.1` after this merges triggers the release + docker-publish workflows.

Build gates (local): `go build ./...` clean, `golangci-lint run ./...` 0 issues, `cd frontend && npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modal dialog accessibility has been enhanced with keyboard focus trapping to prevent focus from escaping modals, along with appropriate ARIA roles. This improves navigation support for keyboard users and screen reader users, providing better overall usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->