### PR TITLE
chore(ci): push :latest from the tag run so its embedded version is correct

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,12 +42,18 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # :latest is set by the TAG run (only when the new tag is the highest
+          # semver), not the main-branch run, so the binary embedded in :latest
+          # always has the matching VERSION string (e.g. v1.3.2). Pre-releases
+          # like v1.4.0-beta1, and hotfix tags for older versions, correctly do
+          # not move :latest. Users tracking trunk can still use :main / :<sha>.
+          flavor: |
+            latest=auto
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Get version for build
         id: version


### PR DESCRIPTION
Tightens the docker-publish workflow so `:latest` is updated by the **tag** run (with the right `VERSION` baked in), not the main-branch run.

## Why
`:latest` was set via `type=raw,value=latest,enable={{is_default_branch}}`, which means the main-branch docker-publish run pushes it. That run is triggered by the release-commit merge to main, *before* the version tag is pushed - so `git describe --tags` returns the previous tag + N commits (e.g. `v1.3.1-1-g3833c8b`) and the binary embedded in `:latest` carried a post-release dev string, not the new release's version. Code was the right release, but `healarr --version` reported a pre-release string. Surfaced while verifying the v1.3.2 release.

## How
Switches to `docker/metadata-action`'s built-in `flavor: latest=auto`. With that:
- **Tag push (highest semver)** -> pushes `:1.3.2`, `:1.3`, **`:latest`**, `:<sha>`. `VERSION` is taken from the tag name, so the embedded version is correct.
- **Pre-release tag** (e.g. `v1.4.0-beta1`) -> does NOT update `:latest` (semver pre-release semantics).
- **Hotfix tag for an older version** -> does NOT update `:latest` (not the highest).
- **Main-branch push** -> still pushes `:main` and `:<sha>` (so anyone tracking trunk can use them); does NOT touch `:latest`.

## Verification
- YAML edit only; no test plan beyond GitHub Actions parsing it on the next push. Confirmed locally that the change matches the documented `docker/metadata-action` API.
- The fix will take effect on the next tag release; in the meantime `:latest` is already correct (refreshed by re-running the previous main-push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image tagging and versioning configuration to improve consistency and reliability across container deployments and releases. The updated build process refines how container images are labeled and distributed, providing better version tracking and ensuring more predictable artifact management throughout automated deployment pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->