### PR TITLE
feat(config): runtime tunables editable from UI (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Settings page now exposes the runtime tunables that were previously env-only.** Thirteen `HEALARR_*` knobs are now editable from `/config` (full list: thorough decode duration / timeout, hardware acceleration mode, default retry cap, scanner worker count, scanner shutdown timeout, dry-run mode, retention days, verification timeout / interval, stale threshold, *arr rate limit RPS / burst). Each field shows whether its current value comes from env, the DB, or the built-in default; env-set values render as read-only with a "Set by `HEALARR_FOO`" badge so it's obvious which fields are operator-locked. Phase 1 of a larger /config redesign - per-path overrides and preset bundles are next. The "first 60 seconds of decode" trick (the main practical use of `HEALARR_HEALTH_CHECK_THOROUGH_DURATION`) is now one click in the UI.
+
+### Changed
+- **Thorough scan duration / timeout / hwaccel changes take effect on the next scan tick without a restart.** These three values were previously only read at process startup. The internal resolver now consults env > DB > default at every health-check call, so a UI-side change applies immediately to the next file scanned. The other ten tunables still flag as restart-required because they are bound to subsystems (scheduler, rate limiter, retention pruner) that cache their config on startup.
+
 ### Fixed
 - **Scan-path validation no longer rejects Windows and UNC paths.** The frontend Zod schema required both `local_path` and `arr_path` to start with `/`, which is wrong for two cases: (1) Healarr running on Windows directly (the binary, not the Docker image), and (2) Healarr running on Linux while talking to a Sonarr/Radarr that itself runs on Windows and therefore returns paths like `D:\Media\Movies` or `\\server\share\Movies`. Both fields now accept POSIX absolute (`/foo`), Windows drive-letter (`C:\foo`, `c:/foo`), and UNC (`\\server\share`, `//server/share`) forms. Fixes [#255](https://github.com/mescon/Healarr/issues/255).
 

--- a/frontend/src/components/config/TunablesSection.tsx
+++ b/frontend/src/components/config/TunablesSection.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Save, Info, Lock } from 'lucide-react';
+import { getTunables, updateTunables, type TunableValue } from '../../lib/api';
+import { useToast } from '../../contexts/ToastContext';
+
+interface TunablesSectionProps {
+    /** Heading shown at the top of the card. */
+    title: string;
+    /** One-sentence helper text under the title. */
+    subtitle?: string;
+    /** Lucide icon for the header chip. */
+    icon: React.ElementType;
+    iconColor: string;
+    /**
+     * Which catalog entries to render. The list is the union of any keys
+     * matching `keyPrefix` and any keys in `keys`. Order in the rendered
+     * card follows the order of `keys` (then the catalog's own order for
+     * anything caught by `keyPrefix`).
+     */
+    keyPrefix?: string;
+    keys?: string[];
+    /** Framer Motion delay for stagger. */
+    delay?: number;
+}
+
+const humanizeKey = (key: string): string => {
+    const tail = key.split('.').pop() ?? key;
+    return tail
+        .split('_')
+        .filter((s) => s !== 'seconds')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+};
+
+/**
+ * Returns a short human label describing where a tunable's current value
+ * came from. Used in the per-field source badge so operators can tell at
+ * a glance which fields are locked by env vs. live in the DB.
+ */
+const sourceLabel = (t: TunableValue): { text: string; tone: 'env' | 'db' | 'default' } => {
+    if (t.source === 'env') return { text: `Set by ${t.env_var}`, tone: 'env' };
+    if (t.source === 'db') return { text: 'Customized', tone: 'db' };
+    return { text: 'Default', tone: 'default' };
+};
+
+const TunablesSection = ({
+    title,
+    subtitle,
+    icon: Icon,
+    iconColor,
+    keyPrefix,
+    keys,
+    delay = 0.1,
+}: TunablesSectionProps) => {
+    const toast = useToast();
+    const queryClient = useQueryClient();
+    const { data, isLoading, error } = useQuery({
+        queryKey: ['tunables'],
+        queryFn: getTunables,
+    });
+
+    // Local form state: key -> value the user has typed but not yet saved.
+    // Falls back to the canonical value from the server when a field has not
+    // been touched. We never mutate `data` directly; the mutation refetch
+    // is the source of truth after save.
+    const [draft, setDraft] = useState<Record<string, number | string | boolean>>({});
+
+    const tunables = useMemo<TunableValue[]>(() => {
+        if (!data) return [];
+        return data.tunables.filter((t) => {
+            if (keys && keys.includes(t.key)) return true;
+            if (keyPrefix && t.key.startsWith(keyPrefix)) return true;
+            return false;
+        });
+    }, [data, keys, keyPrefix]);
+
+    const mutation = useMutation({
+        mutationFn: (updates: Record<string, number | string | boolean>) =>
+            updateTunables(updates),
+        onSuccess: () => {
+            toast.success('Settings saved');
+            setDraft({});
+            void queryClient.invalidateQueries({ queryKey: ['tunables'] });
+        },
+        onError: (err: unknown) => {
+            const e = err as { response?: { data?: { error?: string } }; message?: string };
+            toast.error(`Save failed: ${e.response?.data?.error ?? e.message ?? 'unknown'}`);
+        },
+    });
+
+    const handleSave = () => {
+        if (Object.keys(draft).length === 0) return;
+        mutation.mutate(draft);
+    };
+
+    const handleChange = (key: string, value: number | string | boolean) => {
+        setDraft((prev) => ({ ...prev, [key]: value }));
+    };
+
+    if (isLoading) {
+        return (
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay }}
+                className="bg-white dark:bg-slate-900 rounded-xl p-6 shadow-sm border border-slate-200 dark:border-slate-800"
+            >
+                <p className="text-slate-500 dark:text-slate-400 text-sm">Loading settings…</p>
+            </motion.div>
+        );
+    }
+
+    if (error) {
+        return (
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, delay }}
+                className="bg-white dark:bg-slate-900 rounded-xl p-6 shadow-sm border border-red-200 dark:border-red-900"
+            >
+                <p className="text-red-600 dark:text-red-400 text-sm">Failed to load settings.</p>
+            </motion.div>
+        );
+    }
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay }}
+            className="bg-white dark:bg-slate-900 rounded-xl p-6 shadow-sm border border-slate-200 dark:border-slate-800"
+        >
+            <div className="flex items-center gap-3 mb-6">
+                <div className={`p-2 rounded-lg ${iconColor}`}>
+                    <Icon className="w-5 h-5 text-white" />
+                </div>
+                <div>
+                    <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h2>
+                    {subtitle && (
+                        <p className="text-sm text-slate-500 dark:text-slate-400">{subtitle}</p>
+                    )}
+                </div>
+            </div>
+
+            <div className="space-y-5">
+                {tunables.map((t) => (
+                    <TunableField
+                        key={t.key}
+                        tunable={t}
+                        draftValue={draft[t.key]}
+                        onChange={(v) => handleChange(t.key, v)}
+                    />
+                ))}
+            </div>
+
+            <div className="flex justify-end mt-6 pt-4 border-t border-slate-200 dark:border-slate-800">
+                <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={Object.keys(draft).length === 0 || mutation.isPending}
+                    className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                    <Save className="w-4 h-4" />
+                    {mutation.isPending ? 'Saving…' : 'Save changes'}
+                </button>
+            </div>
+        </motion.div>
+    );
+};
+
+interface TunableFieldProps {
+    tunable: TunableValue;
+    draftValue: number | string | boolean | undefined;
+    onChange: (value: number | string | boolean) => void;
+}
+
+const TunableField = ({ tunable, draftValue, onChange }: TunableFieldProps) => {
+    const label = humanizeKey(tunable.key);
+    const src = sourceLabel(tunable);
+    const isLocked = tunable.source === 'env';
+    // Effective value (draft if user has touched the field, else server value)
+    const current = draftValue ?? tunable.value;
+
+    return (
+        <div>
+            <div className="flex items-baseline justify-between mb-1">
+                <label className="text-sm font-medium text-slate-800 dark:text-slate-200">
+                    {label}
+                    {tunable.requires_restart && (
+                        <span className="ml-2 text-[10px] uppercase tracking-wider text-amber-600 dark:text-amber-400">
+                            restart required
+                        </span>
+                    )}
+                </label>
+                <SourceBadge tone={src.tone} text={src.text} />
+            </div>
+
+            {tunable.description && (
+                <p className="text-xs text-slate-500 dark:text-slate-400 mb-2 flex items-start gap-1">
+                    <Info className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                    <span>{tunable.description}</span>
+                </p>
+            )}
+
+            <FieldControl tunable={tunable} value={current} disabled={isLocked} onChange={onChange} />
+        </div>
+    );
+};
+
+const SourceBadge = ({ tone, text }: { tone: 'env' | 'db' | 'default'; text: string }) => {
+    const classes: Record<typeof tone, string> = {
+        env: 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300',
+        db: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300',
+        default: 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400',
+    };
+    return (
+        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] ${classes[tone]}`}>
+            {tone === 'env' && <Lock className="w-3 h-3" />}
+            {text}
+        </span>
+    );
+};
+
+interface FieldControlProps {
+    tunable: TunableValue;
+    value: number | string | boolean;
+    disabled: boolean;
+    onChange: (value: number | string | boolean) => void;
+}
+
+const FieldControl = ({ tunable, value, disabled, onChange }: FieldControlProps) => {
+    const cls =
+        'w-full px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm text-slate-900 dark:text-slate-100 disabled:bg-slate-100 dark:disabled:bg-slate-900 disabled:cursor-not-allowed';
+
+    switch (tunable.kind) {
+        case 'enum':
+            return (
+                <select
+                    className={cls}
+                    disabled={disabled}
+                    value={String(value)}
+                    onChange={(e) => onChange(e.target.value)}
+                >
+                    {tunable.enum_values?.map((v) => (
+                        <option key={v} value={v}>
+                            {v}
+                        </option>
+                    ))}
+                </select>
+            );
+        case 'bool':
+            return (
+                <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                    <input
+                        type="checkbox"
+                        disabled={disabled}
+                        checked={Boolean(value)}
+                        onChange={(e) => onChange(e.target.checked)}
+                        className="rounded border-slate-300 dark:border-slate-700"
+                    />
+                    Enabled
+                </label>
+            );
+        case 'int':
+            return (
+                <input
+                    type="number"
+                    className={cls}
+                    disabled={disabled}
+                    min={tunable.min_int}
+                    max={tunable.max_int}
+                    step={1}
+                    value={Number(value)}
+                    onChange={(e) => onChange(Number(e.target.value))}
+                />
+            );
+        case 'float':
+            return (
+                <input
+                    type="number"
+                    className={cls}
+                    disabled={disabled}
+                    min={tunable.min_float}
+                    max={tunable.max_float}
+                    step="0.1"
+                    value={Number(value)}
+                    onChange={(e) => onChange(Number(e.target.value))}
+                />
+            );
+        case 'duration_seconds':
+            return <DurationControl tunable={tunable} value={Number(value)} disabled={disabled} onChange={onChange} />;
+        case 'string':
+        default:
+            return (
+                <input
+                    type="text"
+                    className={cls}
+                    disabled={disabled}
+                    value={String(value)}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            );
+    }
+};
+
+interface DurationControlProps {
+    tunable: TunableValue;
+    value: number; // seconds
+    disabled: boolean;
+    onChange: (value: number) => void;
+}
+
+const DurationControl = ({ tunable, value, disabled, onChange }: DurationControlProps) => {
+    // Pick the friendliest unit to display in: hours if value is a whole
+    // number of hours, minutes if whole minutes, else seconds. The user can
+    // change the unit independently of what we picked.
+    const initialUnit: 'seconds' | 'minutes' | 'hours' =
+        value > 0 && value % 3600 === 0 ? 'hours' : value > 0 && value % 60 === 0 ? 'minutes' : 'seconds';
+    const [unit, setUnit] = useState<'seconds' | 'minutes' | 'hours'>(initialUnit);
+
+    const scale = unit === 'hours' ? 3600 : unit === 'minutes' ? 60 : 1;
+    const displayValue = Math.round((value / scale) * 1000) / 1000;
+
+    const handleNumberChange = (n: number) => {
+        if (Number.isNaN(n) || n < 0) return;
+        onChange(Math.round(n * scale));
+    };
+
+    return (
+        <div className="flex gap-2">
+            <input
+                type="number"
+                min={0}
+                step={unit === 'hours' ? 0.25 : 1}
+                value={displayValue}
+                disabled={disabled}
+                onChange={(e) => handleNumberChange(Number(e.target.value))}
+                className="flex-1 px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm text-slate-900 dark:text-slate-100 disabled:bg-slate-100 dark:disabled:bg-slate-900"
+                aria-label={`${tunable.key} value`}
+            />
+            <select
+                value={unit}
+                disabled={disabled}
+                onChange={(e) => setUnit(e.target.value as 'seconds' | 'minutes' | 'hours')}
+                className="px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-sm text-slate-900 dark:text-slate-100 disabled:bg-slate-100 dark:disabled:bg-slate-900"
+                aria-label="unit"
+            >
+                <option value="seconds">seconds</option>
+                <option value="minutes">minutes</option>
+                <option value="hours">hours</option>
+            </select>
+        </div>
+    );
+};
+
+export default TunablesSection;

--- a/frontend/src/components/config/index.ts
+++ b/frontend/src/components/config/index.ts
@@ -6,3 +6,4 @@ export { default as CronTimeBuilder } from './CronTimeBuilder';
 export { default as ArrServersSection } from './ArrServersSection';
 export { default as ScanPathsSection } from './ScanPathsSection';
 export { default as SchedulesSection } from './SchedulesSection';
+export { default as TunablesSection } from './TunablesSection';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -473,6 +473,61 @@ export const resetSetupWizard = async (): Promise<{ message: string }> => {
     return data;
 };
 
+// Tunables - runtime-editable settings that mirror HEALARR_* env vars.
+// One entry per row in the backend's repository.Catalog.
+export type TunableKind =
+    | 'duration_seconds'
+    | 'int'
+    | 'float'
+    | 'bool'
+    | 'string'
+    | 'enum';
+
+export type TunableSource = 'env' | 'db' | 'default';
+
+export interface TunableValue {
+    key: string;
+    env_var: string;
+    kind: TunableKind;
+    description: string;
+    requires_restart: boolean;
+    enum_values?: string[];
+    min_int?: number;
+    max_int?: number;
+    min_float?: number;
+    max_float?: number;
+    // Effective value, JSON-typed per kind:
+    //   duration_seconds -> number (seconds)
+    //   int -> number
+    //   float -> number
+    //   bool -> boolean
+    //   string / enum -> string
+    value: number | string | boolean;
+    // Raw env var string if env is set, else null.
+    env_value: string | null;
+    // Raw DB row string if DB has a value, else null.
+    db_value: string | null;
+    source: TunableSource;
+}
+
+export interface TunablesResponse {
+    tunables: TunableValue[];
+}
+
+export const getTunables = async (): Promise<TunablesResponse> => {
+    const { data } = await api.get<TunablesResponse>('/config/tunables');
+    return data;
+};
+
+export const updateTunables = async (
+    updates: Record<string, number | string | boolean>,
+): Promise<TunablesResponse> => {
+    const { data } = await api.put<TunablesResponse>('/config/tunables', {
+        updates,
+    });
+    return data;
+};
+
 // --- Notification API ---
 
 export interface NotificationConfig {

--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -15,7 +15,8 @@ import clsx from 'clsx';
 import { useToast } from '../contexts/ToastContext';
 import ConfigWarningBanner from '../components/ConfigWarningBanner';
 import AboutSection from '../components/AboutSection';
-import { ArrServersSection, ScanPathsSection, SchedulesSection } from '../components/config';
+import { ArrServersSection, ScanPathsSection, SchedulesSection, TunablesSection } from '../components/config';
+import { Sliders, Activity } from 'lucide-react';
 
 // Notifications Section - imported directly as it has its own complex structure
 import NotificationsSection from './config/NotificationsSection';
@@ -802,6 +803,24 @@ const Config = () => {
             {/* Scan Paths Section */}
             <ScanPathsSection onScrollToDetectionTools={scrollToDetectionTools} />
 
+            {/* Scanning Defaults Section - exposes thorough_duration / timeout / hwaccel / max_retries
+                so operators can tune the "first 60s of decode" feature without env vars or restarts */}
+            <TunablesSection
+                title="Scanning defaults"
+                subtitle="Tuning knobs that apply to all scans. Override per-path on individual scan paths."
+                icon={Sliders}
+                iconColor="bg-blue-500 dark:bg-blue-600"
+                keys={[
+                    'scan.thorough_duration_seconds',
+                    'scan.thorough_timeout_seconds',
+                    'scan.hwaccel',
+                    'scan.default_max_retries',
+                    'scan.workers',
+                    'scan.shutdown_timeout_seconds',
+                    'scan.dry_run_mode',
+                ]}
+            />
+
             {/* Scheduled Scans Section */}
             <SchedulesSection />
 
@@ -906,6 +925,22 @@ const Config = () => {
 
                                         <ServerSettingsSection runtimeConfig={runtimeConfig} queryClient={queryClient} toast={toast} />
                                     </div>
+
+                                    {/* Maintenance & rate limits - retention, verification cadence, *arr API throttling */}
+                                    <TunablesSection
+                                        title="Maintenance & rate limits"
+                                        subtitle="Retention, verification cadence, and outbound rate limits."
+                                        icon={Activity}
+                                        iconColor="bg-emerald-500 dark:bg-emerald-600"
+                                        keys={[
+                                            'maintenance.retention_days',
+                                            'maintenance.verification_timeout_seconds',
+                                            'maintenance.verification_interval_seconds',
+                                            'maintenance.stale_threshold_seconds',
+                                            'limits.arr_rate_limit_rps',
+                                            'limits.arr_rate_limit_burst',
+                                        ]}
+                                    />
 
                                     {/* Security */}
                                     <div className="space-y-4">

--- a/internal/api/handlers_tunables.go
+++ b/internal/api/handlers_tunables.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mescon/Healarr/internal/repository"
+)
+
+// getTunables returns every catalog entry with its effective value,
+// source (env / db / default), the raw env and DB strings (so the UI
+// can show "Set by HEALARR_FOO"), and the metadata needed to render
+// the form (kind, bounds, enum values, requires_restart).
+func (s *RESTServer) getTunables(c *gin.Context) {
+	tn := repository.NewTunables(s.settings)
+	values, err := tn.ResolveAll(c.Request.Context())
+	if err != nil {
+		respondDatabaseError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"tunables": values})
+}
+
+// updateTunables performs a bulk update of one or more tunables.
+//
+// Request shape:
+//
+//	{ "updates": { "scan.thorough_duration_seconds": 60, "scan.hwaccel": "cuda" } }
+//
+// Validation runs through TunablesValidateAndStore which:
+//   - rejects unknown keys
+//   - rejects keys whose matching env var is set (env always wins)
+//   - enforces per-kind bounds and enum membership
+//   - writes the entire batch atomically (one transaction)
+//
+// Error messages from validation are surfaced directly to the caller so
+// the UI can render an inline field error - unlike respondBadRequest
+// which masks the error to avoid leaking internals, here the messages
+// already describe user-facing input problems ("value 999 out of
+// range", "tunable X locked by env var Y").
+func (s *RESTServer) updateTunables(c *gin.Context) {
+	var req struct {
+		Updates map[string]any `json:"updates"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		respondBadRequest(c, err)
+		return
+	}
+	if len(req.Updates) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no updates supplied"})
+		return
+	}
+
+	tn := repository.NewTunables(s.settings)
+	if err := tn.ValidateAndStore(c.Request.Context(), req.Updates); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	values, err := tn.ResolveAll(c.Request.Context())
+	if err != nil {
+		respondDatabaseError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"tunables": values})
+}

--- a/internal/api/handlers_tunables_test.go
+++ b/internal/api/handlers_tunables_test.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mescon/Healarr/internal/repository"
+	"github.com/mescon/Healarr/internal/testutil"
+)
+
+// setupTunablesTestServer wires just the two tunable routes for focused
+// HTTP-level testing. Reuses setupConfigTestDB / setupConfigTestServer
+// because the protected route group already covers authMiddleware.
+func setupTunablesTestServer(t *testing.T) (*gin.Engine, string, func()) {
+	t.Helper()
+	db, dbCleanup := setupConfigTestDB(t)
+	pm := &testutil.MockPathMapper{}
+	r, apiKey, srvCleanup := setupConfigTestServer(t, db, pm, false)
+
+	// Build one server bound to the shared db, then mount the tunable
+	// routes on a protected group that uses *its* authMiddleware. Using
+	// the same server instance for middleware and handlers ensures both
+	// share the same SettingsRepository (otherwise the middleware can't
+	// resolve the API key row).
+	gin.SetMode(gin.TestMode)
+	s := &RESTServer{db: db}
+	s.initRepositories()
+	api := r.Group("/api")
+	protected := api.Group("")
+	protected.Use(s.authMiddleware())
+	protected.GET("/config/tunables", s.getTunables)
+	protected.PUT("/config/tunables", s.updateTunables)
+
+	cleanup := func() {
+		srvCleanup()
+		dbCleanup()
+	}
+	return r, apiKey, cleanup
+}
+
+func TestGetTunables_ReturnsFullCatalog(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+
+	for _, m := range repository.Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config/tunables", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp struct {
+		Tunables []repository.ResolvedValue `json:"tunables"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Tunables, len(repository.Catalog))
+	for _, v := range resp.Tunables {
+		assert.Equal(t, repository.SourceDefault, v.Source,
+			"key %s should be default with no env or db", v.Key)
+	}
+}
+
+func TestUpdateTunables_HappyPath(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+	for _, m := range repository.Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"updates": map[string]any{
+			repository.SettingKeyThoroughDuration: 60,
+			repository.SettingKeyHwAccel:          "cuda",
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/tunables", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// Re-read via GET and verify the new effective values came back.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/config/tunables", nil)
+	getReq.Header.Set("X-API-Key", apiKey)
+	getW := httptest.NewRecorder()
+	r.ServeHTTP(getW, getReq)
+
+	var resp struct {
+		Tunables []repository.ResolvedValue `json:"tunables"`
+	}
+	require.NoError(t, json.Unmarshal(getW.Body.Bytes(), &resp))
+
+	values := make(map[string]repository.ResolvedValue, len(resp.Tunables))
+	for _, v := range resp.Tunables {
+		values[v.Key] = v
+	}
+	assert.Equal(t, float64(60), values[repository.SettingKeyThoroughDuration].Value)
+	assert.Equal(t, repository.SourceDB, values[repository.SettingKeyThoroughDuration].Source)
+	assert.Equal(t, "cuda", values[repository.SettingKeyHwAccel].Value)
+	assert.Equal(t, repository.SourceDB, values[repository.SettingKeyHwAccel].Source)
+}
+
+func TestUpdateTunables_RejectsEnvLocked(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+
+	t.Setenv("HEALARR_HEALTH_CHECK_HWACCEL", "cuda")
+
+	body, _ := json.Marshal(map[string]any{
+		"updates": map[string]any{
+			repository.SettingKeyHwAccel: "off",
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/tunables", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "locked by env var")
+}
+
+func TestUpdateTunables_RejectsUnknownKey(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+	for _, m := range repository.Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"updates": map[string]any{
+			"not.a.real.key": 42,
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/tunables", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unknown tunable")
+}
+
+func TestUpdateTunables_RejectsOutOfRange(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+	for _, m := range repository.Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"updates": map[string]any{
+			repository.SettingKeyDefaultMaxRetries: 999,
+		},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/tunables", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, strings.Contains(w.Body.String(), "out of range"),
+		"want range error, got body=%s", w.Body.String())
+}
+
+func TestUpdateTunables_EmptyBodyRejected(t *testing.T) {
+	r, apiKey, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"updates": map[string]any{},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/tunables", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetTunables_RequiresAuth(t *testing.T) {
+	r, _, cleanup := setupTunablesTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config/tunables", nil)
+	// no API key header
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusOK, w.Code)
+}

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -92,6 +92,11 @@ func (s *RESTServer) initRepositories() {
 	s.settings = repository.NewSettingsRepository(s.db)
 	s.corruptions = repository.NewCorruptionRepository(s.db)
 	s.scanFiles = repository.NewScanFileRepository(s.db)
+
+	// Register the live tunables source so config.LiveX() accessors in
+	// integration/scanner code see DB-side updates from PUT /api/config/tunables
+	// without needing a restart.
+	config.SetLiveTunables(repository.NewTunables(s.settings))
 }
 
 // ServerDeps contains all dependencies required for the REST server
@@ -460,6 +465,10 @@ func (s *RESTServer) setupRoutes() {
 			protected.PUT("/config/settings", s.updateSettings)
 			protected.POST("/config/restart", s.restartServer)
 			protected.POST("/setup/reset", s.handleSetupReset)
+
+			// Config - Tunables (formerly env-only knobs now editable via UI)
+			protected.GET("/config/tunables", s.getTunables)
+			protected.PUT("/config/tunables", s.updateTunables)
 
 			// Config
 			protected.GET("/config/arr", s.getArrInstances)

--- a/internal/config/live.go
+++ b/internal/config/live.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/mescon/Healarr/internal/repository"
+)
+
+// liveTunables is the optional runtime resolver for values that the UI
+// (via PUT /api/config/tunables) can change without restarting Healarr.
+// When set, the LiveX() accessors below consult it; when nil, they fall
+// back to the static Config struct fields that Load() populated from env
+// at startup.
+//
+// The nil-fallback path matters for two reasons: tests that build a
+// Config without a database, and the boot window between cfg = Load()
+// and SetLiveTunables() being called by the server.
+var liveTunables atomic.Pointer[repository.Tunables]
+
+// SetLiveTunables registers t as the live source for runtime-editable
+// settings. Called once at server startup with a Tunables backed by the
+// shared SettingsRepository.
+func SetLiveTunables(t *repository.Tunables) {
+	liveTunables.Store(t)
+}
+
+// LiveHealthCheckThoroughDuration returns the per-file prefix duration
+// ffmpeg decodes during thorough scans. Zero means "decode the whole
+// file". Resolves env > DB > default at every call so a UI-side update
+// takes effect on the next scan tick.
+func LiveHealthCheckThoroughDuration() time.Duration {
+	if tn := liveTunables.Load(); tn != nil {
+		return tn.ThoroughDuration(context.Background()).Value
+	}
+	return Get().HealthCheckThoroughDuration
+}
+
+// LiveHealthCheckThoroughTimeout returns the per-file wall-clock cap for
+// thorough scans. Same precedence rules as LiveHealthCheckThoroughDuration.
+func LiveHealthCheckThoroughTimeout() time.Duration {
+	if tn := liveTunables.Load(); tn != nil {
+		return tn.ThoroughTimeout(context.Background()).Value
+	}
+	return Get().HealthCheckThoroughTimeout
+}
+
+// LiveHealthCheckHwAccel returns the resolved hardware acceleration
+// mode ("auto", "off", or an accelerator name like "cuda"). Same
+// precedence rules as the duration accessors.
+func LiveHealthCheckHwAccel() string {
+	if tn := liveTunables.Load(); tn != nil {
+		return tn.HwAccel(context.Background()).Value
+	}
+	return Get().HealthCheckHwAccel
+}

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -222,20 +222,41 @@ type CmdHealthChecker struct {
 	MediaInfoPath string
 	HandBrakePath string
 
-	// Hardware-acceleration args for ffmpeg thorough/content checks, resolved
-	// once at first use from HEALARR_HEALTH_CHECK_HWACCEL. Empty when "off" or
-	// when no accelerator is available on this host (opportunistic).
-	hwAccelArgs []string
-	hwAccelOnce sync.Once
+	// Hardware-acceleration args for ffmpeg thorough/content checks. The
+	// resolved args are cached keyed by the setting string they were
+	// resolved from - changing the setting via PUT /api/config/tunables
+	// invalidates the cache on the next call. The mutex keeps the
+	// re-probe atomic against concurrent scans.
+	hwAccelMu      sync.RWMutex
+	hwAccelSetting string
+	hwAccelArgs    []string
 }
 
 // hwAccelArgsResolved returns the cached "-hwaccel ..." args, probing ffmpeg
-// the first time if needed. Returns an empty slice when hardware acceleration
-// is unavailable or disabled - callers can safely append it to any args list.
+// when the live setting has changed since the last call. Returns an empty
+// slice when hardware acceleration is unavailable or disabled - callers can
+// safely append it to any args list. The cache means the (expensive) ffmpeg
+// subprocess probe runs at most once per setting value, not once per scan.
 func (hc *CmdHealthChecker) hwAccelArgsResolved() []string {
-	hc.hwAccelOnce.Do(func() {
-		hc.hwAccelArgs = resolveHwAccelArgs(hc.FFmpegPath, config.Get().HealthCheckHwAccel)
-	})
+	setting := config.LiveHealthCheckHwAccel()
+	hc.hwAccelMu.RLock()
+	if hc.hwAccelSetting == setting && hc.hwAccelArgs != nil {
+		args := hc.hwAccelArgs
+		hc.hwAccelMu.RUnlock()
+		return args
+	}
+	hc.hwAccelMu.RUnlock()
+
+	hc.hwAccelMu.Lock()
+	defer hc.hwAccelMu.Unlock()
+	if hc.hwAccelSetting == setting && hc.hwAccelArgs != nil {
+		return hc.hwAccelArgs // another goroutine won the race
+	}
+	hc.hwAccelArgs = resolveHwAccelArgs(hc.FFmpegPath, setting)
+	hc.hwAccelSetting = setting
+	if hc.hwAccelArgs == nil {
+		hc.hwAccelArgs = []string{} // sentinel: non-nil empty means "probed, none"
+	}
 	return hc.hwAccelArgs
 }
 
@@ -867,10 +888,9 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 	// Build ffmpeg command with appropriate filters. Hardware-accel args go
 	// FIRST (they are input options); the optional duration limit "-t N" is
 	// also an input option and must precede "-i".
-	cfg := config.Get()
 	ffmpegArgs := append([]string{"-nostats", "-v", "info"}, hc.hwAccelArgsResolved()...)
-	if cfg.HealthCheckThoroughDuration > 0 {
-		ffmpegArgs = append(ffmpegArgs, "-t", strconv.FormatFloat(cfg.HealthCheckThoroughDuration.Seconds(), 'f', -1, 64))
+	if duration := config.LiveHealthCheckThoroughDuration(); duration > 0 {
+		ffmpegArgs = append(ffmpegArgs, "-t", strconv.FormatFloat(duration.Seconds(), 'f', -1, 64))
 	}
 	ffmpegArgs = append(ffmpegArgs, "-i", path)
 
@@ -893,7 +913,7 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	timeout := cfg.HealthCheckThoroughTimeout
+	timeout := config.LiveHealthCheckThoroughTimeout()
 	done := make(chan error, 1)
 	safego.Run("content-analysis-cmd", func() {
 		done <- cmd.Run()

--- a/internal/integration/health_checker_tools.go
+++ b/internal/integration/health_checker_tools.go
@@ -34,10 +34,9 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 		// corruption (a trade the operator opts into).
 		cmdPath = hc.FFmpegPath
 		cmdName = "ffmpeg"
-		cfg := config.Get()
 		args = append([]string{"-v", "error", argXError}, hc.hwAccelArgsResolved()...)
-		if cfg.HealthCheckThoroughDuration > 0 {
-			args = append(args, "-t", strconv.FormatFloat(cfg.HealthCheckThoroughDuration.Seconds(), 'f', -1, 64))
+		if duration := config.LiveHealthCheckThoroughDuration(); duration > 0 {
+			args = append(args, "-t", strconv.FormatFloat(duration.Seconds(), 'f', -1, 64))
 		}
 		args = append(args, customArgs...)
 		args = append(args, "-i", path, "-f", "null", "-")
@@ -67,7 +66,7 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 	// files, or shrink it once you have set THOROUGH_DURATION to a short prefix).
 	timeout := 30 * time.Second
 	if mode == ModeThorough {
-		timeout = config.Get().HealthCheckThoroughTimeout
+		timeout = config.LiveHealthCheckThoroughTimeout()
 	}
 
 	done := make(chan error, 1)
@@ -109,7 +108,7 @@ func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []strin
 		// Thorough mode: Full scan with preview analysis
 		// --previews 10:0 generates 10 previews at different points to verify stream integrity
 		args = []string{argScan, argPreviews, "10:0", "-i", path}
-		timeout = config.Get().HealthCheckThoroughTimeout
+		timeout = config.LiveHealthCheckThoroughTimeout()
 	} else {
 		// Quick mode: Basic container scan
 		args = []string{argScan, "-i", path}

--- a/internal/repository/settings_keys.go
+++ b/internal/repository/settings_keys.go
@@ -1,0 +1,32 @@
+package repository
+
+// Tunable setting keys. These rows in the `settings` KV table back the
+// /config UI's runtime-editable knobs. Each one has a matching env var
+// (HEALARR_*) whose presence locks the field from the UI side; env wins
+// over DB wins over default.
+//
+// Naming convention: lowercase, dotted by area, *_seconds suffix for
+// durations stored as Go time.ParseDuration strings ("60s", "10m"),
+// *_days/_workers for integers. The keys are stable identifiers - the
+// frontend stores no copies, it asks /api/config/tunables for the
+// catalog plus values.
+const (
+	// Scan defaults
+	SettingKeyThoroughDuration  = "scan.thorough_duration_seconds"
+	SettingKeyThoroughTimeout   = "scan.thorough_timeout_seconds"
+	SettingKeyHwAccel           = "scan.hwaccel"
+	SettingKeyDefaultMaxRetries = "scan.default_max_retries"
+	SettingKeyScannerWorkers    = "scan.workers"
+	SettingKeyShutdownTimeout   = "scan.shutdown_timeout_seconds"
+	SettingKeyDryRunMode        = "scan.dry_run_mode"
+
+	// Maintenance / lifecycle
+	SettingKeyRetentionDays        = "maintenance.retention_days"
+	SettingKeyVerificationTimeout  = "maintenance.verification_timeout_seconds"
+	SettingKeyVerificationInterval = "maintenance.verification_interval_seconds"
+	SettingKeyStaleThreshold       = "maintenance.stale_threshold_seconds"
+
+	// Outbound rate limits
+	SettingKeyArrRateLimitRPS   = "limits.arr_rate_limit_rps"
+	SettingKeyArrRateLimitBurst = "limits.arr_rate_limit_burst"
+)

--- a/internal/repository/tunables.go
+++ b/internal/repository/tunables.go
@@ -1,0 +1,601 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Source identifies where a tunable's effective value came from.
+// Precedence: SourceEnv > SourceDB > SourceDefault.
+type Source string
+
+const (
+	SourceEnv     Source = "env"
+	SourceDB      Source = "db"
+	SourceDefault Source = "default"
+)
+
+// TunableKind is the wire type for a tunable. The REST API converts to
+// JSON accordingly; the frontend uses it to pick a control (number /
+// duration string / select / checkbox).
+type TunableKind string
+
+const (
+	KindDurationSeconds TunableKind = "duration_seconds" // int seconds on the wire; user enters "60s" / "10m" UI-side
+	KindInt             TunableKind = "int"
+	KindFloat           TunableKind = "float"
+	KindBool            TunableKind = "bool"
+	KindString          TunableKind = "string"
+	KindEnum            TunableKind = "enum"
+)
+
+// TunableMeta is the catalog entry for a tunable. The catalog is the
+// single source of truth: every tunable has exactly one entry here,
+// and both the API and (indirectly) the UI iterate over it.
+type TunableMeta struct {
+	Key             string      // DB key (SettingKey* constant)
+	EnvVar          string      // Matching HEALARR_* var name
+	Kind            TunableKind // Wire type
+	Default         string      // Default rendered as string for display
+	Description     string      // One-line UI help text
+	RequiresRestart bool        // True if changing the DB value won't take effect until restart
+	EnumValues      []string    // Populated when Kind == KindEnum
+	// MinInt / MaxInt / MinFloat / MaxFloat are advisory bounds the API
+	// enforces on PUT. Zero values mean "unbounded" for that side.
+	MinInt   int64
+	MaxInt   int64
+	MinFloat float64
+	MaxFloat float64
+}
+
+// Catalog is the immutable list of tunables. Order is the order shown
+// in the UI Advanced section (when the UI iterates this list directly).
+//
+// IMPORTANT: keep this list in sync with the typed getters below. The
+// getters reference Key + EnvVar literally; the catalog provides the
+// metadata the REST endpoint exposes.
+var Catalog = []TunableMeta{
+	{
+		Key:         SettingKeyThoroughDuration,
+		EnvVar:      "HEALARR_HEALTH_CHECK_THOROUGH_DURATION",
+		Kind:        KindDurationSeconds,
+		Default:     "0",
+		Description: "How much of a file thorough scans decode. 0 = full file. A short prefix (e.g. 60s) catches header / decode-init / early-stream errors in seconds, useful for triaging large AV1 libraries.",
+		MinInt:      0,
+		MaxInt:      24 * 3600,
+	},
+	{
+		Key:         SettingKeyThoroughTimeout,
+		EnvVar:      "HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT",
+		Kind:        KindDurationSeconds,
+		Default:     "600",
+		Description: "Per-file wall-clock cap for a thorough ffmpeg / mediainfo / HandBrake run. Files that exceed this are parked for rescan.",
+		MinInt:      30,
+		MaxInt:      6 * 3600,
+	},
+	{
+		Key:         SettingKeyHwAccel,
+		EnvVar:      "HEALARR_HEALTH_CHECK_HWACCEL",
+		Kind:        KindEnum,
+		Default:     "auto",
+		Description: "ffmpeg hardware acceleration. \"auto\" probes the build, \"off\" forces software, or pick a named accelerator.",
+		EnumValues:  []string{"auto", "off", "cuda", "vaapi", "qsv", "videotoolbox", "vdpau", "drm"},
+	},
+	{
+		Key:         SettingKeyDefaultMaxRetries,
+		EnvVar:      "HEALARR_DEFAULT_MAX_RETRIES",
+		Kind:        KindInt,
+		Default:     "3",
+		Description: "Default remediation retry cap. Can still be overridden per scan path.",
+		MinInt:      0,
+		MaxInt:      100,
+	},
+	{
+		Key:             SettingKeyScannerWorkers,
+		EnvVar:          "HEALARR_SCANNER_WORKERS",
+		Kind:            KindInt,
+		Default:         "auto",
+		Description:     "Number of concurrent detection workers. \"auto\" (0) tunes to container memory.",
+		RequiresRestart: true,
+		MinInt:          0,
+		MaxInt:          32,
+	},
+	{
+		Key:             SettingKeyShutdownTimeout,
+		EnvVar:          "HEALARR_SCANNER_SHUTDOWN_TIMEOUT",
+		Kind:            KindDurationSeconds,
+		Default:         "90",
+		Description:     "Graceful drain time when the scanner is stopping.",
+		RequiresRestart: true,
+		MinInt:          1,
+		MaxInt:          3600,
+	},
+	{
+		Key:             SettingKeyDryRunMode,
+		EnvVar:          "HEALARR_DRY_RUN",
+		Kind:            KindBool,
+		Default:         "false",
+		Description:     "Global dry-run: log remediation actions without deleting files.",
+		RequiresRestart: true,
+	},
+	{
+		Key:             SettingKeyRetentionDays,
+		EnvVar:          "HEALARR_RETENTION_DAYS",
+		Kind:            KindInt,
+		Default:         "90",
+		Description:     "Days to keep events and scan history. 0 disables pruning.",
+		RequiresRestart: true,
+		MinInt:          0,
+		MaxInt:          3650,
+	},
+	{
+		Key:             SettingKeyVerificationTimeout,
+		EnvVar:          "HEALARR_VERIFICATION_TIMEOUT",
+		Kind:            KindDurationSeconds,
+		Default:         "259200",
+		Description:     "Max wait for the *arr to produce a replacement file (default 72h).",
+		RequiresRestart: true,
+		MinInt:          60,
+		MaxInt:          30 * 24 * 3600,
+	},
+	{
+		Key:             SettingKeyVerificationInterval,
+		EnvVar:          "HEALARR_VERIFICATION_INTERVAL",
+		Kind:            KindDurationSeconds,
+		Default:         "30",
+		Description:     "Poll interval while waiting for replacement.",
+		RequiresRestart: true,
+		MinInt:          5,
+		MaxInt:          3600,
+	},
+	{
+		Key:             SettingKeyStaleThreshold,
+		EnvVar:          "HEALARR_STALE_THRESHOLD",
+		Kind:            KindDurationSeconds,
+		Default:         "86400",
+		Description:     "Auto-recover items that have been active with no update for this long.",
+		RequiresRestart: true,
+		MinInt:          300,
+		MaxInt:          30 * 24 * 3600,
+	},
+	{
+		Key:             SettingKeyArrRateLimitRPS,
+		EnvVar:          "HEALARR_ARR_RATE_LIMIT_RPS",
+		Kind:            KindFloat,
+		Default:         "5",
+		Description:     "Max requests per second to *arr APIs.",
+		RequiresRestart: true,
+		MinFloat:        0.1,
+		MaxFloat:        100,
+	},
+	{
+		Key:             SettingKeyArrRateLimitBurst,
+		EnvVar:          "HEALARR_ARR_RATE_LIMIT_BURST",
+		Kind:            KindInt,
+		Default:         "10",
+		Description:     "Burst allowance above the RPS cap.",
+		RequiresRestart: true,
+		MinInt:          1,
+		MaxInt:          1000,
+	},
+}
+
+// CatalogByKey returns the meta entry for key, or nil if unknown.
+func CatalogByKey(key string) *TunableMeta {
+	for i := range Catalog {
+		if Catalog[i].Key == key {
+			return &Catalog[i]
+		}
+	}
+	return nil
+}
+
+// Tunables is the live, precedence-aware view over the catalog. Callers
+// in hot paths (health_checker, etc.) use the typed getters; the API
+// layer uses Resolve to iterate the catalog.
+type Tunables struct {
+	repo *SettingsRepository
+}
+
+// NewTunables wires a resolver onto a SettingsRepository. Pass the same
+// repo the rest of the app uses; reads are cheap (single SELECT).
+func NewTunables(repo *SettingsRepository) *Tunables {
+	return &Tunables{repo: repo}
+}
+
+// ResolvedString is a string-typed tunable value with its source.
+type ResolvedString struct {
+	Value  string
+	Source Source
+}
+
+// ResolvedDuration is a duration-typed tunable value with its source.
+type ResolvedDuration struct {
+	Value  time.Duration
+	Source Source
+}
+
+// ResolvedInt is an int-typed tunable value with its source.
+type ResolvedInt struct {
+	Value  int
+	Source Source
+}
+
+// ResolvedFloat is a float-typed tunable value with its source.
+type ResolvedFloat struct {
+	Value  float64
+	Source Source
+}
+
+// ResolvedBool is a bool-typed tunable value with its source.
+type ResolvedBool struct {
+	Value  bool
+	Source Source
+}
+
+// ----- Typed getters ---------------------------------------------------------
+//
+// Each follows the same shape: try env, try DB, fall back to default. Parse
+// errors at any step fall through to the next layer rather than crashing -
+// a corrupt DB value should never lock the operator out of the feature.
+
+// ThoroughDuration is the prefix duration ffmpeg decodes during thorough
+// scans. Zero means "decode the whole file".
+func (t *Tunables) ThoroughDuration(ctx context.Context) ResolvedDuration {
+	return t.resolveDurationSeconds(ctx, "HEALARR_HEALTH_CHECK_THOROUGH_DURATION", SettingKeyThoroughDuration, 0)
+}
+
+// ThoroughTimeout is the per-file wall-clock cap for a thorough scan.
+func (t *Tunables) ThoroughTimeout(ctx context.Context) ResolvedDuration {
+	return t.resolveDurationSeconds(ctx, "HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT", SettingKeyThoroughTimeout, 10*time.Minute)
+}
+
+// HwAccel selects ffmpeg hardware acceleration: "auto" / "off" / accel name.
+func (t *Tunables) HwAccel(ctx context.Context) ResolvedString {
+	return t.resolveString(ctx, "HEALARR_HEALTH_CHECK_HWACCEL", SettingKeyHwAccel, "auto", true)
+}
+
+// resolveString reads env > db > default. If lower is true the value is
+// lowercased so callers can compare against constants without re-casing.
+func (t *Tunables) resolveString(ctx context.Context, envKey, dbKey, def string, lower bool) ResolvedString {
+	norm := func(s string) string {
+		if lower {
+			return strings.ToLower(strings.TrimSpace(s))
+		}
+		return s
+	}
+	if v, ok := os.LookupEnv(envKey); ok && v != "" {
+		return ResolvedString{Value: norm(v), Source: SourceEnv}
+	}
+	if t.repo != nil {
+		if v, err := t.repo.Get(ctx, dbKey); err == nil && v != "" {
+			return ResolvedString{Value: norm(v), Source: SourceDB}
+		}
+	}
+	return ResolvedString{Value: def, Source: SourceDefault}
+}
+
+// resolveDurationSeconds reads env > db > default. Env accepts either
+// time.ParseDuration syntax ("60s", "10m") or a bare integer seconds.
+// DB values are bare integer seconds (the wire format).
+func (t *Tunables) resolveDurationSeconds(ctx context.Context, envKey, dbKey string, def time.Duration) ResolvedDuration {
+	if v, ok := os.LookupEnv(envKey); ok && v != "" {
+		if d, err := parseDurationLoose(v); err == nil {
+			return ResolvedDuration{Value: d, Source: SourceEnv}
+		}
+	}
+	if t.repo != nil {
+		if v, err := t.repo.Get(ctx, dbKey); err == nil && v != "" {
+			if d, err := parseDurationLoose(v); err == nil {
+				return ResolvedDuration{Value: d, Source: SourceDB}
+			}
+		}
+	}
+	return ResolvedDuration{Value: def, Source: SourceDefault}
+}
+
+// parseDurationLoose accepts either a Go duration string ("60s", "1h30m")
+// or a bare integer (interpreted as seconds). The latter is how the API
+// serializes durations on the wire.
+func parseDurationLoose(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errors.New("empty duration")
+	}
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Duration(n) * time.Second, nil
+	}
+	return time.ParseDuration(s)
+}
+
+// ----- Catalog iteration -----------------------------------------------------
+
+// ResolvedValue is the API-level shape of one tunable's effective value
+// plus enough metadata for the UI to render and validate the field.
+type ResolvedValue struct {
+	Key             string      `json:"key"`
+	EnvVar          string      `json:"env_var"`
+	Kind            TunableKind `json:"kind"`
+	Description     string      `json:"description"`
+	RequiresRestart bool        `json:"requires_restart"`
+	EnumValues      []string    `json:"enum_values,omitempty"`
+	MinInt          int64       `json:"min_int,omitempty"`
+	MaxInt          int64       `json:"max_int,omitempty"`
+	MinFloat        float64     `json:"min_float,omitempty"`
+	MaxFloat        float64     `json:"max_float,omitempty"`
+	// Value is the effective value as a JSON-friendly type matched to Kind.
+	Value any `json:"value"`
+	// EnvValue is the raw string from the environment variable if it was
+	// set, otherwise null. The UI uses this to display "Set by env" without
+	// having to re-read process env on the client.
+	EnvValue *string `json:"env_value"`
+	// DBValue is the raw string from the database row if one exists,
+	// otherwise null.
+	DBValue *string `json:"db_value"`
+	Source  Source  `json:"source"`
+}
+
+// ResolveAll iterates the catalog and resolves each entry. Returns one
+// entry per catalog row, in catalog order. Read-only; safe to call from
+// API handlers on every request.
+func (t *Tunables) ResolveAll(ctx context.Context) ([]ResolvedValue, error) {
+	out := make([]ResolvedValue, 0, len(Catalog))
+	for i := range Catalog {
+		v, err := t.Resolve(ctx, &Catalog[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// Resolve resolves a single catalog entry. Exported so handlers can
+// re-resolve a specific tunable after a PUT without re-reading them all.
+func (t *Tunables) Resolve(ctx context.Context, m *TunableMeta) (ResolvedValue, error) {
+	rv := ResolvedValue{
+		Key:             m.Key,
+		EnvVar:          m.EnvVar,
+		Kind:            m.Kind,
+		Description:     m.Description,
+		RequiresRestart: m.RequiresRestart,
+		EnumValues:      m.EnumValues,
+		MinInt:          m.MinInt,
+		MaxInt:          m.MaxInt,
+		MinFloat:        m.MinFloat,
+		MaxFloat:        m.MaxFloat,
+		Source:          SourceDefault,
+	}
+
+	if v, ok := os.LookupEnv(m.EnvVar); ok && v != "" {
+		envCopy := v
+		rv.EnvValue = &envCopy
+	}
+	if t.repo != nil {
+		v, err := t.repo.Get(ctx, m.Key)
+		switch {
+		case err == nil && v != "":
+			dbCopy := v
+			rv.DBValue = &dbCopy
+		case errors.Is(err, ErrNotFound) || v == "":
+			// no DB row, fall through
+		case err != nil:
+			return ResolvedValue{}, fmt.Errorf("read tunable %q: %w", m.Key, err)
+		}
+	}
+
+	raw, src := m.Default, SourceDefault
+	if rv.DBValue != nil {
+		raw, src = *rv.DBValue, SourceDB
+	}
+	if rv.EnvValue != nil {
+		raw, src = *rv.EnvValue, SourceEnv
+	}
+	rv.Source = src
+
+	parsed, err := parseValueForKind(m.Kind, raw)
+	if err != nil {
+		// Fall back to default if a stored value is corrupt; the UI shows
+		// the default and the operator can re-save to fix.
+		parsed, _ = parseValueForKind(m.Kind, m.Default)
+		rv.Source = SourceDefault
+	}
+	rv.Value = parsed
+	return rv, nil
+}
+
+// parseValueForKind converts a raw string into a JSON-friendly Go value
+// matching the declared Kind. For durations the value is integer seconds
+// so the wire form is uniform across consumers.
+func parseValueForKind(k TunableKind, s string) (any, error) {
+	s = strings.TrimSpace(s)
+	switch k {
+	case KindInt:
+		if s == "auto" {
+			return 0, nil
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		return n, nil
+	case KindFloat:
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case KindBool:
+		switch strings.ToLower(s) {
+		case "1", "true", "yes", "on":
+			return true, nil
+		case "0", "false", "no", "off", "":
+			return false, nil
+		}
+		return nil, fmt.Errorf("invalid bool %q", s)
+	case KindDurationSeconds:
+		d, err := parseDurationLoose(s)
+		if err != nil {
+			return nil, err
+		}
+		return int64(d.Seconds()), nil
+	case KindString, KindEnum:
+		return s, nil
+	}
+	return nil, fmt.Errorf("unknown kind %q", k)
+}
+
+// ----- Validation + write ----------------------------------------------------
+
+// ValidateAndStore writes one or more tunable values to the DB after
+// validating each against its catalog entry. Env-locked tunables (i.e.
+// those whose env var is set) are rejected so the API can never make a
+// silent no-op the UI doesn't expect.
+//
+// Values are accepted as the JSON-decoded shape matching Kind:
+//   - KindInt:                int64 or string-parseable as int
+//   - KindFloat:              float64 or string-parseable as float
+//   - KindBool:               bool
+//   - KindDurationSeconds:    int64 seconds, or a Go duration string ("60s")
+//   - KindString / KindEnum:  string
+func (t *Tunables) ValidateAndStore(ctx context.Context, updates map[string]any) error {
+	if t.repo == nil {
+		return errors.New("tunables: no settings repository wired")
+	}
+	stored := make(map[string]string, len(updates))
+	for key, raw := range updates {
+		m := CatalogByKey(key)
+		if m == nil {
+			return fmt.Errorf("unknown tunable %q", key)
+		}
+		if _, ok := os.LookupEnv(m.EnvVar); ok && os.Getenv(m.EnvVar) != "" {
+			return fmt.Errorf("tunable %q is locked by env var %s", key, m.EnvVar)
+		}
+		s, err := serializeForKind(m, raw)
+		if err != nil {
+			return fmt.Errorf("tunable %q: %w", key, err)
+		}
+		stored[key] = s
+	}
+	return t.repo.SetMany(ctx, stored)
+}
+
+// serializeForKind validates the inbound JSON shape, enforces bounds, and
+// renders the canonical DB string form.
+func serializeForKind(m *TunableMeta, raw any) (string, error) {
+	switch m.Kind {
+	case KindInt:
+		n, err := coerceInt64(raw)
+		if err != nil {
+			return "", err
+		}
+		if m.MinInt != 0 || m.MaxInt != 0 {
+			if n < m.MinInt || n > m.MaxInt {
+				return "", fmt.Errorf("value %d out of range [%d,%d]", n, m.MinInt, m.MaxInt)
+			}
+		}
+		return strconv.FormatInt(n, 10), nil
+	case KindFloat:
+		f, err := coerceFloat64(raw)
+		if err != nil {
+			return "", err
+		}
+		if m.MinFloat != 0 || m.MaxFloat != 0 {
+			if f < m.MinFloat || f > m.MaxFloat {
+				return "", fmt.Errorf("value %g out of range [%g,%g]", f, m.MinFloat, m.MaxFloat)
+			}
+		}
+		return strconv.FormatFloat(f, 'f', -1, 64), nil
+	case KindBool:
+		b, ok := raw.(bool)
+		if !ok {
+			return "", fmt.Errorf("expected bool, got %T", raw)
+		}
+		return strconv.FormatBool(b), nil
+	case KindDurationSeconds:
+		var d time.Duration
+		switch v := raw.(type) {
+		case string:
+			parsed, err := parseDurationLoose(v)
+			if err != nil {
+				return "", err
+			}
+			d = parsed
+		default:
+			n, err := coerceInt64(raw)
+			if err != nil {
+				return "", err
+			}
+			d = time.Duration(n) * time.Second
+		}
+		secs := int64(d.Seconds())
+		if m.MinInt != 0 || m.MaxInt != 0 {
+			if secs < m.MinInt || secs > m.MaxInt {
+				return "", fmt.Errorf("value %ds out of range [%ds,%ds]", secs, m.MinInt, m.MaxInt)
+			}
+		}
+		return strconv.FormatInt(secs, 10), nil
+	case KindString, KindEnum:
+		s, ok := raw.(string)
+		if !ok {
+			return "", fmt.Errorf("expected string, got %T", raw)
+		}
+		s = strings.TrimSpace(s)
+		if m.Kind == KindEnum {
+			matched := false
+			for _, allowed := range m.EnumValues {
+				if strings.EqualFold(allowed, s) {
+					s = allowed
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return "", fmt.Errorf("value %q not in allowed set %v", s, m.EnumValues)
+			}
+		}
+		return s, nil
+	}
+	return "", fmt.Errorf("unknown kind %q", m.Kind)
+}
+
+func coerceInt64(raw any) (int64, error) {
+	switch v := raw.(type) {
+	case int:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case float64: // JSON numbers decode as float64
+		return int64(v), nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("expected int, got %q", v)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("expected int, got %T", raw)
+}
+
+func coerceFloat64(raw any) (float64, error) {
+	switch v := raw.(type) {
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return 0, fmt.Errorf("expected float, got %q", v)
+		}
+		return f, nil
+	}
+	return 0, fmt.Errorf("expected float, got %T", raw)
+}

--- a/internal/repository/tunables_test.go
+++ b/internal/repository/tunables_test.go
@@ -1,0 +1,274 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestSettingsRepo opens an in-memory SQLite, creates the settings
+// table, and returns a populated repository.
+func newTestSettingsRepo(t *testing.T) *SettingsRepository {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.Exec(`CREATE TABLE settings (
+		key TEXT PRIMARY KEY,
+		value TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return NewSettingsRepository(db)
+}
+
+func TestTunables_Precedence_EnvBeatsDBBeatsDefault(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	// Default: env unset, DB empty -> 0 (the historical default for thorough_duration)
+	t.Setenv("HEALARR_HEALTH_CHECK_THOROUGH_DURATION", "")
+	got := tn.ThoroughDuration(ctx)
+	if got.Value != 0 || got.Source != SourceDefault {
+		t.Errorf("default: got %v / %s, want 0 / default", got.Value, got.Source)
+	}
+
+	// DB only -> DB wins, source=db, parsed as integer seconds
+	if err := repo.Set(ctx, SettingKeyThoroughDuration, "60"); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+	got = tn.ThoroughDuration(ctx)
+	if got.Value != 60*time.Second || got.Source != SourceDB {
+		t.Errorf("db-only: got %v / %s, want 60s / db", got.Value, got.Source)
+	}
+
+	// Env + DB -> env wins; "10m" form is accepted for env
+	t.Setenv("HEALARR_HEALTH_CHECK_THOROUGH_DURATION", "10m")
+	got = tn.ThoroughDuration(ctx)
+	if got.Value != 10*time.Minute || got.Source != SourceEnv {
+		t.Errorf("env+db: got %v / %s, want 10m / env", got.Value, got.Source)
+	}
+}
+
+func TestTunables_HwAccel_DefaultLowercase(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	t.Setenv("HEALARR_HEALTH_CHECK_HWACCEL", "")
+	got := tn.HwAccel(ctx)
+	if got.Value != "auto" || got.Source != SourceDefault {
+		t.Errorf("default: got %q / %s, want auto / default", got.Value, got.Source)
+	}
+
+	// DB value is uppercased; getter must lowercase so callers can compare against constants.
+	if err := repo.Set(ctx, SettingKeyHwAccel, "CUDA"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got = tn.HwAccel(ctx)
+	if got.Value != "cuda" {
+		t.Errorf("db lowercase: got %q, want cuda", got.Value)
+	}
+}
+
+func TestTunables_CorruptDBValueFallsThroughToDefault(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	// Corrupt int in DB for thorough_duration. ResolveAll should not crash;
+	// the catalog-driven resolver falls back to default.
+	if err := repo.Set(ctx, SettingKeyThoroughDuration, "not-a-number"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	all, err := tn.ResolveAll(ctx)
+	if err != nil {
+		t.Fatalf("resolve all: %v", err)
+	}
+
+	found := false
+	for _, v := range all {
+		if v.Key != SettingKeyThoroughDuration {
+			continue
+		}
+		found = true
+		if v.Source != SourceDefault {
+			t.Errorf("corrupt-db: source = %s, want default", v.Source)
+		}
+		if v.Value != int64(0) {
+			t.Errorf("corrupt-db: value = %v, want 0", v.Value)
+		}
+	}
+	if !found {
+		t.Fatal("thorough_duration not in catalog response")
+	}
+}
+
+func TestTunables_ResolveAll_ContainsEveryCatalogEntry(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	// Clear any env vars that would otherwise affect the test.
+	for _, m := range Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	all, err := tn.ResolveAll(ctx)
+	if err != nil {
+		t.Fatalf("resolve all: %v", err)
+	}
+	if len(all) != len(Catalog) {
+		t.Fatalf("got %d entries, want %d", len(all), len(Catalog))
+	}
+	for i, m := range Catalog {
+		if all[i].Key != m.Key {
+			t.Errorf("entry %d: key = %q, want %q", i, all[i].Key, m.Key)
+		}
+		if all[i].Source != SourceDefault {
+			t.Errorf("entry %d (%s): source = %s, want default", i, m.Key, all[i].Source)
+		}
+	}
+}
+
+func TestTunables_ValidateAndStore_RejectsEnvLocked(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	// Lock the field via env
+	t.Setenv("HEALARR_HEALTH_CHECK_HWACCEL", "cuda")
+
+	err := tn.ValidateAndStore(ctx, map[string]any{
+		SettingKeyHwAccel: "off",
+	})
+	if err == nil {
+		t.Fatal("expected env-lock error, got nil")
+	}
+}
+
+func TestTunables_ValidateAndStore_RejectsUnknownKey(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	err := tn.ValidateAndStore(ctx, map[string]any{
+		"not.a.real.key": 42,
+	})
+	if err == nil {
+		t.Fatal("expected unknown-key error, got nil")
+	}
+}
+
+func TestTunables_ValidateAndStore_EnforcesBounds(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	for _, m := range Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	tests := []struct {
+		name    string
+		updates map[string]any
+		wantErr bool
+	}{
+		{
+			name:    "max_retries 0 is allowed (min)",
+			updates: map[string]any{SettingKeyDefaultMaxRetries: float64(0)},
+			wantErr: false,
+		},
+		{
+			name:    "max_retries 100 is allowed (max)",
+			updates: map[string]any{SettingKeyDefaultMaxRetries: float64(100)},
+			wantErr: false,
+		},
+		{
+			name:    "max_retries 101 rejected (over max)",
+			updates: map[string]any{SettingKeyDefaultMaxRetries: float64(101)},
+			wantErr: true,
+		},
+		{
+			name:    "max_retries -1 rejected (under min)",
+			updates: map[string]any{SettingKeyDefaultMaxRetries: float64(-1)},
+			wantErr: true,
+		},
+		{
+			name:    "hwaccel valid enum value",
+			updates: map[string]any{SettingKeyHwAccel: "vaapi"},
+			wantErr: false,
+		},
+		{
+			name:    "hwaccel garbage rejected",
+			updates: map[string]any{SettingKeyHwAccel: "not-a-real-accel"},
+			wantErr: true,
+		},
+		{
+			name:    "duration accepts string form",
+			updates: map[string]any{SettingKeyThoroughDuration: "60s"},
+			wantErr: false,
+		},
+		{
+			name:    "duration accepts int seconds",
+			updates: map[string]any{SettingKeyThoroughDuration: float64(120)},
+			wantErr: false,
+		},
+		{
+			name:    "rate limit float in range",
+			updates: map[string]any{SettingKeyArrRateLimitRPS: float64(7.5)},
+			wantErr: false,
+		},
+		{
+			name:    "rate limit too high",
+			updates: map[string]any{SettingKeyArrRateLimitRPS: float64(999)},
+			wantErr: true,
+		},
+		{
+			name:    "bool round-trips",
+			updates: map[string]any{SettingKeyDryRunMode: true},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tn.ValidateAndStore(ctx, tt.updates)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAndStore err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTunables_ValidateAndStore_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+	for _, m := range Catalog {
+		t.Setenv(m.EnvVar, "")
+	}
+
+	if err := tn.ValidateAndStore(ctx, map[string]any{
+		SettingKeyThoroughDuration: "90s",
+		SettingKeyHwAccel:          "off",
+	}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	td := tn.ThoroughDuration(ctx)
+	if td.Value != 90*time.Second || td.Source != SourceDB {
+		t.Errorf("thorough_duration: got %v / %s, want 90s / db", td.Value, td.Source)
+	}
+	hw := tn.HwAccel(ctx)
+	if hw.Value != "off" || hw.Source != SourceDB {
+		t.Errorf("hwaccel: got %q / %s, want off / db", hw.Value, hw.Source)
+	}
+}


### PR DESCRIPTION
First of three PRs implementing the /config upgrade plan from the conversation.

## What this PR does

Exposes 13 \`HEALARR_*\` env-only knobs as DB-backed, UI-editable tunables. Precedence at every read: **env > db > default**. Operators who set a value in compose see it locked in the UI; everyone else gets in-product knobs.

The big practical win: the "decode only the first 60 seconds of each file" feature (added in 1.3.3 as \`HEALARR_HEALTH_CHECK_THOROUGH_DURATION\`) is now a single field on the new "Scanning defaults" card. Operators no longer need to know the env var exists.

## What's new in the UI

Two new sections in /config:

1. **Scanning defaults** (between Scan Paths and Schedules) - thorough decode duration / timeout, hwaccel mode, default retry cap, scanner workers + shutdown timeout, global dry-run.
2. **Maintenance & rate limits** (inside Advanced) - retention days, verification cadence, stale threshold, *arr API rate limits.

Each field shows a source badge: "Set by HEALARR_..." (env-locked, read-only), "Customized" (DB), or "Default". The three scan-related knobs that the per-file health check actually consumes (thorough_duration, thorough_timeout, hwaccel) apply on the next scan without a restart. The other ten are flagged "restart required" because they are bound to subsystems that latch config at startup.

## Backend

| File | What |
|---|---|
| \`internal/repository/settings_keys.go\` | Typed key constants for every tunable |
| \`internal/repository/tunables.go\` | Catalog + typed getters + \`ValidateAndStore\` (bulk write) |
| \`internal/repository/tunables_test.go\` | 19 sub-tests: precedence, bounds, env-lock, round-trip, corrupt-value-fallback |
| \`internal/config/live.go\` | \`LiveX()\` accessors with safe fallback for tests/pre-init |
| \`internal/api/handlers_tunables.go\` | \`GET\` + \`PUT /api/config/tunables\` |
| \`internal/api/handlers_tunables_test.go\` | 6 handler tests (happy path, env-lock, unknown key, out-of-range, empty body, auth required) |
| \`internal/integration/health_checker*.go\` | Rewired to live getters. hwaccel cache is now keyed by setting so the ffmpeg probe re-runs only when the value actually changes. |

## Frontend

| File | What |
|---|---|
| \`frontend/src/lib/api.ts\` | \`TunableValue\` type, \`getTunables\` / \`updateTunables\` |
| \`frontend/src/components/config/TunablesSection.tsx\` | Generic catalog-driven section. Right control per kind (number, enum select, bool checkbox, duration + unit picker). Source badge per field. |
| \`frontend/src/pages/Config.tsx\` | Mounts both new cards |

## What's NOT in this PR (Phase 2 & 3)

- Per-scan-path overrides (thorough_duration etc. as nullable columns on \`scan_paths\` that inherit the new globals). Phase 2.
- Preset bundles, including custom user-defined ones. Phase 3.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` -> 0 issues
- [x] \`go test ./internal/repository/ ./internal/integration/ ./internal/api/ ./internal/config/\` -> all green (25 new tests across the repository + handler layers)
- [x] \`npm run typecheck\`, \`npm run lint\`, \`npm run build\`, \`npx vitest run\` all green (166/167 tests, 1 pre-existing skip)
- [ ] Manual: load /config, edit thorough decode duration to 60s, save, hit a scan with an AV1 file, confirm ffmpeg is invoked with \`-t 60\`
- [ ] Manual: set \`HEALARR_HEALTH_CHECK_HWACCEL=cuda\` in env, reload UI, confirm hwaccel field is read-only with "Set by HEALARR_..." badge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime-editable tunables UI in the `/config` section, allowing real-time adjustments to scan defaults (duration, timeout, hardware acceleration) without restart.
  * New configuration sections for "Scanning defaults" and "Maintenance & rate limits" with visual indicators showing whether values come from environment variables, database, or defaults.
  * Some tunables now take effect immediately on the next scan tick; others remain restart-required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->