### PR TITLE
feat(integration): IsMonitored + SetMonitored arr-client methods (re-monitor PR 1/3)

### DIFF
--- a/internal/api/handlers_arr_test.go
+++ b/internal/api/handlers_arr_test.go
@@ -88,6 +88,14 @@ func (m *mockArrClient) MarkReleaseAsFailed(_ string, _ int64) error {
 	return nil
 }
 
+func (m *mockArrClient) IsMonitored(_ string, _ int64) (bool, error) {
+	return false, nil
+}
+
+func (m *mockArrClient) SetMonitored(_ string, _ int64, _ bool) error {
+	return nil
+}
+
 func (m *mockArrClient) RefreshMonitoredDownloadsByPath(_ string) error {
 	return nil
 }

--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -1648,6 +1648,62 @@ func (c *HTTPArrClient) MarkReleaseAsFailed(arrPath string, historyID int64) err
 	return c.markReleaseAsFailed(instance, historyID)
 }
 
+// IsMonitored reports whether the movie/series identified by mediaID is
+// monitored in the *arr that owns arrPath. Unlike getMovieDetails/
+// getSeriesDetails (which degrade to nil for display), this returns an error on
+// any failure, because the remediator must know the true prior state before it
+// overrides it.
+func (c *HTTPArrClient) IsMonitored(arrPath string, mediaID int64) (bool, error) {
+	instance, err := c.getInstanceForPath(arrPath)
+	if err != nil {
+		return false, err
+	}
+	endpoint := fmt.Sprintf("/api/v3/movie/%d", mediaID)
+	if isSeriesType(instance) {
+		endpoint = fmt.Sprintf("/api/v3/series/%d", mediaID)
+	}
+	resp, err := c.doRequest(instance, "GET", endpoint, nil)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("fetch monitored status for media %d: %s", mediaID, resp.Status)
+	}
+	var body struct {
+		Monitored bool `json:"monitored"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, fmt.Errorf("decode monitored status for media %d: %w", mediaID, err)
+	}
+	return body.Monitored, nil
+}
+
+// SetMonitored sets the monitored flag for a movie/series via the *arr bulk
+// editor endpoint. Used by remediation to temporarily monitor an item so the
+// *arr will grab a replacement; the original state is restored afterward.
+func (c *HTTPArrClient) SetMonitored(arrPath string, mediaID int64, monitored bool) error {
+	instance, err := c.getInstanceForPath(arrPath)
+	if err != nil {
+		return err
+	}
+	endpoint := "/api/v3/movie/editor"
+	payload := map[string]interface{}{"movieIds": []int{int(mediaID)}, "monitored": monitored}
+	if isSeriesType(instance) {
+		endpoint = "/api/v3/series/editor"
+		payload = map[string]interface{}{"seriesIds": []int{int(mediaID)}, "monitored": monitored}
+	}
+	resp, err := c.doRequest(instance, "PUT", endpoint, payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("set monitored=%t for media %d: %s", monitored, mediaID, resp.Status)
+	}
+	return nil
+}
+
 // RefreshMonitoredDownloadsByPath implements ArrClient interface
 func (c *HTTPArrClient) RefreshMonitoredDownloadsByPath(arrPath string) error {
 	instance, err := c.getInstanceForPath(arrPath)

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -6306,3 +6306,100 @@ func TestHTTPArrClient_MarkReleaseAsFailed_InstanceNotFound(t *testing.T) {
 		t.Fatal("expected an error when no instance owns the path")
 	}
 }
+
+func TestHTTPArrClient_SetMonitored_Movie(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	var gotMethod, gotPath string
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Radarr', 'radarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/movies', '/movies', 1, 0, 0)`)
+
+	if err := client.SetMonitored("/movies/Some Movie/movie.mkv", 55, true); err != nil {
+		t.Fatalf("SetMonitored: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/api/v3/movie/editor" {
+		t.Errorf("path = %q, want /api/v3/movie/editor", gotPath)
+	}
+	if gotBody["monitored"] != true {
+		t.Errorf("monitored = %v, want true", gotBody["monitored"])
+	}
+	// movieIds should carry the id (JSON numbers decode to float64).
+	ids, _ := gotBody["movieIds"].([]interface{})
+	if len(ids) != 1 || ids[0] != float64(55) {
+		t.Errorf("movieIds = %v, want [55]", gotBody["movieIds"])
+	}
+}
+
+func TestHTTPArrClient_SetMonitored_Series(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	var gotPath string
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Sonarr', 'sonarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/tv', '/tv', 1, 0, 0)`)
+
+	if err := client.SetMonitored("/tv/Show/episode.mkv", 7, false); err != nil {
+		t.Fatalf("SetMonitored: %v", err)
+	}
+	if gotPath != "/api/v3/series/editor" {
+		t.Errorf("path = %q, want /api/v3/series/editor", gotPath)
+	}
+	if gotBody["monitored"] != false {
+		t.Errorf("monitored = %v, want false", gotBody["monitored"])
+	}
+	if _, ok := gotBody["seriesIds"]; !ok {
+		t.Error("expected seriesIds in body")
+	}
+}
+
+func TestHTTPArrClient_IsMonitored(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	monitored := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/movie/55" {
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 55, "monitored": monitored})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Radarr', 'radarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/movies', '/movies', 1, 0, 0)`)
+
+	got, err := client.IsMonitored("/movies/Some Movie/movie.mkv", 55)
+	if err != nil || !got {
+		t.Fatalf("IsMonitored = (%v, %v), want (true, nil)", got, err)
+	}
+
+	// A non-200 must surface as an error (not a silent false), so the remediator
+	// never overrides based on an unknown prior state.
+	if _, err := client.IsMonitored("/movies/Some Movie/movie.mkv", 999); err == nil {
+		t.Error("expected an error when the movie lookup fails")
+	}
+}

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -64,6 +64,11 @@ type ArrClient interface {
 	// re-grab it. historyID is the *arr "grabbed" history record's ID.
 	MarkReleaseAsFailed(arrPath string, historyID int64) error
 
+	// Monitored state - read and set, so remediation can temporarily monitor an
+	// unmonitored item to let the *arr grab a replacement, then restore it.
+	IsMonitored(arrPath string, mediaID int64) (bool, error)
+	SetMonitored(arrPath string, mediaID int64, monitored bool) error
+
 	// Media details - fetch friendly titles for display
 	// Returns nil (not error) if media not found, to allow graceful degradation
 	GetMediaDetails(mediaID int64, arrPath string) (*MediaDetails, error)

--- a/internal/services/health_monitor_test.go
+++ b/internal/services/health_monitor_test.go
@@ -108,6 +108,14 @@ func (m *mockHealthArrClient) MarkReleaseAsFailed(_ string, _ int64) error {
 	return nil
 }
 
+func (m *mockHealthArrClient) IsMonitored(_ string, _ int64) (bool, error) {
+	return false, nil
+}
+
+func (m *mockHealthArrClient) SetMonitored(_ string, _ int64, _ bool) error {
+	return nil
+}
+
 func (m *mockHealthArrClient) RefreshMonitoredDownloadsByPath(_ string) error {
 	return nil
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -215,6 +215,8 @@ type MockArrClient struct {
 	GetRecentHistoryForMediaByPathFunc  func(arrPath string, mediaID int64, limit int) ([]integration.HistoryItemInfo, error)
 	RemoveFromQueueByPathFunc           func(arrPath string, queueID int64, removeFromClient, blocklist bool) error
 	MarkReleaseAsFailedFunc             func(arrPath string, historyID int64) error
+	IsMonitoredFunc                     func(arrPath string, mediaID int64) (bool, error)
+	SetMonitoredFunc                    func(arrPath string, mediaID int64, monitored bool) error
 	RefreshMonitoredDownloadsByPathFunc func(arrPath string) error
 	GetMediaDetailsFunc                 func(mediaID int64, arrPath string) (*integration.MediaDetails, error)
 
@@ -403,6 +405,24 @@ func (m *MockArrClient) MarkReleaseAsFailed(arrPath string, historyID int64) err
 		return m.MarkReleaseAsFailedFunc(arrPath, historyID)
 	}
 	m.unconfigured("MarkReleaseAsFailed")
+	return nil
+}
+
+func (m *MockArrClient) IsMonitored(arrPath string, mediaID int64) (bool, error) {
+	m.recordCall("IsMonitored", arrPath, mediaID)
+	if m.IsMonitoredFunc != nil {
+		return m.IsMonitoredFunc(arrPath, mediaID)
+	}
+	m.unconfigured("IsMonitored")
+	return false, nil
+}
+
+func (m *MockArrClient) SetMonitored(arrPath string, mediaID int64, monitored bool) error {
+	m.recordCall("SetMonitored", arrPath, mediaID, monitored)
+	if m.SetMonitoredFunc != nil {
+		return m.SetMonitoredFunc(arrPath, mediaID, monitored)
+	}
+	m.unconfigured("SetMonitored")
 	return nil
 }
 


### PR DESCRIPTION
First of three PRs implementing **re-monitor-during-remediation** for unmonitored items (the Tdarr/AV1 data-loss scenario: a transcode pipeline unmonitors a movie, the conversion silently corrupts the file, and Healarr currently deletes it but can't re-acquire because the *arr won't grab an unmonitored item).

Plumbing only, no behavior change (no caller yet):
- `IsMonitored(arrPath, mediaID) (bool, error)` — reads `/api/v3/movie|series/{id}`.`monitored`. Returns an **error** on any failure (not a silent `false`), so the remediator only ever overrides a *known* prior state.
- `SetMonitored(arrPath, mediaID, monitored)` — `PUT /api/v3/movie|series/editor` with the bulk `{movieIds|seriesIds, monitored}` payload (no full-object round-trip).
- `ArrClient` interface entries + the three test doubles (`MockArrClient`, `mockHealthArrClient`, `mockArrClient`).

De-risk note: the design relies on "monitored + MoviesSearch grabs," which is already the proven behavior of the existing remediation path for monitored movies — so flipping the flag puts us on a path that works in production today.

## Test plan
- `go build ./...`, `go vet ./...` clean; `golangci-lint` 0 issues
- New `TestHTTPArrClient_SetMonitored_Movie` (asserts `PUT /api/v3/movie/editor` + body), `_Series` (`series/editor`), `TestHTTPArrClient_IsMonitored` (reads monitored; non-200 surfaces as error)
- `go test ./internal/integration/ ./internal/services/ ./internal/api/`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for media monitoring functionality.

* **Refactor**
  * Enhanced monitoring-state management capabilities in internal systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->