### PR TITLE
feat(remediator): re-monitor unmonitored items + recurring-corruption loop-breaker (re-monitor PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Unmonitored items are now re-acquired during remediation.** If a corrupt file belongs to an item the *arr has unmonitored (for example a transcode pipeline like Tdarr unmonitored it to protect its output), Healarr now temporarily monitors it so the *arr can grab and import a healthy replacement, then restores the original monitored state. Previously such an item was deleted but never re-acquired, leaving you with nothing.
+- **Remediation loop-breaker.** If the same file keeps coming back corrupt even after being restored to health several times (the signature of a transcode pipeline or failing storage re-corrupting it, which re-downloading cannot fix), Healarr now pauses auto-remediation for that file and raises a needs-attention notification instead of repeatedly deleting and re-downloading it. It resets automatically once the file stays healthy.
+
 ## [1.3.1] - 2026-05-27
 
 ### Added

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -338,6 +338,7 @@ func GetEventGroups() []EventGroup {
 				{string(domain.ManuallyRemoved), "Manually Removed", "When user removes item from *arr queue"},
 				{string(domain.DownloadIgnored), "Download Ignored", "When download was skipped or ignored by *arr"},
 				{string(domain.SearchExhausted), "No Replacement Found", "When indexers have no candidates after retries"},
+				{string(domain.RemediationPaused), "Remediation Paused", "When a file keeps returning corrupt after restores (e.g. a transcode pipeline keeps re-corrupting it)"},
 			},
 		},
 		{
@@ -917,6 +918,7 @@ var eventTitles = map[string]string{
 	string(domain.RetryScheduled):       "🔄 Retry Scheduled",
 	string(domain.MaxRetriesReached):    "⚠️ Max Retries Reached",
 	string(domain.SearchExhausted):      "🔍 No Replacement Found",
+	string(domain.RemediationPaused):    "⏸️ Remediation Paused - Manual Action Required",
 	string(domain.DownloadFailed):       "❌ Download Failed",
 	string(domain.SystemHealthDegraded): "⚠️ System Health Degraded",
 	string(domain.InstanceUnhealthy):    "🔴 Arr Instance Unreachable",

--- a/internal/notifier/notifier_format.go
+++ b/internal/notifier/notifier_format.go
@@ -86,6 +86,7 @@ var messageFormatters = map[string]messageFormatter{
 	string(domain.RetryScheduled):       fmtRetryScheduled,
 	string(domain.MaxRetriesReached):    fmtMaxRetriesReached,
 	string(domain.SearchExhausted):      fmtSearchExhausted,
+	string(domain.RemediationPaused):    fmtRemediationPaused,
 	string(domain.DownloadFailed):       fmtDownloadFailed,
 	string(domain.SystemHealthDegraded): fmtSystemHealthDegraded,
 	string(domain.InstanceUnhealthy):    fmtInstanceUnhealthy,
@@ -187,6 +188,13 @@ func fmtSearchExhausted(ctx messageContext) string {
 		msg += fmt.Sprintf(msgFmtReason, ctx.Reason)
 	}
 	msg += "\n👉 Check your indexers or manually search in Sonarr/Radarr"
+	return msg
+}
+
+func fmtRemediationPaused(ctx messageContext) string {
+	msg := fmt.Sprintf("⏸️ Remediation paused: %s", ctx.FileName)
+	msg += "\n♻️ This file keeps coming back corrupt after being restored, so re-downloading can't fix it."
+	msg += "\n👉 Likely a transcode pipeline (e.g. Tdarr) or failing storage. Auto-remediation is paused for this file; please investigate."
 	return msg
 }
 

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -57,6 +57,7 @@ func (m *MonitorService) Start() {
 	// Events requiring manual intervention - emit NeedsAttention for UI visibility
 	m.eventBus.Subscribe(domain.ImportBlocked, m.handleNeedsAttention)
 	m.eventBus.Subscribe(domain.SearchExhausted, m.handleNeedsAttention)
+	m.eventBus.Subscribe(domain.RemediationPaused, m.handleNeedsAttention)
 	// Terminal states from VerifierService - user-initiated actions that ended the flow
 	m.eventBus.Subscribe(domain.DownloadIgnored, m.handleNeedsAttention)
 	m.eventBus.Subscribe(domain.ManuallyRemoved, m.handleNeedsAttention)

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -62,6 +62,15 @@ func NewRemediatorService(eb eventbus.Publisher, arr integration.ArrClient, pm i
 // remediatorQueryTimeout bounds the scan-path config lookup done before remediating.
 const remediatorQueryTimeout = 10 * time.Second
 
+// Loop-breaker: once a file has been successfully remediated this many times
+// within remediationLoopWindowDays and is corrupt again, re-downloading clearly
+// is not fixing it (a transcode pipeline or failing storage keeps re-corrupting
+// it), so auto-remediation pauses and surfaces the item instead of thrashing.
+const (
+	maxRemediationsBeforePause = 3
+	remediationLoopWindowDays  = 30
+)
+
 // resolveRemediationPolicy returns the AUTHORITATIVE auto-remediate and dry-run
 // settings for a corruption, read from the scan path's current config rather than
 // the triggering event. The event payload is not trustworthy for this decision:
@@ -89,6 +98,11 @@ func (r *RemediatorService) resolveRemediationPolicy(pathID int64, evtAuto, evtD
 func (r *RemediatorService) Start() {
 	r.eventBus.Subscribe(domain.CorruptionDetected, r.handleCorruptionDetected)
 	r.eventBus.Subscribe(domain.RetryScheduled, r.handleRetry)
+	// Restore an overridden monitored flag once remediation reaches a terminal
+	// state (success or give-up), so we leave the library as we found it.
+	r.eventBus.Subscribe(domain.VerificationSuccess, r.handleRemediationTerminal)
+	r.eventBus.Subscribe(domain.MaxRetriesReached, r.handleRemediationTerminal)
+	r.eventBus.Subscribe(domain.SearchExhausted, r.handleRemediationTerminal)
 }
 
 // Stop gracefully shuts down the RemediatorService.
@@ -487,6 +501,95 @@ func (r *RemediatorService) handleStalledDownloadBeforeSearch(corruptionID strin
 	return blocklistedAny
 }
 
+// shouldPauseForRecurringCorruption reports whether this file has been
+// successfully remediated too many times within the loop window to keep trying.
+// On a query error it returns false - a transient DB issue must not change
+// remediation behavior.
+func (r *RemediatorService) shouldPauseForRecurringCorruption(filePath string) bool {
+	if r.corruptions == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	n, err := r.corruptions.CountSuccessfulRemediationsForPath(ctx, filePath, remediationLoopWindowDays)
+	if err != nil {
+		logger.Warnf("Loop-breaker: cannot count prior remediations for %s; proceeding: %v", filePath, err)
+		return false
+	}
+	return n >= maxRemediationsBeforePause
+}
+
+// ensureMonitoredForRemediation temporarily monitors an unmonitored item so the
+// *arr will grab a replacement, recording the original state (a MonitorOverridden
+// event) so handleRemediationTerminal can restore it later. Failing to read or
+// set the flag is non-fatal: we log and proceed (the search may simply no-op,
+// which is no worse than before this feature).
+func (r *RemediatorService) ensureMonitoredForRemediation(corruptionID, arrPath string, mediaID int64) {
+	monitored, err := r.arrClient.IsMonitored(arrPath, mediaID)
+	if err != nil {
+		logger.Warnf("Could not read monitored status for %s (media %d); proceeding without override: %v", corruptionID, mediaID, err)
+		return
+	}
+	if monitored {
+		return
+	}
+	if err := r.arrClient.SetMonitored(arrPath, mediaID, true); err != nil {
+		logger.Warnf("Could not monitor %s (media %d) for remediation; proceeding anyway: %v", corruptionID, mediaID, err)
+		return
+	}
+	if err := r.eventBus.Publish(domain.Event{
+		AggregateID:   corruptionID,
+		AggregateType: "corruption",
+		EventType:     domain.MonitorOverridden,
+		EventData: map[string]interface{}{
+			"media_id":           mediaID,
+			"arr_path":           arrPath,
+			"original_monitored": false,
+		},
+	}); err != nil {
+		logger.Errorf("Failed to publish MonitorOverridden event for %s: %v", corruptionID, err)
+	}
+	logger.Infof("Temporarily monitored media %d for %s so the *arr can grab a replacement (was unmonitored)", mediaID, corruptionID)
+}
+
+// monitorOverrideOriginal returns the arr path, media id, and original monitored
+// flag recorded by a prior MonitorOverridden event for this aggregate, if any.
+func (r *RemediatorService) monitorOverrideOriginal(corruptionID string) (arrPath string, mediaID int64, original, found bool) {
+	if r.corruptions == nil {
+		return "", 0, false, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	raw, err := r.corruptions.LatestEventData(ctx, corruptionID, string(domain.MonitorOverridden), "DESC")
+	if err != nil {
+		return "", 0, false, false
+	}
+	var d struct {
+		ArrPath  string  `json:"arr_path"`
+		MediaID  float64 `json:"media_id"`
+		Original bool    `json:"original_monitored"`
+	}
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		return "", 0, false, false
+	}
+	return d.ArrPath, int64(d.MediaID), d.Original, true
+}
+
+// handleRemediationTerminal restores a monitored flag that remediation overrode,
+// once the journey reaches a terminal state. No-op for items we never overrode.
+// Restoring is idempotent (sets the flag back to its original value).
+func (r *RemediatorService) handleRemediationTerminal(event domain.Event) {
+	arrPath, mediaID, original, found := r.monitorOverrideOriginal(event.AggregateID)
+	if !found {
+		return
+	}
+	if err := r.arrClient.SetMonitored(arrPath, mediaID, original); err != nil {
+		logger.Warnf("Failed to restore monitored=%t for %s after remediation: %v", original, event.AggregateID, err)
+		return
+	}
+	logger.Infof("Restored monitored=%t for %s after remediation reached a terminal state", original, event.AggregateID)
+}
+
 func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {
 	corruptionID := event.AggregateID
 
@@ -622,6 +725,27 @@ func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath s
 		return
 	}
 
+	// Loop-breaker: if this file keeps coming back corrupt even though we have
+	// already restored it to health several times, re-downloading will not fix it
+	// (a transcode pipeline or failing storage is re-corrupting it). Pause and
+	// surface it rather than thrash - and crucially do NOT delete, since deleting
+	// would just lose the file with no way to re-acquire a good one.
+	if r.shouldPauseForRecurringCorruption(filePath) {
+		logger.Warnf("Remediation paused for %s: still corrupt after %d successful restores in %d days", filePath, maxRemediationsBeforePause, remediationLoopWindowDays)
+		if err := r.eventBus.Publish(domain.Event{
+			AggregateID:   corruptionID,
+			AggregateType: "corruption",
+			EventType:     domain.RemediationPaused,
+			EventData: map[string]interface{}{
+				"file_path": filePath,
+				"reason":    "recurring_corruption",
+			},
+		}); err != nil {
+			logger.Errorf("Failed to publish RemediationPaused event: %v", err)
+		}
+		return
+	}
+
 	// Find media first - validates we can proceed before publishing DeletionStarted
 	mediaID, err := r.arrClient.FindMediaByPath(arrPath)
 	if err != nil {
@@ -629,6 +753,11 @@ func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath s
 		r.publishError(corruptionID, domain.DeletionFailed, err.Error())
 		return
 	}
+
+	// If the item is unmonitored (e.g. a transcode pipeline like Tdarr unmonitored
+	// it to protect its output), temporarily monitor it so the *arr will grab a
+	// replacement. The original state is recorded and restored at a terminal state.
+	r.ensureMonitoredForRemediation(corruptionID, arrPath, mediaID)
 
 	// Publish deletion started - now that we've validated we can proceed
 	if err := r.eventBus.Publish(domain.Event{

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -2194,3 +2194,169 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		}
 	})
 }
+
+// seedSuccessfulRemediation appends a CorruptionDetected(file_path) + a
+// VerificationSuccess for one aggregate, i.e. one completed remediation cycle.
+func seedSuccessfulRemediation(t *testing.T, db *sql.DB, aggregateID, filePath string) {
+	t.Helper()
+	cd, _ := json.Marshal(map[string]interface{}{"file_path": filePath})
+	if _, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', ?, 'CorruptionDetected', ?, 1, datetime('now'))`, aggregateID, string(cd)); err != nil {
+		t.Fatalf("seed CorruptionDetected: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', ?, 'VerificationSuccess', '{}', 1, datetime('now'))`, aggregateID); err != nil {
+		t.Fatalf("seed VerificationSuccess: %v", err)
+	}
+}
+
+func TestRemediator_ShouldPauseForRecurringCorruption(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	r := NewRemediatorService(testutil.NewMockEventBus(), &testutil.MockArrClient{}, &testutil.MockPathMapper{}, db)
+	const p = "/movies/x.mkv"
+
+	seedSuccessfulRemediation(t, db, "a1", p)
+	seedSuccessfulRemediation(t, db, "a2", p)
+	if r.shouldPauseForRecurringCorruption(p) {
+		t.Fatal("2 prior successes (< 3) must not pause")
+	}
+	seedSuccessfulRemediation(t, db, "a3", p)
+	if !r.shouldPauseForRecurringCorruption(p) {
+		t.Fatal("3 prior successes (>= 3) must pause")
+	}
+	if r.shouldPauseForRecurringCorruption("/movies/other.mkv") {
+		t.Fatal("a different path must not be affected")
+	}
+}
+
+func TestRemediator_EnsureMonitoredForRemediation(t *testing.T) {
+	t.Run("unmonitored item is monitored and recorded", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		eb := testutil.NewMockEventBus()
+		var setCalls int
+		var setTo bool
+		arr := &testutil.MockArrClient{
+			IsMonitoredFunc:  func(string, int64) (bool, error) { return false, nil },
+			SetMonitoredFunc: func(_ string, _ int64, m bool) error { setCalls++; setTo = m; return nil },
+		}
+		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
+
+		r.ensureMonitoredForRemediation("agg1", "/data/movies/x.mkv", 55)
+		if setCalls != 1 || !setTo {
+			t.Errorf("SetMonitored calls=%d setTo=%v, want 1/true", setCalls, setTo)
+		}
+		if eb.EventCount(domain.MonitorOverridden) != 1 {
+			t.Errorf("MonitorOverridden events = %d, want 1", eb.EventCount(domain.MonitorOverridden))
+		}
+	})
+
+	t.Run("already monitored: no-op", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{IsMonitoredFunc: func(string, int64) (bool, error) { return true, nil }}
+		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
+
+		r.ensureMonitoredForRemediation("agg1", "/data/movies/x.mkv", 55)
+		if arr.CallCount("SetMonitored") != 0 {
+			t.Error("must not change monitored when already monitored")
+		}
+		if eb.EventCount(domain.MonitorOverridden) != 0 {
+			t.Error("must not record an override when already monitored")
+		}
+	})
+
+	t.Run("IsMonitored error: no override", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{IsMonitoredFunc: func(string, int64) (bool, error) { return false, errors.New("api down") }}
+		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
+
+		r.ensureMonitoredForRemediation("agg1", "/data/movies/x.mkv", 55)
+		if arr.CallCount("SetMonitored") != 0 {
+			t.Error("must not override when the prior state is unknown")
+		}
+		if eb.EventCount(domain.MonitorOverridden) != 0 {
+			t.Error("must not record an override on read error")
+		}
+	})
+}
+
+func TestRemediator_HandleRemediationTerminal_RestoresMonitored(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ov, _ := json.Marshal(map[string]interface{}{"media_id": 55, "arr_path": "/data/movies/x.mkv", "original_monitored": false})
+	if _, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', 'agg1', 'MonitorOverridden', ?, 1, datetime('now'))`, string(ov)); err != nil {
+		t.Fatalf("seed MonitorOverridden: %v", err)
+	}
+
+	var restoredTo bool
+	var calls int
+	arr := &testutil.MockArrClient{SetMonitoredFunc: func(_ string, _ int64, m bool) error { calls++; restoredTo = m; return nil }}
+	r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
+
+	r.handleRemediationTerminal(domain.Event{AggregateID: "agg1"})
+	if calls != 1 || restoredTo {
+		t.Errorf("restore SetMonitored calls=%d to=%v, want 1/false", calls, restoredTo)
+	}
+
+	// An aggregate we never overrode must be a no-op.
+	arr2 := &testutil.MockArrClient{}
+	r2 := NewRemediatorService(testutil.NewMockEventBus(), arr2, &testutil.MockPathMapper{}, db)
+	r2.handleRemediationTerminal(domain.Event{AggregateID: "never-overridden"})
+	if arr2.CallCount("SetMonitored") != 0 {
+		t.Error("must not restore for an aggregate that was never overridden")
+	}
+}
+
+func TestRemediator_LoopBreaker_PausesAndDoesNotDelete(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	const fp = "/local/movies/loop.mkv"
+	for _, agg := range []string{"a1", "a2", "a3"} {
+		seedSuccessfulRemediation(t, db, agg, fp)
+	}
+
+	eb := testutil.NewMockEventBus()
+	arr := &testutil.MockArrClient{
+		FindMediaByPathFunc: func(string) (int64, error) { return 55, nil },
+		DeleteFileFunc:      func(int64, string) (map[string]interface{}, error) { return map[string]interface{}{}, nil },
+	}
+	pm := &testutil.MockPathMapper{ToArrPathFunc: func(p string) (string, error) { return p, nil }}
+	r := NewRemediatorService(eb, arr, pm, db)
+
+	event := testutil.NewCorruptionEventWithType(fp, integration.ErrorTypeCorruptHeader, testutil.WithAutoRemediate(true))
+	r.handleCorruptionDetected(event)
+	time.Sleep(200 * time.Millisecond)
+
+	if eb.EventCount(domain.RemediationPaused) != 1 {
+		t.Errorf("RemediationPaused events = %d, want 1", eb.EventCount(domain.RemediationPaused))
+	}
+	if arr.CallCount("DeleteFile") != 0 {
+		t.Error("a paused remediation must not delete the file")
+	}
+}


### PR DESCRIPTION
Final PR for the re-monitor-during-remediation design (the Tdarr/AV1 scenario from the brainstorm). PRs 1-2 added the client methods, loop-breaker query, and events; this is the behavior.

**Re-monitor unmonitored items.** When remediating a corrupt file whose *arr item is unmonitored (e.g. a transcode pipeline unmonitored it), `executeRemediation` now temporarily sets `monitored=true` so the search actually grabs a replacement - the existing failure was that the *arr won't grab an unmonitored item, so Healarr deleted the file and could never re-acquire it (silent data loss). It records a `MonitorOverridden` event with the original state, and `handleRemediationTerminal` (subscribed to `VerificationSuccess` / `MaxRetriesReached` / `SearchExhausted`) restores the original flag on any terminal outcome. Leaves the library as found; respects the pipeline's deliberate unmonitor.

**Loop-breaker.** Before remediating, if this file has already been successfully restored `maxRemediationsBeforePause` (3) times within 30 days and is corrupt *again*, something local (transcode pipeline / failing storage) is re-corrupting it that re-downloading can't fix. Healarr **pauses**: emits `RemediationPaused` and does **not** delete (deleting would just lose the file). Self-resets as successes age out.

`RemediationPaused` is wired to the monitor's needs-attention handling and the notifier (title + formatter + config toggle), so it reaches the user. `MonitorOverridden` is internal and doesn't notify.

De-risk: re-monitor relies on "monitored + MoviesSearch grabs," which is the existing proven path for monitored items - no new external behavior.

## Test plan
- `go build ./...`, `go vet ./...` clean; `golangci-lint` 0 issues on changed packages
- New remediator tests: `ShouldPauseForRecurringCorruption` (threshold), `EnsureMonitoredForRemediation` (unmonitored→set+record / already-monitored no-op / read-error no-override), `HandleRemediationTerminal_RestoresMonitored` (restore / no-op when never overridden), `LoopBreaker_PausesAndDoesNotDelete` (3 prior successes → RemediationPaused, no DeleteFile)
- Full `go test ./internal/services/ ./internal/notifier/ ./internal/repository/`: pass