### PR TITLE
fix(paths): accept Windows and UNC absolute paths in scan-path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scan-path validation no longer rejects Windows and UNC paths.** The frontend Zod schema required both `local_path` and `arr_path` to start with `/`, which is wrong for two cases: (1) Healarr running on Windows directly (the binary, not the Docker image), and (2) Healarr running on Linux while talking to a Sonarr/Radarr that itself runs on Windows and therefore returns paths like `D:\Media\Movies` or `\\server\share\Movies`. Both fields now accept POSIX absolute (`/foo`), Windows drive-letter (`C:\foo`, `c:/foo`), and UNC (`\\server\share`, `//server/share`) forms. Fixes [#255](https://github.com/mescon/Healarr/issues/255).
+
 ### Changed
 - **Docker image now ships a custom ffmpeg with NVIDIA codec support baked in.** The stock Alpine `apk` ffmpeg was compiled without NVDEC/NVENC/CUVID, so AV1 files always fell back to software decode (`libdav1d`) even on hosts with an NVIDIA GPU passed through. The image now bundles a from-source ffmpeg 7.1.1 built with `--enable-cuda --enable-cuvid --enable-nvdec --enable-nvenc --enable-vaapi`, so AV1 / HEVC / H.264 hardware decode and encode all work when `/dev/nvidia*` (NVIDIA Container Toolkit) or `/dev/dri` (VAAPI / Intel QSV / AMD) is exposed to the container. Runtime ABI shim (`gcompat`) is included so the musl-linked ffmpeg can dlopen the glibc NVIDIA libraries the Container Toolkit injects. Image size: 371 MB (was 249 MB).
 

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { isAbsolutePath } from './paths';
+
+describe('isAbsolutePath', () => {
+  describe('POSIX absolute paths', () => {
+    it.each([
+      '/',
+      '/media',
+      '/media/Movies',
+      '/mnt/storage/tv',
+      '/foo/bar/baz.mkv',
+    ])('accepts %s', (path) => {
+      expect(isAbsolutePath(path)).toBe(true);
+    });
+
+    it('accepts // (also valid as a Linux-style UNC)', () => {
+      expect(isAbsolutePath('//alexpr4100/media/TV Shows')).toBe(true);
+    });
+  });
+
+  describe('Windows drive-letter paths', () => {
+    it.each([
+      'C:\\',
+      'C:\\Media',
+      'C:\\Media\\Movies',
+      'D:\\Media\\TV Shows',
+      'Z:\\foo',
+    ])('accepts backslash form %s', (path) => {
+      expect(isAbsolutePath(path)).toBe(true);
+    });
+
+    it.each(['C:/', 'C:/Media', 'd:/media/movies'])(
+      'accepts forward-slash form %s',
+      (path) => {
+        expect(isAbsolutePath(path)).toBe(true);
+      },
+    );
+
+    it('accepts lowercase drive letters', () => {
+      expect(isAbsolutePath('c:\\foo')).toBe(true);
+    });
+  });
+
+  describe('Windows UNC paths', () => {
+    it.each([
+      '\\\\server\\share',
+      '\\\\server\\share\\foo',
+      '\\\\alexpr4100\\media\\Movies',
+    ])('accepts backslash UNC %s', (path) => {
+      expect(isAbsolutePath(path)).toBe(true);
+    });
+  });
+
+  describe('rejected paths', () => {
+    it.each([
+      '',
+      'relative/path',
+      'media',
+      './foo',
+      '../foo',
+      'C:',
+      'C:foo',
+      '1:\\foo',
+      '\\notUNC',
+    ])('rejects %s', (path) => {
+      expect(isAbsolutePath(path)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns true if `path` is an absolute path in any of the forms we accept:
+ *   - POSIX absolute:           /foo, /foo/bar
+ *   - Windows drive-letter:     C:\foo, c:/foo, D:\Media\Movies
+ *   - Windows UNC (backslash):  \\server\share\foo
+ *   - Windows UNC (forward):    //server/share/foo  (covered by the POSIX rule)
+ *
+ * Healarr can run on either Linux or Windows, and even when it runs on one
+ * OS the *arr it talks to may run on the other. local_path must match
+ * Healarr's host (the process opens the file); arr_path must match the
+ * *arr's host (it is a label substituted into *arr API calls). Both fields
+ * therefore need to accept absolute paths from either OS.
+ */
+export function isAbsolutePath(path: string): boolean {
+  if (path.startsWith('/')) return true;
+  if (path.startsWith('\\\\')) return true;
+  return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+export const absolutePathErrorMessage =
+  'Must be an absolute path (Linux /path, Windows C:\\path, or UNC \\\\server\\share)';

--- a/frontend/src/lib/schemas/scan-path.ts
+++ b/frontend/src/lib/schemas/scan-path.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { absolutePathErrorMessage, isAbsolutePath } from '../paths';
 
 /**
  * Validation schema for scan path configuration.
@@ -8,15 +9,11 @@ export const scanPathSchema = z.object({
   local_path: z
     .string()
     .min(1, 'Path is required')
-    .refine((path) => path.startsWith('/'), {
-      message: 'Path must be an absolute path starting with /',
-    }),
+    .refine(isAbsolutePath, { message: absolutePathErrorMessage }),
   arr_path: z
     .string()
     .min(1, 'Arr path is required')
-    .refine((path) => path.startsWith('/'), {
-      message: 'Arr path must be an absolute path starting with /',
-    }),
+    .refine(isAbsolutePath, { message: absolutePathErrorMessage }),
   arr_instance_id: z
     .number()
     .nullable()


### PR DESCRIPTION
Fixes #255.

## Summary

The scan-path form rejected Windows and UNC paths because the frontend Zod schema required both \`local_path\` and \`arr_path\` to start with \`/\`. That's wrong for two real cases:

1. **Healarr running natively on Windows.** \`local_path\` is the file the Healarr process opens, so it has to match Healarr's host OS. On a Windows host that means \`C:\Media\...\`.
2. **Healarr on Linux talking to a Windows *arr.** \`arr_path\` is a label substituted into *arr API calls, so it has to match the *arr's host OS. A Windows Sonarr returns \`D:\Media\Movies\` or \`\\server\share\Movies\` and the form refused to save those.

Issue #255 hit case 2: Healarr in Docker on Windows, *arr also on Windows with NAS-mounted media, UNC paths everywhere, and no way to enter them.

## Fix

New shared \`isAbsolutePath\` predicate accepts:
- POSIX absolute: \`/foo\`, \`/foo/bar\`
- Windows drive: \`C:\foo\`, \`c:/foo\`, \`D:\Media\Movies\`
- Windows UNC backslash: \`\\server\share\foo\`
- Windows UNC forward: \`//server/share/foo\` (same code path as POSIX)

Applied to both \`local_path\` and \`arr_path\`. Go backend already uses OS-specific \`filepath.IsAbs\`, so no backend change needed.

## Test plan

- [x] \`npx vitest run src/lib/paths.test.ts\` -> 27/27 passing (all forms above, plus rejection of empty / relative / bare-drive-letter / non-letter-drive / single-backslash)
- [x] Full \`npx vitest run\` -> 166 passing, 1 skipped (no regressions)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (0 issues)
- [x] \`npm run build\` succeeds
- [ ] Verify in browser: existing /-style paths still validate; Windows \`C:\foo\` and \`\\server\share\foo\` now save without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Scan-path validation now accepts Windows drive-letter paths (e.g., `C:\folder`) and Windows UNC paths in addition to POSIX absolute paths, resolving cross-platform path compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->