### PR TITLE
feat(docker): custom ffmpeg with NVIDIA codec support + smarter hwaccel probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Docker image now ships a custom ffmpeg with NVIDIA codec support baked in.** The stock Alpine `apk` ffmpeg was compiled without NVDEC/NVENC/CUVID, so AV1 files always fell back to software decode (`libdav1d`) even on hosts with an NVIDIA GPU passed through. The image now bundles a from-source ffmpeg 7.1.1 built with `--enable-cuda --enable-cuvid --enable-nvdec --enable-nvenc --enable-vaapi`, so AV1 / HEVC / H.264 hardware decode and encode all work when `/dev/nvidia*` (NVIDIA Container Toolkit) or `/dev/dri` (VAAPI / Intel QSV / AMD) is exposed to the container. Runtime ABI shim (`gcompat`) is included so the musl-linked ffmpeg can dlopen the glibc NVIDIA libraries the Container Toolkit injects. Image size: 371 MB (was 249 MB).
+
+### Fixed
+- **Hardware acceleration probe no longer claims success on hosts that only expose an emulated VGA.** When `HEALARR_HEALTH_CHECK_HWACCEL=auto`, the probe used to accept any ffmpeg whose build advertised hwaccels, even inside a VM where the only "GPU" is QEMU/Bochs emulated VGA (PCI vendor `0x1234`) with no decode hardware behind it. Healarr would then add `-hwaccel auto` to every command, ffmpeg would silently fall back to software, and AV1 thorough checks would time out. The probe now also verifies that at least one credible GPU device is exposed to the container (`/dev/nvidiactl`, or a `/dev/dri/renderD*` whose sysfs vendor is not `0x1234`) and logs a clear warning otherwise so the misconfiguration is obvious from the logs.
+
 ## [1.3.3] - 2026-05-29
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,26 +43,87 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     ./cmd/server
 
 # -----------------------------------------------------------------------------
-# Stage 3: Production Runtime
+# Stage 3: ffmpeg builder (custom build with NVIDIA codec support)
+# -----------------------------------------------------------------------------
+# Alpine's stock ffmpeg is built without NVIDIA codec support, so AV1 files
+# silently decode in software (libdav1d) even when the host has an NVIDIA GPU
+# passed through. We compile ffmpeg from source with cuvid/nvdec/nvenc enabled.
+# nv-codec-headers is open-source stub headers - no CUDA toolkit is needed at
+# build time. At runtime ffmpeg dlopen's the host's libnvcuvid / libcuda /
+# libnvidia-encode injected by the NVIDIA Container Toolkit. Total image
+# growth vs stock Alpine ffmpeg: roughly nothing - we just trade the apk
+# binary for our own.
+FROM alpine:3.23 AS ffmpeg-builder
+
+ARG FFMPEG_VERSION=7.1.1
+ARG NVCODEC_HEADERS_VERSION=12.2.72.0
+
+RUN apk add --no-cache \
+    build-base nasm yasm pkgconfig bash wget tar xz \
+    x264-dev x265-dev libvpx-dev libass-dev opus-dev \
+    dav1d-dev aom-dev lame-dev libva-dev
+
+# NVIDIA codec header stubs (open source, ~50KB; no CUDA toolkit needed)
+WORKDIR /tmp/nv
+RUN wget -q "https://github.com/FFmpeg/nv-codec-headers/archive/refs/tags/n${NVCODEC_HEADERS_VERSION}.tar.gz" && \
+    tar -xzf "n${NVCODEC_HEADERS_VERSION}.tar.gz" && \
+    cd "nv-codec-headers-n${NVCODEC_HEADERS_VERSION}" && \
+    make install PREFIX=/usr/local
+
+# ffmpeg with the codec libs Healarr's health checks actually exercise.
+# Skipping --enable-libnpp (would need CUDA libs at build time) - that is for
+# image-processing filters, not the decode path we care about.
+WORKDIR /tmp/ffmpeg
+RUN wget -q "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" && \
+    tar -xJf "ffmpeg-${FFMPEG_VERSION}.tar.xz" && \
+    cd "ffmpeg-${FFMPEG_VERSION}" && \
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/pkgconfig \
+    ./configure \
+        --prefix=/opt/ffmpeg \
+        --enable-gpl --enable-nonfree --enable-version3 \
+        --enable-cuda --enable-cuvid --enable-nvdec --enable-nvenc \
+        --enable-vaapi \
+        --enable-libx264 --enable-libx265 \
+        --enable-libvpx --enable-libopus --enable-libass --enable-libmp3lame \
+        --enable-libdav1d --enable-libaom \
+        --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages \
+        --extra-cflags=-I/usr/local/include \
+        --extra-ldflags=-L/usr/local/lib && \
+    make -j"$(nproc)" && \
+    make install && \
+    strip /opt/ffmpeg/bin/ffmpeg /opt/ffmpeg/bin/ffprobe
+
+# -----------------------------------------------------------------------------
+# Stage 4: Production Runtime
 # -----------------------------------------------------------------------------
 FROM alpine:3.23
 
-# Install runtime dependencies
-# - ffmpeg: for video health checking (ffprobe)
+# Runtime dependencies.
+# - codec shared libs that match the builder stage's -dev packages (libx264,
+#   libx265, libvpx, libass, opus, dav1d, aom, lame)
 # - mediainfo: alternative health check method
-# - handbrake: HandBrake video transcoder (provides HandBrakeCLI)
-# - ca-certificates: for HTTPS connections to *arr APIs
-# - tzdata: for proper timezone handling
-# - su-exec: for running as non-root user after entrypoint setup
-# - shadow: for usermod/groupmod commands
+# - handbrake: HandBrake CLI for the HandBrake detection method
+# - ca-certificates, tzdata: HTTPS + TZ handling
+# - su-exec: drop privileges from root to PUID/PGID user
+# - shadow: usermod/groupmod for the PUID/PGID remap in the entrypoint
+# - gcompat: glibc-compat shim so the custom ffmpeg can dlopen the host's
+#   glibc-linked NVIDIA libs (libnvcuvid.so / libcuda.so / libnvidia-encode.so)
+#   that the NVIDIA Container Toolkit injects at runtime. Without it the
+#   dlopen fails silently on musl and we fall back to software decode.
 RUN apk add --no-cache \
-    ffmpeg \
     mediainfo \
     handbrake \
     ca-certificates \
     tzdata \
     su-exec \
-    shadow
+    shadow \
+    gcompat \
+    x264-libs x265-libs libvpx libass opus libgcc \
+    dav1d aom-libs lame-libs libva
+
+# Custom ffmpeg/ffprobe with NVIDIA cuvid/nvdec/nvenc (from ffmpeg-builder)
+COPY --from=ffmpeg-builder /opt/ffmpeg/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=ffmpeg-builder /opt/ffmpeg/bin/ffprobe /usr/local/bin/ffprobe
 
 # Create default user (will be modified by entrypoint if PUID/PGID set)
 RUN addgroup -g 1000 healarr && \

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -263,15 +263,23 @@ func resolveHwAccelArgs(ffmpegPath, setting string) []string {
 }
 
 // probeHwAccelAvailable runs "ffmpeg -hide_banner -hwaccels" and reports
-// whether any GPU accelerator is listed (anything other than "none"). Any
-// failure (binary missing, exec error) is treated as "no accel available" so
-// the caller silently falls back to software decode.
+// whether any GPU accelerator is listed AND a usable device node is exposed
+// to the container. Both halves matter: ffmpeg may have been compiled with
+// hwaccel support (it will show in -hwaccels) yet have no GPU to talk to
+// because /dev/dri or /dev/nvidia* was not mapped into the container - in
+// which case decode silently falls back to software (libdav1d for AV1) and
+// nobody notices until scans repeatedly time out. When that mismatch is
+// detected we log a clear warning instead of returning true, so the operator
+// can fix their compose entry rather than wondering why scans are still
+// CPU-bound. Any error (binary missing, exec error) is treated as "no accel
+// available".
 func probeHwAccelAvailable(ffmpegPath string) bool {
 	cmd := exec.Command(ffmpegPath, "-hide_banner", "-hwaccels")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return false
 	}
+	hwaccelsListed := false
 	for _, line := range strings.Split(string(out), "\n") {
 		name := strings.TrimSpace(line)
 		if name == "" || strings.Contains(strings.ToLower(name), "hardware acceleration methods") {
@@ -280,7 +288,63 @@ func probeHwAccelAvailable(ffmpegPath string) bool {
 		if strings.ToLower(name) == "none" {
 			continue
 		}
+		hwaccelsListed = true
+		break
+	}
+	if !hwaccelsListed {
+		return false
+	}
+	if !hwAccelDeviceAvailable() {
+		logger.Warnf("Health check: ffmpeg lists hardware accelerators in its build but no usable GPU device is exposed to the container. " +
+			"Decodes will silently fall back to software. To enable hardware acceleration, map /dev/nvidia* " +
+			"(for NVIDIA NVDEC/CUVID) or /dev/dri (for VAAPI/QSV) into the container via the compose 'devices:' entry " +
+			"and re-launch. See HEALARR_HEALTH_CHECK_HWACCEL.")
+		return false
+	}
+	return true
+}
+
+// hwAccelDeviceAvailable returns true if at least one credible GPU device
+// node is exposed to this container. Healarr does not care which accelerator
+// family is present; ffmpeg -hwaccel auto picks whatever works for the codec.
+// We just want to distinguish "ffmpeg was compiled with hwaccel support" from
+// "there is an actual device to talk to". Counts as available:
+//   - /dev/nvidiactl present (NVIDIA Container Toolkit has injected a card)
+//   - /dev/dri/renderD* present AND the device vendor is not QEMU/Bochs
+//     virtio (0x1234), which is the emulated VGA inside a VM with no GPU
+//     passthrough - it has a render node but no decode hardware behind it.
+//
+// If /sys/class/drm/<dev>/device/vendor cannot be read (sysfs not mounted,
+// permissions), we fail open and trust the presence of the render node.
+func hwAccelDeviceAvailable() bool {
+	return hwAccelDeviceAvailableIn("/dev", "/sys/class/drm")
+}
+
+// hwAccelDeviceAvailableIn is the testable form of hwAccelDeviceAvailable.
+// devRoot stands in for /dev, sysClassDrmRoot for /sys/class/drm. The split
+// lets tests assemble a fake filesystem layout without touching real device
+// nodes.
+func hwAccelDeviceAvailableIn(devRoot, sysClassDrmRoot string) bool {
+	if _, err := os.Stat(filepath.Join(devRoot, "nvidiactl")); err == nil {
 		return true
+	}
+	entries, err := os.ReadDir(filepath.Join(devRoot, "dri"))
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "renderD") {
+			continue
+		}
+		vendor, err := os.ReadFile(filepath.Join(sysClassDrmRoot, e.Name(), "device", "vendor"))
+		if err != nil {
+			// sysfs path not readable; presence of the render node is the best signal we have.
+			return true
+		}
+		// Vendor ID 0x1234 is QEMU/Bochs emulated VGA - no decode hardware.
+		if strings.TrimSpace(string(vendor)) != "0x1234" {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -1669,3 +1669,136 @@ func hwAccelSlicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// =============================================================================
+// hwAccelDeviceAvailable tests
+// =============================================================================
+
+// fakeGPULayout builds a fake /dev + /sys/class/drm pair under tempdir for
+// driving hwAccelDeviceAvailableIn. Returns (devRoot, sysClassDrmRoot).
+func fakeGPULayout(t *testing.T, opts fakeGPUOpts) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	devRoot := filepath.Join(root, "dev")
+	sysClassDrm := filepath.Join(root, "sys", "class", "drm")
+	if err := os.MkdirAll(devRoot, 0o755); err != nil {
+		t.Fatalf("mkdir devRoot: %v", err)
+	}
+	if err := os.MkdirAll(sysClassDrm, 0o755); err != nil {
+		t.Fatalf("mkdir sysClassDrm: %v", err)
+	}
+
+	if opts.hasNvidiactl {
+		if err := os.WriteFile(filepath.Join(devRoot, "nvidiactl"), []byte{}, 0o644); err != nil {
+			t.Fatalf("write nvidiactl: %v", err)
+		}
+	}
+
+	if len(opts.driEntries) > 0 {
+		driDir := filepath.Join(devRoot, "dri")
+		if err := os.MkdirAll(driDir, 0o755); err != nil {
+			t.Fatalf("mkdir dri: %v", err)
+		}
+		for _, e := range opts.driEntries {
+			if err := os.WriteFile(filepath.Join(driDir, e.name), []byte{}, 0o644); err != nil {
+				t.Fatalf("write %s: %v", e.name, err)
+			}
+			if e.vendorID != "" {
+				deviceDir := filepath.Join(sysClassDrm, e.name, "device")
+				if err := os.MkdirAll(deviceDir, 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", deviceDir, err)
+				}
+				if err := os.WriteFile(filepath.Join(deviceDir, "vendor"), []byte(e.vendorID+"\n"), 0o644); err != nil {
+					t.Fatalf("write vendor: %v", err)
+				}
+			}
+		}
+	}
+
+	return devRoot, sysClassDrm
+}
+
+type fakeDRIEntry struct {
+	name     string
+	vendorID string // empty -> no sysfs vendor file at all (simulating unreadable sysfs)
+}
+
+type fakeGPUOpts struct {
+	hasNvidiactl bool
+	driEntries   []fakeDRIEntry
+}
+
+func TestHwAccelDeviceAvailableIn(t *testing.T) {
+	tests := []struct {
+		name string
+		opts fakeGPUOpts
+		want bool
+	}{
+		{
+			name: "nvidiactl present -> available",
+			opts: fakeGPUOpts{hasNvidiactl: true},
+			want: true,
+		},
+		{
+			name: "no nvidiactl and no /dev/dri -> not available",
+			opts: fakeGPUOpts{},
+			want: false,
+		},
+		{
+			name: "renderD128 with real vendor (Intel 0x8086) -> available",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "renderD128", vendorID: "0x8086"}}},
+			want: true,
+		},
+		{
+			name: "renderD128 with AMD vendor (0x1002) -> available",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "renderD128", vendorID: "0x1002"}}},
+			want: true,
+		},
+		{
+			name: "renderD128 with NVIDIA vendor (0x10de) -> available",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "renderD128", vendorID: "0x10de"}}},
+			want: true,
+		},
+		{
+			name: "only QEMU/Bochs emulated VGA (0x1234) -> not available",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "renderD128", vendorID: "0x1234"}}},
+			want: false,
+		},
+		{
+			name: "QEMU emulated card AND a real Intel card -> available (real one wins)",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{
+				{name: "renderD128", vendorID: "0x1234"},
+				{name: "renderD129", vendorID: "0x8086"},
+			}},
+			want: true,
+		},
+		{
+			name: "render node with unreadable sysfs vendor -> fail open (available)",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "renderD128", vendorID: ""}}},
+			want: true,
+		},
+		{
+			name: "non-render node (card0) is ignored",
+			opts: fakeGPUOpts{driEntries: []fakeDRIEntry{{name: "card0", vendorID: "0x8086"}}},
+			want: false,
+		},
+		{
+			name: "nvidiactl wins even if /dev/dri only has emulated VGA",
+			opts: fakeGPUOpts{
+				hasNvidiactl: true,
+				driEntries:   []fakeDRIEntry{{name: "renderD128", vendorID: "0x1234"}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devRoot, sysClassDrm := fakeGPULayout(t, tt.opts)
+			got := hwAccelDeviceAvailableIn(devRoot, sysClassDrm)
+			if got != tt.want {
+				t.Errorf("hwAccelDeviceAvailableIn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The stock Alpine \`apk\` ffmpeg is built **without** NVIDIA codec support, so AV1 files in the live deployment have been silently falling back to software decode (libdav1d) even on the GPU host. This PR replaces it with a from-source ffmpeg 7.1.1 built with full NVDEC/NVENC/CUVID + VAAPI.

It also closes a sibling false-positive: the existing \`HEALARR_HEALTH_CHECK_HWACCEL=auto\` probe used to claim success on any ffmpeg whose **build** advertised hwaccels, even inside a VM whose only "GPU" was QEMU emulated VGA. Now the probe also verifies a real device node is exposed.

### Image size landed

| Variant | Size | NVDEC | NVENC | VAAPI |
|---|---|---|---|---|
| Current \`latest\` (stock Alpine ffmpeg) | 249 MB | x | x | x |
| Debian-slim (tried, rejected, 625 MB heavier) | 874 MB | check | check | check |
| **This PR** (Alpine + custom ffmpeg) | **371 MB** | check | check | check |

### What's in the new ffmpeg

- \`av1_cuvid\`, \`h264_cuvid\`, \`hevc_cuvid\` (NVDEC)
- \`av1_nvenc\`, \`h264_nvenc\`, \`hevc_nvenc\` (NVENC)
- VAAPI (Intel QSV / AMD)
- All the userspace codec libs we already shipped (x264, x265, libvpx, dav1d, aom, opus, libass, lame)
- \`gcompat\` runtime shim so the musl-linked ffmpeg can dlopen the glibc NVIDIA libs the NVIDIA Container Toolkit injects

The CUDA toolkit is **not** needed at build time. Only \`nv-codec-headers\` (open-source header stubs) is. The actual NVIDIA shared libraries are injected by the host at container start.

### Smarter hwaccel probe

Added \`hwAccelDeviceAvailable\` (split into \`hwAccelDeviceAvailableIn\` for testability). Returns true when:

- \`/dev/nvidiactl\` is present, OR
- a \`/dev/dri/renderD*\` exists whose sysfs PCI vendor is not \`0x1234\` (QEMU/Bochs emulated VGA)

If neither, \`probeHwAccelAvailable\` returns false and logs an actionable warning pointing at the compose \`devices:\` entry. Previously this case silently degraded to software decode and AV1 thorough scans timed out.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./internal/integration/\` -> 0 issues
- [x] \`go test ./internal/integration/\` -> all green (10 new subtests for the device probe, including the QEMU 0x1234 case, NVIDIA/AMD/Intel vendor IDs, missing sysfs fail-open, mixed real+emulated, non-render-node ignore)
- [x] Docker image build succeeds end-to-end (\`docker build -t healarr:hwaccel-alpine .\`)
- [x] Inside built image: \`ffmpeg -decoders | grep cuvid\` shows av1_cuvid / h264_cuvid / hevc_cuvid
- [x] Inside built image: \`ffmpeg -encoders | grep nvenc\` shows av1_nvenc / h264_nvenc / hevc_nvenc
- [x] Inside built image: \`ffmpeg -hwaccels\` lists \`cuda\`, \`vaapi\`, \`drm\`
- [x] Inside built image: \`ldd /usr/local/bin/ffmpeg\` resolves cleanly under musl
- [ ] Deploy to Sokaris (RTX 4070 + NVIDIA Container Toolkit), confirm AV1 file decodes via NVDEC end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker image now includes a custom FFmpeg build with NVIDIA codec support for hardware acceleration
  * Enhanced GPU device detection that verifies actual GPU presence and logs warnings when devices are not properly exposed

* **Bug Fixes**
  * Hardware acceleration probe now validates actual GPU device availability rather than just reporting compiled-in support

* **Tests**
  * Added comprehensive test coverage for GPU device availability detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mescon/Healarr/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->