### PR TITLE
fix(notifier): tag NotificationSent/Failed with the source aggregate type (fixes /corruptions "All" crash)

### DIFF
--- a/internal/db/migrations/007_filter_stray_corruption_summary.sql
+++ b/internal/db/migrations/007_filter_stray_corruption_summary.sql
@@ -1,0 +1,35 @@
+-- 007_filter_stray_corruption_summary.sql
+--
+-- Cleans up non-corruption rows that leaked into the corruption_summary
+-- table via a notifier bug (notifier.publishNotificationEvent hardcoded
+-- AggregateType: "corruption" on every NotificationSent/NotificationFailed
+-- event, even when the original event being notified about was on a
+-- different aggregate, e.g. a SystemHealthDegraded with aggregate_id
+-- "database_pool"). The trigger that maintains corruption_summary correctly
+-- gates on aggregate_type='corruption', so it dutifully inserted those
+-- mis-tagged notification events; with no underlying CorruptionDetected for
+-- the aggregate the row's file_path stayed NULL. Loading /corruptions with
+-- the "All" filter then tripped a scan error converting NULL to string.
+--
+-- The publisher is fixed in the same change. This migration removes any
+-- already-leaked rows and tightens the corruption_status view with
+-- WHERE file_path IS NOT NULL so a future mis-tag (in this codebase or
+-- another) cannot crash the API.
+
+DELETE FROM corruption_summary WHERE file_path IS NULL;
+
+DROP VIEW IF EXISTS corruption_status;
+
+CREATE VIEW corruption_status AS
+		SELECT
+			corruption_id,
+			current_state,
+			retry_count,
+			file_path,
+			path_id,
+			last_error,
+			corruption_type,
+			detected_at,
+			last_updated_at
+		FROM corruption_summary
+		WHERE file_path IS NOT NULL;

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -408,13 +408,22 @@ func (n *Notifier) Start() error {
 	for _, event := range events {
 		eventType := domain.EventType(event) // Capture for closure
 		n.eb.Subscribe(eventType, func(ev domain.Event) {
-			// Ensure aggregate_id is included in data for proper event correlation
+			// Ensure aggregate_id and aggregate_type are included in data for
+			// proper event correlation. aggregate_type is critical: the
+			// NotificationSent/Failed event published downstream inherits it, and
+			// the corruption_summary trigger keys off it. Hardcoding "corruption"
+			// here previously caused notifications fired for non-corruption
+			// aggregates (e.g. health events like SystemHealthDegraded) to leak
+			// into corruption_summary as stray, file_path-less rows.
 			data := ev.EventData
 			if data == nil {
 				data = make(map[string]interface{})
 			}
 			if ev.AggregateID != "" {
 				data["aggregate_id"] = ev.AggregateID
+			}
+			if ev.AggregateType != "" {
+				data["aggregate_type"] = ev.AggregateType
 			}
 			n.handleEvent(string(eventType), data)
 		})
@@ -437,8 +446,17 @@ func (n *Notifier) Stop() {
 	n.wg.Wait()
 }
 
-// SendSystemHealthDegraded sends a notification when system health is degraded
+// SendSystemHealthDegraded sends a notification when system health is degraded.
+// This path bypasses the event-bus subscription, so it must set aggregate_type
+// explicitly; otherwise the downstream NotificationSent would be tagged as a
+// corruption event and leak into corruption_summary.
 func (n *Notifier) SendSystemHealthDegraded(data map[string]interface{}) {
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+	if _, ok := data["aggregate_type"]; !ok {
+		data["aggregate_type"] = "health"
+	}
 	n.handleEvent(string(domain.SystemHealthDegraded), data)
 }
 
@@ -606,6 +624,7 @@ func (n *Notifier) sendNotification(cfg *NotificationConfig, eventType string, d
 
 	// Log result and publish to EventBus for timeline
 	aggregateID := n.extractAggregateID(data)
+	aggregateType := extractAggregateType(data)
 	providerLabel := n.getProviderLabel(cfg.ProviderType)
 
 	if err != nil {
@@ -616,7 +635,7 @@ func (n *Notifier) sendNotification(cfg *NotificationConfig, eventType string, d
 		// throttle window open so the next event can try again.
 		logger.Errorf("Failed to send notification %d: %v", cfg.ID, err)
 		n.logNotification(cfg.ID, eventType, message, "failed", err.Error())
-		n.publishNotificationEvent(aggregateID, domain.NotificationFailed, providerLabel, eventType, err.Error())
+		n.publishNotificationEvent(aggregateID, aggregateType, domain.NotificationFailed, providerLabel, eventType, err.Error())
 		return
 	}
 
@@ -627,13 +646,32 @@ func (n *Notifier) sendNotification(cfg *NotificationConfig, eventType string, d
 
 	logger.Debugf("Sent notification %d for event %s", cfg.ID, eventType)
 	n.logNotification(cfg.ID, eventType, message, "sent", "")
-	n.publishNotificationEvent(aggregateID, domain.NotificationSent, providerLabel, eventType, "")
+	n.publishNotificationEvent(aggregateID, aggregateType, domain.NotificationSent, providerLabel, eventType, "")
 }
 
-// publishNotificationEvent publishes notification success/failure events to the event bus
-func (n *Notifier) publishNotificationEvent(aggregateID string, eventType domain.EventType, provider, triggerEvent, errMsg string) {
+// extractAggregateType reads the source event's aggregate_type from data (set
+// by the subscription handler in Start). Returns "" if missing so callers can
+// apply a sensible default.
+func extractAggregateType(data map[string]interface{}) string {
+	if v, ok := data["aggregate_type"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// publishNotificationEvent publishes notification success/failure events to the
+// event bus. aggregateType must come from the source event being notified about
+// (e.g. "corruption" for CorruptionDetected, "health" for SystemHealthDegraded).
+// If it is empty (a defensive fallback, not a normal path), we default to
+// "notification" - never "corruption" - so a notification that lost its origin
+// type does not leak into corruption_summary as a stray row.
+func (n *Notifier) publishNotificationEvent(aggregateID, aggregateType string, eventType domain.EventType, provider, triggerEvent, errMsg string) {
 	if aggregateID == "" {
 		return
+	}
+
+	if aggregateType == "" {
+		aggregateType = "notification"
 	}
 
 	eventData := map[string]interface{}{
@@ -645,7 +683,7 @@ func (n *Notifier) publishNotificationEvent(aggregateID string, eventType domain
 	}
 
 	if err := n.eb.Publish(domain.Event{
-		AggregateType: "corruption",
+		AggregateType: aggregateType,
 		AggregateID:   aggregateID,
 		EventType:     eventType,
 		EventData:     eventData,

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
+	"github.com/mescon/Healarr/internal/testutil"
 )
 
 // =============================================================================
@@ -2696,25 +2697,65 @@ func TestNotifier_PublishNotificationEvent(t *testing.T) {
 
 	t.Run("does nothing with empty aggregateID", func(t *testing.T) {
 		// Should not panic or insert anything
-		n.publishNotificationEvent("", domain.NotificationSent, "Discord", "CorruptionDetected", "")
+		n.publishNotificationEvent("", "corruption", domain.NotificationSent, "Discord", "CorruptionDetected", "")
 		// Success = no panic (early return when aggregateID is empty)
 	})
 
 	t.Run("calls publish with NotificationSent event", func(t *testing.T) {
 		// Verifies the function doesn't error/panic when called with valid data
 		// The actual persistence is tested in eventbus tests
-		n.publishNotificationEvent("corruption-789", domain.NotificationSent, "Discord", "CorruptionDetected", "")
+		n.publishNotificationEvent("corruption-789", "corruption", domain.NotificationSent, "Discord", "CorruptionDetected", "")
 		// Success = no panic
 	})
 
 	t.Run("calls publish with NotificationFailed event", func(t *testing.T) {
-		n.publishNotificationEvent("corruption-456", domain.NotificationFailed, "Telegram", "VerificationSuccess", "connection refused")
+		n.publishNotificationEvent("corruption-456", "corruption", domain.NotificationFailed, "Telegram", "VerificationSuccess", "connection refused")
 		// Success = no panic
 	})
 
 	t.Run("handles empty error message", func(t *testing.T) {
-		n.publishNotificationEvent("corruption-111", domain.NotificationFailed, "Slack", "DownloadStarted", "")
+		n.publishNotificationEvent("corruption-111", "corruption", domain.NotificationFailed, "Slack", "DownloadStarted", "")
 		// Success = no panic
+	})
+
+}
+
+// TestNotifier_PublishNotificationEvent_AggregateTypePropagation is the
+// regression test for the corruption_summary pollution bug: notifications for
+// non-corruption events (e.g. a SystemHealthDegraded on the "health"
+// aggregate) used to be published with AggregateType hardcoded to "corruption",
+// which the corruption_summary trigger then dutifully inserted as stray rows
+// with NULL file_path - making the /corruptions "All" filter crash on the
+// scan. Uses MockEventBus to avoid the real eventbus's events-table persistence
+// in this test fixture.
+func TestNotifier_PublishNotificationEvent_AggregateTypePropagation(t *testing.T) {
+	t.Run("non-corruption aggregateType propagates", func(t *testing.T) {
+		eb := testutil.NewMockEventBus()
+		n := &Notifier{eb: eb}
+		n.publishNotificationEvent("database_pool", "health", domain.NotificationSent, "Pushover", "SystemHealthDegraded", "")
+		evs := eb.GetEvents(domain.NotificationSent)
+		if len(evs) != 1 {
+			t.Fatalf("got %d NotificationSent events, want 1", len(evs))
+		}
+		if evs[0].AggregateType != "health" {
+			t.Errorf("AggregateType = %q, want %q (must NOT be hardcoded 'corruption')", evs[0].AggregateType, "health")
+		}
+	})
+
+	t.Run("missing aggregateType falls back to 'notification', never 'corruption'", func(t *testing.T) {
+		eb := testutil.NewMockEventBus()
+		n := &Notifier{eb: eb}
+		n.publishNotificationEvent("agg-x", "", domain.NotificationFailed, "Telegram", "SomeEvent", "boom")
+		evs := eb.GetEvents(domain.NotificationFailed)
+		if len(evs) != 1 {
+			t.Fatalf("got %d NotificationFailed events, want 1", len(evs))
+		}
+		if evs[0].AggregateType == "corruption" {
+			t.Error("AggregateType defaulted to 'corruption'; must default to 'notification' to avoid corruption_summary pollution")
+		}
+		if evs[0].AggregateType != "notification" {
+			t.Errorf("AggregateType = %q, want %q", evs[0].AggregateType, "notification")
+		}
 	})
 }
 


### PR DESCRIPTION
Closes the bug where selecting **All** on /corruptions returns a database error.

## Root cause
`notifier.publishNotificationEvent` hardcoded `AggregateType: "corruption"` on every notification it published. So a notification fired for a non-corruption event (e.g. a Pushover alert for `SystemHealthDegraded` on the "health" aggregate `database_pool`) was published with the wrong aggregate type. The `corruption_summary` trigger correctly gates on `aggregate_type='corruption'`, so it dutifully inserted those mis-tagged events. With no underlying `CorruptionDetected` for the aggregate, `file_path` stayed NULL. Loading `/corruptions` with `status=all` (no WHERE filter) included that stray row, and the Go scan into `FilePath string` then crashed with `converting NULL to string is unsupported`.

Verified against the prod DB: exactly 1 stray row, aggregate `database_pool`, latest event `NotificationSent` triggered by `SystemHealthDegraded`.

## Fix
1. **Subscription handler** (`Start`) stashes the source `AggregateType` in the event data, alongside `aggregate_id`.
2. **`publishNotificationEvent`** now takes the source aggregate type and uses it. Empty (defensive) defaults to `"notification"` - **never `"corruption"`** - so a future stray cannot pollute `corruption_summary`.
3. **`SendSystemHealthDegraded`** (bypasses subscriptions) explicitly sets `aggregate_type="health"`.
4. **Migration 007** removes existing stray rows (`DELETE FROM corruption_summary WHERE file_path IS NULL`) and tightens the `corruption_status` view with `WHERE file_path IS NOT NULL` as belt-and-braces.

Audited all other `AggregateType:` usages in the codebase - they're all legitimate corruption/scan/instance events. Only the notifier mis-tagged.

## Test plan
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean
- Existing `TestNotifier_PublishNotificationEvent` subtests updated for the new signature; new `TestNotifier_PublishNotificationEvent_AggregateTypePropagation` (uses `MockEventBus`) verifies (a) a `"health"` aggregate type propagates through, (b) missing aggregate type falls back to `"notification"` and NOT to `"corruption"`
- Full `go test ./internal/{notifier,repository,api,services}/`: pass (migration 007 applies cleanly on test DBs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stray NULL values from notification data storage to ensure data consistency.

* **New Features**
  * Notifications now properly track and propagate event source information throughout the system for improved event correlation.

* **Tests**
  * Added test coverage validating correct event source tracking and default handling in notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->