### PR TITLE
chore(release): v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.3] - 2026-05-29
 
 ### Added
 - **Thorough health checks are now tunable for slow codecs (AV1) and large files.** Three new env vars:


### PR DESCRIPTION
Cuts v1.3.3. Renames the `[Unreleased]` CHANGELOG section to `[1.3.3] - 2026-05-29`; the entries (#257 corruptions/All crash, #258 health-check tuning, #259 scan-cancel + orphan reconciliation) were merged with their respective PRs. Tagging `v1.3.3` after this merges triggers the release + docker-publish workflows. Per #256, `:latest` is now correctly pushed by the tag run with the right embedded VERSION - no manual re-run needed this time.

Build gates (local): `go build ./...` clean, `golangci-lint run ./...` 0 issues, full per-package test suite passes (repository / services / api / integration / notifier / config / domain / testutil / db), `cd frontend && npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.3.3 released on 2026-05-29. Previously unreleased additions, fixes, and security updates are now officially part of this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->