### PR TITLE
feat(health-check): configurable thorough timeout, prefix-only duration, opportunistic ffmpeg hwaccel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Thorough health checks are now tunable for slow codecs (AV1) and large files.** Three new env vars:
+  - `HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT` (default `10m`) - raise this if scans repeatedly time out and end up parked in the rescan queue.
+  - `HEALARR_HEALTH_CHECK_THOROUGH_DURATION` (default `0`, no limit) - when set (e.g. `60s`), the thorough decode walks only the first N seconds via ffmpeg `-t`. Catches header errors, codec-init errors, decode errors at the start, and files that will not open at all; trades completeness for speed.
+  - `HEALARR_HEALTH_CHECK_HWACCEL` (default `auto`) - opportunistic ffmpeg hardware acceleration. Probes `ffmpeg -hwaccels` once and adds `-hwaccel auto` if any accelerator is reported; falls back silently to software on hosts without one. `off` to disable, `<name>` (e.g. `cuda`, `vaapi`, `videotoolbox`) to force a specific one.
+
+### Fixed
+- **`/corruptions` with the "All" filter no longer crashes with a database scan error.** The notifier was publishing every `NotificationSent`/`NotificationFailed` with a hardcoded `aggregate_type="corruption"`, so notifications fired for non-corruption events (e.g. a Pushover alert for `SystemHealthDegraded`) leaked into `corruption_summary` as stray rows with `NULL file_path`. Loading the corruptions page with no filter included them and tripped a `converting NULL to string` scan error. The notifier now propagates the source event's aggregate type, defaults defensively to `"notification"` if missing (never `"corruption"`), and a migration cleans up any rows already polluted while tightening the `corruption_status` view as belt-and-braces.
+
 ## [1.3.2] - 2026-05-28
 
 ### Added

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,29 @@ type Config struct {
 	// VerificationInterval is the polling interval when checking for file replacement (default: 30s)
 	VerificationInterval time.Duration
 
+	// HealthCheckThoroughTimeout bounds a single thorough-mode ffmpeg/ffprobe/HandBrake
+	// run and the post-pass AnalyzeContent ffmpeg run. A full-file decode of a long
+	// AV1 movie can easily exceed the default; raise this if scans repeatedly time
+	// out and end up parked in the rescan queue (default: 10m).
+	HealthCheckThoroughTimeout time.Duration
+
+	// HealthCheckThoroughDuration, when > 0, limits ffmpeg thorough/content checks
+	// to the first N of the input via "-t". A short prefix decode catches header
+	// errors, decode errors at the start, and files that will not open at all;
+	// it does NOT catch mid- or late-file corruption. Use this to trade
+	// completeness for scan speed (default: 0, no limit = decode whole file).
+	HealthCheckThoroughDuration time.Duration
+
+	// HealthCheckHwAccel controls ffmpeg hardware acceleration for thorough +
+	// content checks:
+	//   "auto"   - probe ffmpeg -hwaccels once; if any GPU accelerator is
+	//              present, pass "-hwaccel auto" (default).
+	//   "off"    - never pass -hwaccel.
+	//   "<name>" - pass "-hwaccel <name>" explicitly (e.g. "cuda", "vaapi").
+	// Opportunistic: a system without any accelerator silently falls back to
+	// software, scans still work.
+	HealthCheckHwAccel string
+
 	// StaleThreshold is how long an item must be in an active state with no updates
 	// before it's considered stale and eligible for recovery (default: 24h)
 	// This accounts for downloads that may wait for unpacking, seeding, or queue delays
@@ -249,26 +272,29 @@ func Load() *Config {
 	}
 
 	cfg = &Config{
-		Port:                 getEnvOrDefault("HEALARR_PORT", "3090"),
-		BasePath:             basePath,
-		BasePathSource:       basePathSource,
-		LogLevel:             strings.ToLower(getEnvOrDefault("HEALARR_LOG_LEVEL", "info")),
-		VerificationTimeout:  getEnvDurationOrDefault("HEALARR_VERIFICATION_TIMEOUT", 72*time.Hour),
-		VerificationInterval: getEnvDurationOrDefault("HEALARR_VERIFICATION_INTERVAL", 30*time.Second),
-		StaleThreshold:       getEnvDurationOrDefault("HEALARR_STALE_THRESHOLD", 24*time.Hour),
-		DefaultMaxRetries:    getEnvIntOrDefault("HEALARR_DEFAULT_MAX_RETRIES", 3),
-		DryRunMode:           getEnvBoolOrDefault("HEALARR_DRY_RUN", false),
-		ArrRateLimitRPS:      getEnvFloatOrDefault("HEALARR_ARR_RATE_LIMIT_RPS", 5.0),
-		ArrRateLimitBurst:    getEnvIntOrDefault("HEALARR_ARR_RATE_LIMIT_BURST", 10),
-		RetentionDays:        getEnvIntOrDefault("HEALARR_RETENTION_DAYS", 90),
-		DataDir:              dataDir,
-		DatabasePath:         dbPath,
-		LogDir:               logDir,
-		WebDir:               webDir,
-		FFprobePath:          getEnvOrDefault("HEALARR_FFPROBE_PATH", "ffprobe"),
-		FFmpegPath:           getEnvOrDefault("HEALARR_FFMPEG_PATH", "ffmpeg"),
-		MediaInfoPath:        getEnvOrDefault("HEALARR_MEDIAINFO_PATH", "mediainfo"),
-		HandBrakePath:        getEnvOrDefault("HEALARR_HANDBRAKE_PATH", "HandBrakeCLI"),
+		Port:                        getEnvOrDefault("HEALARR_PORT", "3090"),
+		BasePath:                    basePath,
+		BasePathSource:              basePathSource,
+		LogLevel:                    strings.ToLower(getEnvOrDefault("HEALARR_LOG_LEVEL", "info")),
+		VerificationTimeout:         getEnvDurationOrDefault("HEALARR_VERIFICATION_TIMEOUT", 72*time.Hour),
+		VerificationInterval:        getEnvDurationOrDefault("HEALARR_VERIFICATION_INTERVAL", 30*time.Second),
+		StaleThreshold:              getEnvDurationOrDefault("HEALARR_STALE_THRESHOLD", 24*time.Hour),
+		HealthCheckThoroughTimeout:  getEnvDurationOrDefault("HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT", 10*time.Minute),
+		HealthCheckThoroughDuration: getEnvDurationOrDefault("HEALARR_HEALTH_CHECK_THOROUGH_DURATION", 0),
+		HealthCheckHwAccel:          strings.ToLower(getEnvOrDefault("HEALARR_HEALTH_CHECK_HWACCEL", "auto")),
+		DefaultMaxRetries:           getEnvIntOrDefault("HEALARR_DEFAULT_MAX_RETRIES", 3),
+		DryRunMode:                  getEnvBoolOrDefault("HEALARR_DRY_RUN", false),
+		ArrRateLimitRPS:             getEnvFloatOrDefault("HEALARR_ARR_RATE_LIMIT_RPS", 5.0),
+		ArrRateLimitBurst:           getEnvIntOrDefault("HEALARR_ARR_RATE_LIMIT_BURST", 10),
+		RetentionDays:               getEnvIntOrDefault("HEALARR_RETENTION_DAYS", 90),
+		DataDir:                     dataDir,
+		DatabasePath:                dbPath,
+		LogDir:                      logDir,
+		WebDir:                      webDir,
+		FFprobePath:                 getEnvOrDefault("HEALARR_FFPROBE_PATH", "ffprobe"),
+		FFmpegPath:                  getEnvOrDefault("HEALARR_FFMPEG_PATH", "ffmpeg"),
+		MediaInfoPath:               getEnvOrDefault("HEALARR_MEDIAINFO_PATH", "mediainfo"),
+		HandBrakePath:               getEnvOrDefault("HEALARR_HANDBRAKE_PATH", "HandBrakeCLI"),
 	}
 
 	// Validate log level
@@ -329,26 +355,29 @@ func SetForTesting(c *Config) {
 // NewTestConfig returns a minimal Config suitable for unit tests.
 func NewTestConfig() *Config {
 	return &Config{
-		Port:                 "8080",
-		BasePath:             "/",
-		BasePathSource:       "test",
-		LogLevel:             "debug",
-		VerificationTimeout:  72 * time.Hour,
-		VerificationInterval: 30 * time.Second,
-		StaleThreshold:       24 * time.Hour,
-		DefaultMaxRetries:    3,
-		DryRunMode:           false,
-		ArrRateLimitRPS:      5,
-		ArrRateLimitBurst:    10,
-		RetentionDays:        90,
-		DataDir:              "/tmp/healarr-test",
-		DatabasePath:         "/tmp/healarr-test/healarr.db",
-		LogDir:               "/tmp/healarr-test/logs",
-		WebDir:               "",
-		FFprobePath:          "ffprobe",
-		FFmpegPath:           "ffmpeg",
-		MediaInfoPath:        "mediainfo",
-		HandBrakePath:        "HandBrakeCLI",
+		Port:                        "8080",
+		BasePath:                    "/",
+		BasePathSource:              "test",
+		LogLevel:                    "debug",
+		VerificationTimeout:         72 * time.Hour,
+		VerificationInterval:        30 * time.Second,
+		StaleThreshold:              24 * time.Hour,
+		HealthCheckThoroughTimeout:  10 * time.Minute,
+		HealthCheckThoroughDuration: 0,
+		HealthCheckHwAccel:          "off",
+		DefaultMaxRetries:           3,
+		DryRunMode:                  false,
+		ArrRateLimitRPS:             5,
+		ArrRateLimitBurst:           10,
+		RetentionDays:               90,
+		DataDir:                     "/tmp/healarr-test",
+		DatabasePath:                "/tmp/healarr-test/healarr.db",
+		LogDir:                      "/tmp/healarr-test/logs",
+		WebDir:                      "",
+		FFprobePath:                 "ffprobe",
+		FFmpegPath:                  "ffmpeg",
+		MediaInfoPath:               "mediainfo",
+		HandBrakePath:               "HandBrakeCLI",
 	}
 }
 

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -11,8 +11,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/safego"
 )
@@ -219,6 +221,68 @@ type CmdHealthChecker struct {
 	FFmpegPath    string
 	MediaInfoPath string
 	HandBrakePath string
+
+	// Hardware-acceleration args for ffmpeg thorough/content checks, resolved
+	// once at first use from HEALARR_HEALTH_CHECK_HWACCEL. Empty when "off" or
+	// when no accelerator is available on this host (opportunistic).
+	hwAccelArgs []string
+	hwAccelOnce sync.Once
+}
+
+// hwAccelArgsResolved returns the cached "-hwaccel ..." args, probing ffmpeg
+// the first time if needed. Returns an empty slice when hardware acceleration
+// is unavailable or disabled - callers can safely append it to any args list.
+func (hc *CmdHealthChecker) hwAccelArgsResolved() []string {
+	hc.hwAccelOnce.Do(func() {
+		hc.hwAccelArgs = resolveHwAccelArgs(hc.FFmpegPath, config.Get().HealthCheckHwAccel)
+	})
+	return hc.hwAccelArgs
+}
+
+// resolveHwAccelArgs translates HEALARR_HEALTH_CHECK_HWACCEL into the actual
+// ffmpeg args to use. Split out so it can be tested without a real ffmpeg.
+//   - "off"    -> []
+//   - "auto"   -> probe ffmpeg -hwaccels; ["-hwaccel","auto"] iff any GPU
+//     accelerator is reported (anything other than "none"); else []
+//   - "<name>" -> ["-hwaccel","<name>"] (operator opted in to a specific one)
+func resolveHwAccelArgs(ffmpegPath, setting string) []string {
+	switch setting {
+	case "", "off":
+		return nil
+	case "auto":
+		if probeHwAccelAvailable(ffmpegPath) {
+			logger.Infof("Health check: ffmpeg hardware acceleration detected, enabling -hwaccel auto")
+			return []string{"-hwaccel", "auto"}
+		}
+		logger.Debugf("Health check: no ffmpeg hardware acceleration available, scans will use software decode")
+		return nil
+	default:
+		logger.Infof("Health check: ffmpeg hardware acceleration forced via config: -hwaccel %s", setting)
+		return []string{"-hwaccel", setting}
+	}
+}
+
+// probeHwAccelAvailable runs "ffmpeg -hide_banner -hwaccels" and reports
+// whether any GPU accelerator is listed (anything other than "none"). Any
+// failure (binary missing, exec error) is treated as "no accel available" so
+// the caller silently falls back to software decode.
+func probeHwAccelAvailable(ffmpegPath string) bool {
+	cmd := exec.Command(ffmpegPath, "-hide_banner", "-hwaccels")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || strings.Contains(strings.ToLower(name), "hardware acceleration methods") {
+			continue
+		}
+		if strings.ToLower(name) == "none" {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // NewHealthChecker creates a health checker with default binary paths (uses PATH lookup).
@@ -736,8 +800,15 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 		return true, nil
 	}
 
-	// Build ffmpeg command with appropriate filters
-	ffmpegArgs := []string{"-nostats", "-v", "info", "-i", path}
+	// Build ffmpeg command with appropriate filters. Hardware-accel args go
+	// FIRST (they are input options); the optional duration limit "-t N" is
+	// also an input option and must precede "-i".
+	cfg := config.Get()
+	ffmpegArgs := append([]string{"-nostats", "-v", "info"}, hc.hwAccelArgsResolved()...)
+	if cfg.HealthCheckThoroughDuration > 0 {
+		ffmpegArgs = append(ffmpegArgs, "-t", strconv.FormatFloat(cfg.HealthCheckThoroughDuration.Seconds(), 'f', -1, 64))
+	}
+	ffmpegArgs = append(ffmpegArgs, "-i", path)
 
 	var vf []string
 	if info.HasVideo {
@@ -758,7 +829,7 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	timeout := 10 * time.Minute
+	timeout := cfg.HealthCheckThoroughTimeout
 	done := make(chan error, 1)
 	safego.Run("content-analysis-cmd", func() {
 		done <- cmd.Run()

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -1629,3 +1629,43 @@ func TestParseDurations_SilenceDetect(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveHwAccelArgs(t *testing.T) {
+	// A non-existent ffmpeg path makes probeHwAccelAvailable return false,
+	// which is what we need to test the "auto + no accelerator" branch
+	// without depending on the host's ffmpeg.
+	const missingFfmpeg = "/nonexistent/ffmpeg-for-test"
+
+	tests := []struct {
+		name    string
+		setting string
+		ffmpeg  string
+		want    []string
+	}{
+		{"off disables hwaccel", "off", missingFfmpeg, nil},
+		{"empty disables hwaccel", "", missingFfmpeg, nil},
+		{"auto with no probe success falls back to nil", "auto", missingFfmpeg, nil},
+		{"explicit cuda is honored", "cuda", missingFfmpeg, []string{"-hwaccel", "cuda"}},
+		{"explicit vaapi is honored", "vaapi", missingFfmpeg, []string{"-hwaccel", "vaapi"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHwAccelArgs(tt.ffmpeg, tt.setting)
+			if !hwAccelSlicesEqual(got, tt.want) {
+				t.Errorf("resolveHwAccelArgs(%q, %q) = %v, want %v", tt.ffmpeg, tt.setting, got, tt.want)
+			}
+		})
+	}
+}
+
+func hwAccelSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/integration/health_checker_tools.go
+++ b/internal/integration/health_checker_tools.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/safego"
 )
@@ -22,21 +24,23 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 	var cmdName string
 
 	if mode == ModeThorough {
-		// Thorough mode: Use ffmpeg to decode the entire file and check for stream corruption
-		// This catches issues that header-only checks miss (mid-file corruption, bad frames, etc.)
-		// -xerror makes ffmpeg exit on first decode error
-		// -f null - outputs to null device (no output file needed)
+		// Thorough mode: Use ffmpeg to decode the file and check for stream
+		// corruption. Catches issues that header-only checks miss (mid-file
+		// corruption, bad frames, etc.). -xerror exits on first decode error.
+		// "-f null -" discards output. Hardware-accel args go first (they are
+		// input options). When HEALARR_HEALTH_CHECK_THOROUGH_DURATION > 0 we
+		// also inject "-t <seconds>" so the decode walks only the prefix - far
+		// faster on slow codecs like AV1, at the cost of not catching mid/late
+		// corruption (a trade the operator opts into).
 		cmdPath = hc.FFmpegPath
 		cmdName = "ffmpeg"
-		args = []string{"-v", "error", argXError, "-i", path, "-f", "null", "-"}
-
-		// Insert custom args before -i (if any)
-		if len(customArgs) > 0 {
-			newArgs := []string{"-v", "error", argXError}
-			newArgs = append(newArgs, customArgs...)
-			newArgs = append(newArgs, "-i", path, "-f", "null", "-")
-			args = newArgs
+		cfg := config.Get()
+		args = append([]string{"-v", "error", argXError}, hc.hwAccelArgsResolved()...)
+		if cfg.HealthCheckThoroughDuration > 0 {
+			args = append(args, "-t", strconv.FormatFloat(cfg.HealthCheckThoroughDuration.Seconds(), 'f', -1, 64))
 		}
+		args = append(args, customArgs...)
+		args = append(args, "-i", path, "-f", "null", "-")
 	} else {
 		// Quick mode (default): Use ffprobe to check container structure and stream headers
 		// Fast and reliable for detecting obvious corruption
@@ -57,10 +61,13 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	// Thorough mode needs much longer timeout since it decodes entire file
+	// Thorough mode needs a much longer timeout since it decodes (some or all
+	// of) the file. The thorough cap is configurable via
+	// HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT (raise it for slow codecs / large
+	// files, or shrink it once you have set THOROUGH_DURATION to a short prefix).
 	timeout := 30 * time.Second
 	if mode == ModeThorough {
-		timeout = 10 * time.Minute // Large files can take a while to fully decode
+		timeout = config.Get().HealthCheckThoroughTimeout
 	}
 
 	done := make(chan error, 1)
@@ -102,7 +109,7 @@ func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []strin
 		// Thorough mode: Full scan with preview analysis
 		// --previews 10:0 generates 10 previews at different points to verify stream integrity
 		args = []string{argScan, argPreviews, "10:0", "-i", path}
-		timeout = 10 * time.Minute
+		timeout = config.Get().HealthCheckThoroughTimeout
 	} else {
 		// Quick mode: Basic container scan
 		args = []string{argScan, "-i", path}


### PR DESCRIPTION
Three new env vars on the thorough-mode health check, addressing scans timing out on AV1 / large files. All default backward-compatible.

## Why
On the prod scan the user is running now, 71 files hit `ffmpeg timed out after 10m0s` in a single burst - all AV1 (Tdarr output). Thorough mode was full-decoding each file with no hardware acceleration and a hardcoded 10m cap that AV1 movies easily exceed on CPU. Classification is correct (timeouts -> `Recoverable` -> rescan queue, not corruption -> no false-positive deletes - #235 still working), but the files end up in rescan purgatory because the rescan hits the same wall. The operator's framing: "either it plays the video stream or it doesn't" - a short prefix decode is enough to catch their failure modes (header errors, broken Tdarr output).

## What
| Env var | Default | Effect |
|---|---|---|
| `HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT` | `10m` | Replaces three hardcoded 10m sites: thorough ffmpeg decode, thorough HandBrake scan, post-pass `AnalyzeContent`. |
| `HEALARR_HEALTH_CHECK_THOROUGH_DURATION` | `0` (no limit) | When >0, injects `-t <seconds>` into ffmpeg so the decode walks only the prefix. Catches header errors, codec-init errors, decode errors at the start, and files that won't open at all. Does **not** catch mid/late corruption - explicit trade. |
| `HEALARR_HEALTH_CHECK_HWACCEL` | `auto` | Opportunistic GPU accel. `auto` probes `ffmpeg -hwaccels` once (sync.Once cache); adds `-hwaccel auto` iff any accelerator is reported; falls back silently to software otherwise. `off` never adds the flag; `<name>` (e.g. `cuda`, `vaapi`, `videotoolbox`) forces a specific one. |

The hwaccel + `-t` args are injected for ffmpeg thorough and `AnalyzeContent` (black/freeze/silence). `ffprobe` quick mode doesn't decode video, so it's unaffected. HandBrake gets the configurable timeout but not the ffmpeg-specific flags.

`resolveHwAccelArgs` / `probeHwAccelAvailable` are split out as small pure-ish functions so they can be unit-tested without depending on a real ffmpeg on the test host.

## Recommended setup for the AV1 / Tdarr case
```
HEALARR_HEALTH_CHECK_THOROUGH_DURATION=60s
HEALARR_HEALTH_CHECK_HWACCEL=auto    # default; explicit is fine
# HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT can stay at 10m or shrink to e.g. 2m
```

## Test plan
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean
- New `TestResolveHwAccelArgs`: off / empty / explicit-cuda / explicit-vaapi / auto-but-probe-fails (uses a non-existent ffmpeg path so the probe deterministically returns false)
- `go test ./internal/{integration,config,services}/`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tunable health checks for slow codecs and large files with configurable timeout and duration settings
  * Hardware acceleration support for media scanning operations

* **Bug Fixes**
  * Fixed crash in corruptions endpoint when using "All" filter
  * Fixed notifier events incorrectly treated as corruption notifications

* **Chores**
  * Database migration to clean previously polluted corruption records

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->