### PR TITLE
feat(repository): loop-breaker query + re-monitor events (re-monitor PR 2/3)

### DIFF
--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -31,6 +31,8 @@ const (
 	MaxRetriesReached    EventType = "MaxRetriesReached"
 	SearchExhausted      EventType = "SearchExhausted"    // No replacement found - arr search returned 0 results or item vanished
 	ReleaseBlocklisted   EventType = "ReleaseBlocklisted" // A specific corrupt release was marked-as-failed (blocklisted) in the *arr
+	MonitorOverridden    EventType = "MonitorOverridden"  // Remediation temporarily changed the *arr monitored flag (records the original state to restore)
+	RemediationPaused    EventType = "RemediationPaused"  // Auto-remediation halted for a file that keeps recurring corrupt despite successful restores (likely a transcode pipeline or failing storage)
 	ScanStarted          EventType = "ScanStarted"
 	ScanCompleted        EventType = "ScanCompleted"
 	ScanFailed           EventType = "ScanFailed"

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -223,6 +223,35 @@ func (r *CorruptionRepository) CorruptionDetectedFileInfo(ctx context.Context, a
 	return fp.String, pathID, nil
 }
 
+// CountSuccessfulRemediationsForPath counts how many times the file at filePath
+// has been successfully remediated (reached VerificationSuccess) within the last
+// windowDays days, across all corruption aggregates for that path. The
+// remediation loop-breaker uses this: a file that keeps coming back corrupt even
+// though we have already restored it to health several times is being
+// re-corrupted by something we cannot fix by re-downloading (a transcode
+// pipeline or failing storage), so auto-remediation should pause rather than
+// thrash. The window lets a file that was healthy for a long time and then
+// breaks again start fresh.
+func (r *CorruptionRepository) CountSuccessfulRemediationsForPath(ctx context.Context, filePath string, windowDays int) (int, error) {
+	var n int
+	// windowDays is bound as a datetime modifier parameter, not interpolated.
+	modifier := fmt.Sprintf("-%d days", windowDays)
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events vs
+		WHERE vs.event_type = 'VerificationSuccess'
+		  AND vs.created_at > datetime('now', ?)
+		  AND vs.aggregate_id IN (
+		      SELECT cd.aggregate_id FROM events cd
+		      WHERE cd.event_type = 'CorruptionDetected'
+		        AND json_extract(cd.event_data, '$.file_path') = ?
+		  )
+	`, modifier, filePath).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count successful remediations for path: %w", err)
+	}
+	return n, nil
+}
+
 // DeleteEvents removes all events for an aggregate and returns the row count.
 func (r *CorruptionRepository) DeleteEvents(ctx context.Context, aggregateID string) (int64, error) {
 	res, err := r.db.ExecContext(ctx, `DELETE FROM events WHERE aggregate_id = ?`, aggregateID)

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -358,6 +358,40 @@ func TestCorruptionRepository_ListActiveFilePathsUnderRoot(t *testing.T) {
 	}
 }
 
+func TestCorruptionRepository_CountSuccessfulRemediationsForPath(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	now := time.Now().UTC()
+	const target = "/movies/x.mkv"
+
+	// Two successful remediations of the target within the window.
+	appendEvent(t, db, "a1", "CorruptionDetected", `{"file_path":"/movies/x.mkv"}`, now.Add(-2*time.Hour))
+	appendEvent(t, db, "a1", "VerificationSuccess", `{}`, now.Add(-2*time.Hour+time.Minute))
+	appendEvent(t, db, "a2", "CorruptionDetected", `{"file_path":"/movies/x.mkv"}`, now.Add(-time.Hour))
+	appendEvent(t, db, "a2", "VerificationSuccess", `{}`, now.Add(-time.Hour+time.Minute))
+	// Old success for the target, outside a 30-day window.
+	appendEvent(t, db, "a3", "CorruptionDetected", `{"file_path":"/movies/x.mkv"}`, now.Add(-60*24*time.Hour))
+	appendEvent(t, db, "a3", "VerificationSuccess", `{}`, now.Add(-60*24*time.Hour))
+	// Success for a different path -> excluded.
+	appendEvent(t, db, "a4", "CorruptionDetected", `{"file_path":"/movies/other.mkv"}`, now)
+	appendEvent(t, db, "a4", "VerificationSuccess", `{}`, now)
+	// Target corruption still in progress (no success) -> not counted.
+	appendEvent(t, db, "a5", "CorruptionDetected", `{"file_path":"/movies/x.mkv"}`, now)
+
+	if n, err := repo.CountSuccessfulRemediationsForPath(context.Background(), target, 30); err != nil || n != 2 {
+		t.Errorf("within 30d: got (%d, %v), want (2, nil)", n, err)
+	}
+	// Widening the window to 90 days pulls in the old success too.
+	if n, err := repo.CountSuccessfulRemediationsForPath(context.Background(), target, 90); err != nil || n != 3 {
+		t.Errorf("within 90d: got (%d, %v), want (3, nil)", n, err)
+	}
+	// A path with no successful remediations.
+	if n, err := repo.CountSuccessfulRemediationsForPath(context.Background(), "/movies/none.mkv", 30); err != nil || n != 0 {
+		t.Errorf("unknown path: got (%d, %v), want (0, nil)", n, err)
+	}
+}
+
 func TestCorruptionRepository_CountDetectedByDay(t *testing.T) {
 	t.Parallel()
 	db := newCorruptionTestDB(t)


### PR DESCRIPTION
Second of three PRs for re-monitor-during-remediation. Read-side pieces, no behavior change.

- `CorruptionRepository.CountSuccessfulRemediationsForPath(filePath, windowDays)` — counts how many times a path has reached `VerificationSuccess` within a rolling window (across all its corruption aggregates). PR 3's loop-breaker uses this: a file that keeps returning corrupt *after* we've already restored it healthy N times is being re-corrupted by something re-downloading can't fix (transcode pipeline / failing storage), so remediation should pause. The window lets a long-healthy-then-broken file start fresh (auto-resets). The day count is bound as a `datetime` modifier parameter, not interpolated.
- Domain events `MonitorOverridden` (records the original monitored flag so PR 3 can restore it on any terminal outcome) and `RemediationPaused` (loop-breaker tripped → needs-attention).

## Test plan
- `go build ./...` clean; `golangci-lint` 0 issues
- New `TestCorruptionRepository_CountSuccessfulRemediationsForPath`: 2 within 30d, 3 within 90d (old one included), 0 for an unknown path; excludes a different path and an in-progress (no-success) aggregate
- `go test ./internal/repository/ ./internal/domain/`: pass