### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.2] - 2026-05-28
 
 ### Added
 - **Unmonitored items are now re-acquired during remediation.** If a corrupt file belongs to an item the *arr has unmonitored (for example a transcode pipeline like Tdarr unmonitored it to protect its output), Healarr now temporarily monitors it so the *arr can grab and import a healthy replacement, then restores the original monitored state. Previously such an item was deleted but never re-acquired, leaving you with nothing.


### PR DESCRIPTION
Cuts v1.3.2. Renames the `[Unreleased]` CHANGELOG section to `[1.3.2] - 2026-05-28`; the entries (re-monitor unmonitored items during remediation + recurring-corruption loop-breaker) were merged with #251-#253. Tagging `v1.3.2` after merge triggers the release + docker-publish workflows.

Build gates (local): `go build ./...` clean, `golangci-lint run ./...` 0 issues, `cd frontend && npm run build` succeeds.