### PR TITLE
feat(scan-paths): per-path overrides for thorough/timeout/hwaccel (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-scan-path overrides for the three scan-related global tunables.** Each scan path can now pin its own `thorough_duration_seconds`, `thorough_timeout_seconds`, and `hwaccel` (NULL = inherit the global; non-NULL wins for that path). Lets a mixed setup keep one global value while making narrow exceptions: e.g. a 4K AV1 library on a CUDA host forces `hwaccel=cuda` and `thorough_duration=60s`, while the same Healarr instance scanning a remote SMB share runs with `hwaccel=off` and a longer thorough timeout. Configured under the "Override scanning defaults for this path" disclosure on each scan path. Phase 2 of the /config redesign; Phase 3 (preset bundles, including user-defined ones) is next.
+- **Per-path Dry Run checkbox.** The `dry_run` column has existed on `scan_paths` for several versions but was missing from the form, so it could only be set via direct DB poke or import/export. It now sits next to the Auto Remediate checkbox.
+
+### Removed
+- **Dead `health_check_mode` column on `scan_paths`.** It was defined in `001_schema.sql` with a CHECK constraint but never read or written by any Go code; the concept moved into `detection_mode` (which is what the scanner actually consults). Carrying both invited future confusion. Migration `008` drops the column.
+
+### Added
 - **Settings page now exposes the runtime tunables that were previously env-only.** Thirteen `HEALARR_*` knobs are now editable from `/config` (full list: thorough decode duration / timeout, hardware acceleration mode, default retry cap, scanner worker count, scanner shutdown timeout, dry-run mode, retention days, verification timeout / interval, stale threshold, *arr rate limit RPS / burst). Each field shows whether its current value comes from env, the DB, or the built-in default; env-set values render as read-only with a "Set by `HEALARR_FOO`" badge so it's obvious which fields are operator-locked. Phase 1 of a larger /config redesign - per-path overrides and preset bundles are next. The "first 60 seconds of decode" trick (the main practical use of `HEALARR_HEALTH_CHECK_THOROUGH_DURATION`) is now one click in the UI.
 
 ### Changed

--- a/frontend/src/components/config/ScanPathsSection.tsx
+++ b/frontend/src/components/config/ScanPathsSection.tsx
@@ -226,11 +226,15 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
             arr_instance_id: path.arr_instance_id,
             enabled: path.enabled,
             auto_remediate: path.auto_remediate,
+            dry_run: path.dry_run ?? false,
             detection_method: path.detection_method || 'ffprobe',
             detection_mode: path.detection_mode || 'quick',
             detection_args: detectionArgsStr,
             max_retries: path.max_retries ?? 3,
-            verification_timeout_hours: path.verification_timeout_hours ?? null
+            verification_timeout_hours: path.verification_timeout_hours ?? null,
+            thorough_duration_seconds: path.thorough_duration_seconds ?? null,
+            thorough_timeout_seconds: path.thorough_timeout_seconds ?? null,
+            hwaccel: path.hwaccel ?? null,
         });
         setEditingId(path.id);
         setIsAddExpanded(true);
@@ -240,13 +244,17 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
         setNewPath({
             enabled: true,
             auto_remediate: true,
+            dry_run: false,
             local_path: '',
             arr_path: '',
             arr_instance_id: null,
             detection_method: 'ffprobe',
             detection_mode: 'quick',
             max_retries: 3,
-            verification_timeout_hours: null
+            verification_timeout_hours: null,
+            thorough_duration_seconds: null,
+            thorough_timeout_seconds: null,
+            hwaccel: null,
         });
         setIsAddExpanded(false);
         setEditingId(null);
@@ -396,6 +404,18 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
                                             <label htmlFor="path-auto-remediate" className="text-sm text-slate-700 dark:text-slate-300">Auto Remediate</label>
                                         </div>
                                         <div className="flex items-center gap-3">
+                                            <input
+                                                type="checkbox"
+                                                id="path-dry-run"
+                                                checked={newPath.dry_run || false}
+                                                onChange={e => setNewPath({ ...newPath, dry_run: e.target.checked })}
+                                                className="w-4 h-4 text-amber-500 bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-700 rounded focus:ring-amber-500"
+                                            />
+                                            <label htmlFor="path-dry-run" className="text-sm text-slate-700 dark:text-slate-300" title="Log remediation actions for this path without actually deleting files. Useful for testing.">
+                                                Dry run
+                                            </label>
+                                        </div>
+                                        <div className="flex items-center gap-3">
                                             <label htmlFor="path-max-retries" className="text-sm text-slate-700 dark:text-slate-300">Max Retries:</label>
                                             <input
                                                 type="number"
@@ -431,6 +451,92 @@ const ScanPathsSection = ({ onScrollToDetectionTools }: ScanPathsSectionProps) =
                                             How long to keep searching for replacements. Use longer timeouts for rare/hard-to-find content.
                                         </p>
                                     </div>
+
+                                    {/* Per-path scan overrides. Each field defaults to "Inherit global", in
+                                        which case the values configured under Settings -> Scanning defaults
+                                        are used. A non-empty value pins this path to that specific value
+                                        regardless of the global - useful for mixed setups (e.g. a 4K library
+                                        on CUDA, a remote SMB share on software decode). */}
+                                    <details className="pb-2">
+                                        <summary className="cursor-pointer text-sm font-medium text-slate-700 dark:text-slate-300 select-none">
+                                            Override scanning defaults for this path
+                                        </summary>
+                                        <div className="mt-3 ml-4 space-y-3 border-l-2 border-slate-200 dark:border-slate-700 pl-4">
+                                            {/* Thorough decode duration */}
+                                            <div className="flex items-center gap-3">
+                                                <label htmlFor="path-thorough-duration" className="text-sm text-slate-700 dark:text-slate-300 w-48">
+                                                    Thorough decode duration:
+                                                </label>
+                                                <select
+                                                    id="path-thorough-duration"
+                                                    value={newPath.thorough_duration_seconds ?? ''}
+                                                    onChange={e => setNewPath({ ...newPath, thorough_duration_seconds: e.target.value === '' ? null : parseInt(e.target.value) })}
+                                                    className="w-40 px-3 py-1.5 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500"
+                                                >
+                                                    <option value="">Inherit global</option>
+                                                    <option value="0">Full file</option>
+                                                    <option value="30">First 30 seconds</option>
+                                                    <option value="60">First 60 seconds</option>
+                                                    <option value="300">First 5 minutes</option>
+                                                    <option value="600">First 10 minutes</option>
+                                                </select>
+                                            </div>
+
+                                            {/* Thorough decode timeout */}
+                                            <div className="flex items-center gap-3">
+                                                <label htmlFor="path-thorough-timeout" className="text-sm text-slate-700 dark:text-slate-300 w-48">
+                                                    Thorough decode timeout:
+                                                </label>
+                                                <select
+                                                    id="path-thorough-timeout"
+                                                    value={newPath.thorough_timeout_seconds ?? ''}
+                                                    onChange={e => setNewPath({ ...newPath, thorough_timeout_seconds: e.target.value === '' ? null : parseInt(e.target.value) })}
+                                                    className="w-40 px-3 py-1.5 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500"
+                                                >
+                                                    <option value="">Inherit global</option>
+                                                    <option value="60">1 minute</option>
+                                                    <option value="300">5 minutes</option>
+                                                    <option value="600">10 minutes</option>
+                                                    <option value="1800">30 minutes</option>
+                                                    <option value="3600">1 hour</option>
+                                                </select>
+                                            </div>
+
+                                            {/* Hardware acceleration */}
+                                            <div className="flex items-center gap-3">
+                                                <label htmlFor="path-hwaccel" className="text-sm text-slate-700 dark:text-slate-300 w-48">
+                                                    Hardware acceleration:
+                                                </label>
+                                                <select
+                                                    id="path-hwaccel"
+                                                    value={newPath.hwaccel ?? ''}
+                                                    onChange={e => {
+                                                        const v = e.target.value;
+                                                        setNewPath({
+                                                            ...newPath,
+                                                            hwaccel: v === '' ? null : (v as NonNullable<ScanPathFormState['hwaccel']>),
+                                                        });
+                                                    }}
+                                                    className="w-40 px-3 py-1.5 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500"
+                                                >
+                                                    <option value="">Inherit global</option>
+                                                    <option value="auto">auto</option>
+                                                    <option value="off">off</option>
+                                                    <option value="cuda">cuda</option>
+                                                    <option value="vaapi">vaapi</option>
+                                                    <option value="qsv">qsv</option>
+                                                    <option value="videotoolbox">videotoolbox</option>
+                                                    <option value="vdpau">vdpau</option>
+                                                    <option value="drm">drm</option>
+                                                </select>
+                                            </div>
+                                            <p className="text-xs text-slate-500">
+                                                Each field defaults to "Inherit global". Pick a value to pin this path to that
+                                                specific setting (e.g. force <code>cuda</code> on your 4K library while leaving
+                                                the rest on auto).
+                                            </p>
+                                        </div>
+                                    </details>
 
                                     {/* Detection Configuration */}
                                     <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -259,6 +259,14 @@ export interface ScanPath {
     detection_mode?: 'quick' | 'thorough';
     max_retries?: number;
     verification_timeout_hours?: number | null;  // NULL = use global setting
+
+    // Per-path overrides for the matching global scan tunables. null/undefined
+    // means "inherit the global" (the existing behaviour); a non-null value
+    // wins over the global. Bounds and enums mirror the catalog entries on
+    // the backend.
+    thorough_duration_seconds?: number | null;
+    thorough_timeout_seconds?: number | null;
+    hwaccel?: 'auto' | 'off' | 'cuda' | 'vaapi' | 'qsv' | 'videotoolbox' | 'vdpau' | 'drm' | null;
 }
 
 export const getArrInstances = async (): Promise<ArrInstance[]> => {

--- a/frontend/src/lib/schemas/scan-path.ts
+++ b/frontend/src/lib/schemas/scan-path.ts
@@ -41,6 +41,27 @@ export const scanPathSchema = z.object({
     .max(168, 'Maximum 168 hours (7 days)')
     .nullable()
     .optional(),
+
+  // Per-path overrides for the global scan tunables. null = "inherit the
+  // global" (the existing behaviour); a numeric/string value wins for this
+  // specific path. Bounds mirror the catalog entries on the backend
+  // (internal/repository/tunables.go).
+  thorough_duration_seconds: z
+    .number()
+    .min(0, 'Cannot be negative')
+    .max(86400, 'Maximum 24 hours')
+    .nullable()
+    .optional(),
+  thorough_timeout_seconds: z
+    .number()
+    .min(30, 'Must be at least 30 seconds')
+    .max(21600, 'Maximum 6 hours')
+    .nullable()
+    .optional(),
+  hwaccel: z
+    .enum(['auto', 'off', 'cuda', 'vaapi', 'qsv', 'videotoolbox', 'vdpau', 'drm'])
+    .nullable()
+    .optional(),
 });
 
 /**

--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -81,6 +81,9 @@ func setupConfigTestDB(t *testing.T) (*sql.DB, func()) {
 			detection_mode TEXT DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
 			verification_timeout_hours INTEGER DEFAULT NULL,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 

--- a/internal/api/handlers_health_test.go
+++ b/internal/api/handlers_health_test.go
@@ -93,8 +93,13 @@ func setupTestDBForHealth(t *testing.T) (*sql.DB, string, func()) {
 			auto_remediate INTEGER DEFAULT 0,
 			dry_run INTEGER DEFAULT 0,
 			detection_method TEXT DEFAULT 'ffprobe',
+			detection_args TEXT,
 			detection_mode TEXT DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
+			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
@@ -170,7 +175,7 @@ func (m *mockHealthChecker) CheckWithConfig(_ string, _ integration.DetectionCon
 	return m.healthy, m.err
 }
 
-func (m *mockHealthChecker) AnalyzeContent(_ string) (bool, *integration.HealthCheckError) {
+func (m *mockHealthChecker) AnalyzeContent(_ string, _ *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
 	return m.healthy, m.err
 }
 

--- a/internal/api/handlers_paths.go
+++ b/internal/api/handlers_paths.go
@@ -39,6 +39,15 @@ func scanPathFieldsFromRequest(req *scanPathRequest, detectionArgsJSON []byte) r
 	if req.VerificationTimeoutHours != nil {
 		fields.VerificationTimeoutHours = sql.NullInt64{Int64: int64(*req.VerificationTimeoutHours), Valid: true}
 	}
+	if req.ThoroughDurationSeconds != nil {
+		fields.ThoroughDurationSeconds = sql.NullInt64{Int64: *req.ThoroughDurationSeconds, Valid: true}
+	}
+	if req.ThoroughTimeoutSeconds != nil {
+		fields.ThoroughTimeoutSeconds = sql.NullInt64{Int64: *req.ThoroughTimeoutSeconds, Valid: true}
+	}
+	if req.Hwaccel != nil && *req.Hwaccel != "" {
+		fields.Hwaccel = sql.NullString{String: *req.Hwaccel, Valid: true}
+	}
 	return fields
 }
 
@@ -78,6 +87,13 @@ func sanitizeBrowsePath(requestedPath string) (string, error) {
 }
 
 // scanPathRequest is the common request structure for creating and updating scan paths.
+//
+// The three pointer fields at the bottom (ThoroughDurationSeconds /
+// ThoroughTimeoutSeconds / Hwaccel) are per-path overrides. nil/empty
+// means "inherit the matching global tunable" - the existing behavior
+// for every row that predates Phase 2. A non-nil value wins over the
+// global for that specific path; the resolver picks per-path > global >
+// env > default.
 type scanPathRequest struct {
 	LocalPath                string   `json:"local_path"`
 	ArrPath                  string   `json:"arr_path"`
@@ -90,6 +106,9 @@ type scanPathRequest struct {
 	DetectionMode            string   `json:"detection_mode"`
 	MaxRetries               int      `json:"max_retries"`
 	VerificationTimeoutHours *int     `json:"verification_timeout_hours"`
+	ThoroughDurationSeconds  *int64   `json:"thorough_duration_seconds,omitempty"`
+	ThoroughTimeoutSeconds   *int64   `json:"thorough_timeout_seconds,omitempty"`
+	Hwaccel                  *string  `json:"hwaccel,omitempty"`
 }
 
 // prepareScanPathRequest validates and normalizes a scan path request.
@@ -126,6 +145,32 @@ func prepareScanPathRequest(req *scanPathRequest, c *gin.Context) ([]byte, bool)
 		hours := *req.VerificationTimeoutHours
 		if hours < 1 || hours > 8760 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "verification_timeout_hours must be between 1 and 8760"})
+			return nil, false
+		}
+	}
+
+	// Validate per-path overrides. Bounds mirror the catalog entries
+	// (internal/repository/tunables.go) so the validation rule is the
+	// same whether the value lands in a global setting or a per-path
+	// override. nil/zero/empty means "inherit", which is always allowed.
+	if req.ThoroughDurationSeconds != nil {
+		if v := *req.ThoroughDurationSeconds; v < 0 || v > 24*3600 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "thorough_duration_seconds must be between 0 and 86400"})
+			return nil, false
+		}
+	}
+	if req.ThoroughTimeoutSeconds != nil {
+		if v := *req.ThoroughTimeoutSeconds; v < 30 || v > 6*3600 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "thorough_timeout_seconds must be between 30 and 21600"})
+			return nil, false
+		}
+	}
+	if req.Hwaccel != nil && *req.Hwaccel != "" {
+		switch *req.Hwaccel {
+		case "auto", "off", "cuda", "vaapi", "qsv", "videotoolbox", "vdpau", "drm":
+			// allowed
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid hwaccel value"})
 			return nil, false
 		}
 	}
@@ -191,6 +236,21 @@ func (s *RESTServer) getScanPaths(c *gin.Context) {
 			path["verification_timeout_hours"] = p.VerificationTimeoutHours.Int64
 		} else {
 			path["verification_timeout_hours"] = nil
+		}
+		if p.ThoroughDurationSeconds.Valid {
+			path["thorough_duration_seconds"] = p.ThoroughDurationSeconds.Int64
+		} else {
+			path["thorough_duration_seconds"] = nil
+		}
+		if p.ThoroughTimeoutSeconds.Valid {
+			path["thorough_timeout_seconds"] = p.ThoroughTimeoutSeconds.Int64
+		} else {
+			path["thorough_timeout_seconds"] = nil
+		}
+		if p.Hwaccel.Valid {
+			path["hwaccel"] = p.Hwaccel.String
+		} else {
+			path["hwaccel"] = nil
 		}
 		paths = append(paths, path)
 	}

--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -43,6 +43,9 @@ func setupPathsTestDB(t *testing.T) (*sql.DB, func()) {
 		ALTER TABLE scan_paths ADD COLUMN max_retries INTEGER DEFAULT 3;
 		ALTER TABLE scan_paths ADD COLUMN verification_timeout_hours INTEGER;
 		ALTER TABLE scan_paths ADD COLUMN dry_run INTEGER DEFAULT 0;
+		ALTER TABLE scan_paths ADD COLUMN thorough_duration_seconds INTEGER;
+		ALTER TABLE scan_paths ADD COLUMN thorough_timeout_seconds INTEGER;
+		ALTER TABLE scan_paths ADD COLUMN hwaccel TEXT;
 	`
 	_, err := db.Exec(schema)
 	require.NoError(t, err)
@@ -261,6 +264,9 @@ func TestGetScanPaths_ArrInstanceIDNull(t *testing.T) {
 		detection_mode TEXT DEFAULT 'quick',
 		max_retries INTEGER DEFAULT 3,
 		verification_timeout_hours INTEGER,
+		thorough_duration_seconds INTEGER,
+		thorough_timeout_seconds INTEGER,
+		hwaccel TEXT,
 		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 	)`)
 	require.NoError(t, err)

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -77,6 +77,9 @@ func setupScansTestDB(t *testing.T) (*sql.DB, func()) {
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
 			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 

--- a/internal/api/handlers_stats_test.go
+++ b/internal/api/handlers_stats_test.go
@@ -80,7 +80,10 @@ func setupStatsTestDB(t *testing.T) (*sql.DB, func()) {
 			detection_args TEXT,
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER
+			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT
 		);
 
 		CREATE VIEW corruption_status AS

--- a/internal/config/live.go
+++ b/internal/config/live.go
@@ -30,11 +30,18 @@ func SetLiveTunables(t *repository.Tunables) {
 // ffmpeg decodes during thorough scans. Zero means "decode the whole
 // file". Resolves env > DB > default at every call so a UI-side update
 // takes effect on the next scan tick.
+//
+// Falls back to the hardcoded default (0, "decode full file") when
+// neither a live tunables source nor a loaded Config exists - keeps
+// unit tests that don't call config.Load() out of panic-land.
 func LiveHealthCheckThoroughDuration() time.Duration {
 	if tn := liveTunables.Load(); tn != nil {
 		return tn.ThoroughDuration(context.Background()).Value
 	}
-	return Get().HealthCheckThoroughDuration
+	if cfg != nil {
+		return cfg.HealthCheckThoroughDuration
+	}
+	return 0
 }
 
 // LiveHealthCheckThoroughTimeout returns the per-file wall-clock cap for
@@ -43,7 +50,10 @@ func LiveHealthCheckThoroughTimeout() time.Duration {
 	if tn := liveTunables.Load(); tn != nil {
 		return tn.ThoroughTimeout(context.Background()).Value
 	}
-	return Get().HealthCheckThoroughTimeout
+	if cfg != nil {
+		return cfg.HealthCheckThoroughTimeout
+	}
+	return 10 * time.Minute
 }
 
 // LiveHealthCheckHwAccel returns the resolved hardware acceleration
@@ -53,5 +63,8 @@ func LiveHealthCheckHwAccel() string {
 	if tn := liveTunables.Load(); tn != nil {
 		return tn.HwAccel(context.Background()).Value
 	}
-	return Get().HealthCheckHwAccel
+	if cfg != nil {
+		return cfg.HealthCheckHwAccel
+	}
+	return "auto"
 }

--- a/internal/db/migrations/008_scan_path_overrides.sql
+++ b/internal/db/migrations/008_scan_path_overrides.sql
@@ -1,0 +1,49 @@
+-- 008_scan_path_overrides.sql
+--
+-- Per-scan-path overrides for the scan tunables that used to be global-only.
+--
+-- The thorough health-check timing knobs (thorough_duration_seconds,
+-- thorough_timeout_seconds) and the ffmpeg hwaccel selector are currently
+-- stored as global rows in the settings table under keys
+-- "scan.thorough_duration_seconds", "scan.thorough_timeout_seconds" and
+-- "scan.hwaccel" (see internal/repository/settings_keys.go). That is the
+-- right default for most homelabs, but breaks down on mixed setups:
+--   - a 4K library on a CUDA box wants -hwaccel cuda;
+--   - the same Healarr instance also scanning a remote SMB share wants
+--     hwaccel=off (no GPU there) plus a longer thorough duration to ride
+--     out network latency.
+--
+-- Rather than forcing the operator to pick one global value, this migration
+-- adds three nullable override columns on scan_paths. NULL means "inherit
+-- the global setting" - that's the existing behavior, so every pre-
+-- migration row keeps working without any backfill. A non-NULL value wins
+-- over the global for that specific path. The hwaccel CHECK mirrors the
+-- enum exposed by the tunables catalog (see internal/repository/tunables.go)
+-- so the DB rejects junk before it reaches ffmpeg.
+--
+-- Same migration also drops scan_paths.health_check_mode, which has been
+-- dead since the codebase moved to detection_mode. The column was created
+-- in 001_schema.sql with a CHECK on ('quick','thorough') but no Go code
+-- ever reads or writes it; detection_mode (added to 001 in the same
+-- consolidation) is what the scanner actually consults. Carrying both
+-- around invites future confusion ("which one wins?"), so we remove it.
+--
+-- DROP COLUMN is available natively from SQLite 3.35+. Healarr runs on
+-- modernc.org/sqlite (see internal/db/repository.go), currently v1.50.x,
+-- which embeds SQLite well past 3.35 - no table-rebuild dance needed.
+-- The column has no index, trigger, view or FK referencing it, so the
+-- drop is a clean single statement.
+--
+-- Heads-up for the caller of this skill: internal/testutil/testdb.go still
+-- declares health_check_mode in its hand-written test schema. That file
+-- needs the column removed in the same change so tests that spin up a DB
+-- via testutil match the migrated schema. No production repo code reads
+-- the column, so nothing else needs to move.
+
+ALTER TABLE scan_paths ADD COLUMN thorough_duration_seconds INTEGER;
+ALTER TABLE scan_paths ADD COLUMN thorough_timeout_seconds INTEGER;
+ALTER TABLE scan_paths ADD COLUMN hwaccel TEXT
+    CHECK (hwaccel IS NULL OR hwaccel IN
+        ('auto', 'off', 'cuda', 'vaapi', 'qsv', 'videotoolbox', 'vdpau', 'drm'));
+
+ALTER TABLE scan_paths DROP COLUMN health_check_mode;

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -212,6 +212,26 @@ type DetectionConfig struct {
 	Method DetectionMethod
 	Args   []string
 	Mode   string // "quick" or "thorough"
+	// Overrides is the optional per-scan-path override bundle. nil means
+	// "inherit every value from the live global tunables". When non-nil,
+	// any non-nil field inside wins over the matching global for this
+	// specific check.
+	Overrides *ScanOverrides
+}
+
+// ScanOverrides bundles per-scan-path values that take precedence over the
+// global tunables in the settings table. All fields are optional; nil
+// means "inherit the matching global". The scanner constructs one of
+// these from a `scan_paths` row before kicking off a file check.
+//
+// The fields mirror the catalog entries that have meaningful per-library
+// variance: AV1 / 4K libraries on a CUDA host want -hwaccel cuda and a
+// short thorough_duration; a remote SMB share wants hwaccel=off and a
+// longer thorough_timeout to ride out network latency.
+type ScanOverrides struct {
+	ThoroughDurationSeconds *int64
+	ThoroughTimeoutSeconds  *int64
+	Hwaccel                 *string
 }
 
 // CmdHealthChecker validates media files using external command-line tools.
@@ -232,12 +252,20 @@ type CmdHealthChecker struct {
 	hwAccelArgs    []string
 }
 
-// hwAccelArgsResolved returns the cached "-hwaccel ..." args, probing ffmpeg
-// when the live setting has changed since the last call. Returns an empty
-// slice when hardware acceleration is unavailable or disabled - callers can
-// safely append it to any args list. The cache means the (expensive) ffmpeg
-// subprocess probe runs at most once per setting value, not once per scan.
-func (hc *CmdHealthChecker) hwAccelArgsResolved() []string {
+// hwAccelArgsResolved returns the "-hwaccel ..." args for this check,
+// probing ffmpeg when the setting has changed since the last call.
+// Returns an empty slice when hardware acceleration is unavailable or
+// disabled - callers can safely append it to any args list.
+//
+// When ov.Hwaccel is set, the per-path override wins over the global
+// (no caching for the override path - per-path values are rare and
+// re-probing per-call avoids cache-key proliferation). The cached
+// fast-path is reserved for the global setting, which the scanner hits
+// thousands of times.
+func (hc *CmdHealthChecker) hwAccelArgsResolved(ov *ScanOverrides) []string {
+	if ov != nil && ov.Hwaccel != nil && *ov.Hwaccel != "" {
+		return resolveHwAccelArgs(hc.FFmpegPath, *ov.Hwaccel)
+	}
 	setting := config.LiveHealthCheckHwAccel()
 	hc.hwAccelMu.RLock()
 	if hc.hwAccelSetting == setting && hc.hwAccelArgs != nil {
@@ -258,6 +286,24 @@ func (hc *CmdHealthChecker) hwAccelArgsResolved() []string {
 		hc.hwAccelArgs = []string{} // sentinel: non-nil empty means "probed, none"
 	}
 	return hc.hwAccelArgs
+}
+
+// effectiveThoroughDuration picks the per-path override if set, otherwise
+// the live global from the tunable resolver. Zero return means "no -t flag".
+func effectiveThoroughDuration(ov *ScanOverrides) time.Duration {
+	if ov != nil && ov.ThoroughDurationSeconds != nil {
+		return time.Duration(*ov.ThoroughDurationSeconds) * time.Second
+	}
+	return config.LiveHealthCheckThoroughDuration()
+}
+
+// effectiveThoroughTimeout picks the per-path override if set, otherwise
+// the live global from the tunable resolver.
+func effectiveThoroughTimeout(ov *ScanOverrides) time.Duration {
+	if ov != nil && ov.ThoroughTimeoutSeconds != nil {
+		return time.Duration(*ov.ThoroughTimeoutSeconds) * time.Second
+	}
+	return config.LiveHealthCheckThoroughTimeout()
 }
 
 // resolveHwAccelArgs translates HEALARR_HEALTH_CHECK_HWACCEL into the actual
@@ -430,7 +476,7 @@ func (hc *CmdHealthChecker) CheckWithConfig(path string, config DetectionConfig)
 	// 3. Run appropriate detector with mode awareness
 	switch config.Method {
 	case DetectionFFprobe:
-		err := hc.runFFprobeWithArgs(path, config.Args, mode)
+		err := hc.runFFprobeWithArgs(path, config.Args, mode, config.Overrides)
 		if err != nil {
 			return false, hc.classifyDetectorError(err, path)
 		}
@@ -440,7 +486,7 @@ func (hc *CmdHealthChecker) CheckWithConfig(path string, config DetectionConfig)
 			return false, hc.classifyDetectorError(err, path)
 		}
 	case DetectionHandBrake:
-		err := hc.runHandBrakeWithArgs(path, config.Args, mode)
+		err := hc.runHandBrakeWithArgs(path, config.Args, mode, config.Overrides)
 		if err != nil {
 			// HandBrake errors are typically stream-level corruption
 			errStr := err.Error()
@@ -861,7 +907,11 @@ func (hc *CmdHealthChecker) getMediaProbeInfo(path string) (*mediaProbeInfo, err
 // AnalyzeContent checks for content-level issues (black video, frozen video, silent audio)
 // in files that have already passed structural health checks.
 // Only meaningful in thorough mode — call after CheckWithConfig passes.
-func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError) {
+//
+// ov bundles the per-scan-path overrides for the global scan tunables
+// (thorough duration / timeout / hwaccel). Pass nil to inherit every
+// value from the live globals.
+func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError) {
 	if err := validateMediaPath(path); err != nil {
 		return false, &HealthCheckError{
 			Type:    ErrorTypeInvalidConfig,
@@ -888,8 +938,8 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 	// Build ffmpeg command with appropriate filters. Hardware-accel args go
 	// FIRST (they are input options); the optional duration limit "-t N" is
 	// also an input option and must precede "-i".
-	ffmpegArgs := append([]string{"-nostats", "-v", "info"}, hc.hwAccelArgsResolved()...)
-	if duration := config.LiveHealthCheckThoroughDuration(); duration > 0 {
+	ffmpegArgs := append([]string{"-nostats", "-v", "info"}, hc.hwAccelArgsResolved(ov)...)
+	if duration := effectiveThoroughDuration(ov); duration > 0 {
 		ffmpegArgs = append(ffmpegArgs, "-t", strconv.FormatFloat(duration.Seconds(), 'f', -1, 64))
 	}
 	ffmpegArgs = append(ffmpegArgs, "-i", path)
@@ -913,7 +963,7 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string) (bool, *HealthCheckError
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	timeout := config.LiveHealthCheckThoroughTimeout()
+	timeout := effectiveThoroughTimeout(ov)
 	done := make(chan error, 1)
 	safego.Run("content-analysis-cmd", func() {
 		done <- cmd.Run()

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -1802,3 +1802,87 @@ func TestHwAccelDeviceAvailableIn(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// ScanOverrides / effective* tests
+// =============================================================================
+
+func TestEffectiveThoroughDuration_OverrideWinsOverGlobal(t *testing.T) {
+	t.Setenv("HEALARR_HEALTH_CHECK_THOROUGH_DURATION", "")
+
+	tests := []struct {
+		name string
+		ov   *ScanOverrides
+		want time.Duration
+	}{
+		{
+			name: "nil overrides falls through to live global (default 0)",
+			ov:   nil,
+			want: 0,
+		},
+		{
+			name: "nil ThoroughDurationSeconds inside overrides also falls through",
+			ov:   &ScanOverrides{},
+			want: 0,
+		},
+		{
+			name: "non-nil override wins",
+			ov:   &ScanOverrides{ThoroughDurationSeconds: ptrInt64(90)},
+			want: 90 * time.Second,
+		},
+		{
+			name: "zero seconds override wins (operator explicitly chose 'full file')",
+			ov:   &ScanOverrides{ThoroughDurationSeconds: ptrInt64(0)},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveThoroughDuration(tt.ov); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveThoroughTimeout_OverrideWinsOverGlobal(t *testing.T) {
+	t.Setenv("HEALARR_HEALTH_CHECK_THOROUGH_TIMEOUT", "")
+
+	// nil -> live global, which is 10m default when env unset and no live tunables source
+	if got := effectiveThoroughTimeout(nil); got != 10*time.Minute {
+		t.Errorf("nil ov: got %v, want 10m", got)
+	}
+
+	// override wins
+	ov := &ScanOverrides{ThoroughTimeoutSeconds: ptrInt64(300)}
+	if got := effectiveThoroughTimeout(ov); got != 300*time.Second {
+		t.Errorf("override: got %v, want 5m", got)
+	}
+}
+
+func TestHwAccelArgsResolved_OverrideBypassesCache(t *testing.T) {
+	t.Setenv("HEALARR_HEALTH_CHECK_HWACCEL", "off") // global says off
+	hc := &CmdHealthChecker{FFmpegPath: "/nonexistent/ffmpeg"}
+
+	// No override -> global "off" -> empty args.
+	if got := hc.hwAccelArgsResolved(nil); len(got) != 0 {
+		t.Errorf("global off: got %v, want empty", got)
+	}
+
+	// Override "cuda" -> ["-hwaccel","cuda"] regardless of global.
+	cuda := "cuda"
+	ov := &ScanOverrides{Hwaccel: &cuda}
+	args := hc.hwAccelArgsResolved(ov)
+	if len(args) != 2 || args[0] != "-hwaccel" || args[1] != "cuda" {
+		t.Errorf("cuda override: got %v, want [-hwaccel cuda]", args)
+	}
+
+	// Empty-string override is treated as nil (inherit global).
+	empty := ""
+	ov2 := &ScanOverrides{Hwaccel: &empty}
+	if got := hc.hwAccelArgsResolved(ov2); len(got) != 0 {
+		t.Errorf("empty-string override: got %v, want empty (inherit global off)", got)
+	}
+}
+
+func ptrInt64(v int64) *int64 { return &v }

--- a/internal/integration/health_checker_tools.go
+++ b/internal/integration/health_checker_tools.go
@@ -9,12 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/safego"
 )
 
-func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string, mode string) error {
+func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string, mode string, ov *ScanOverrides) error {
 	// Mode determines the type of check:
 	// - "quick": Only check container headers and stream info (fast, ~1-2 seconds) using ffprobe
 	// - "thorough": Decode entire file to detect stream corruption (slow, can take minutes) using ffmpeg
@@ -34,8 +33,8 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 		// corruption (a trade the operator opts into).
 		cmdPath = hc.FFmpegPath
 		cmdName = "ffmpeg"
-		args = append([]string{"-v", "error", argXError}, hc.hwAccelArgsResolved()...)
-		if duration := config.LiveHealthCheckThoroughDuration(); duration > 0 {
+		args = append([]string{"-v", "error", argXError}, hc.hwAccelArgsResolved(ov)...)
+		if duration := effectiveThoroughDuration(ov); duration > 0 {
 			args = append(args, "-t", strconv.FormatFloat(duration.Seconds(), 'f', -1, 64))
 		}
 		args = append(args, customArgs...)
@@ -66,7 +65,7 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 	// files, or shrink it once you have set THOROUGH_DURATION to a short prefix).
 	timeout := 30 * time.Second
 	if mode == ModeThorough {
-		timeout = config.LiveHealthCheckThoroughTimeout()
+		timeout = effectiveThoroughTimeout(ov)
 	}
 
 	done := make(chan error, 1)
@@ -96,7 +95,7 @@ func (hc *CmdHealthChecker) runFFprobeWithArgs(path string, customArgs []string,
 	return nil
 }
 
-func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []string, mode string) error {
+func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []string, mode string, ov *ScanOverrides) error {
 	// Mode determines the type of check:
 	// - "quick": Basic scan of container structure
 	// - "thorough": Full stream analysis (HandBrake's default scan is already quite thorough)
@@ -108,7 +107,7 @@ func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []strin
 		// Thorough mode: Full scan with preview analysis
 		// --previews 10:0 generates 10 previews at different points to verify stream integrity
 		args = []string{argScan, argPreviews, "10:0", "-i", path}
-		timeout = config.LiveHealthCheckThoroughTimeout()
+		timeout = effectiveThoroughTimeout(ov)
 	} else {
 		// Quick mode: Basic container scan
 		args = []string{argScan, "-i", path}

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -173,7 +173,7 @@ func itoa(n int) string {
 type HealthChecker interface {
 	Check(path, mode string) (bool, *HealthCheckError)
 	CheckWithConfig(path string, config DetectionConfig) (bool, *HealthCheckError)
-	AnalyzeContent(path string) (bool, *HealthCheckError)
+	AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError)
 }
 
 // PathMapper defines the interface for translating paths

--- a/internal/integration/path_mapper_test.go
+++ b/internal/integration/path_mapper_test.go
@@ -34,6 +34,9 @@ func newTestDBForPathMapper() (*sql.DB, error) {
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
 			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)
 	`)

--- a/internal/repository/scan_path.go
+++ b/internal/repository/scan_path.go
@@ -28,6 +28,14 @@ type ScanPath struct {
 	DetectionMode            string
 	MaxRetries               int
 	VerificationTimeoutHours sql.NullInt64
+
+	// Per-path overrides. NULL means "inherit the matching global tunable"
+	// (scan.thorough_duration_seconds / scan.thorough_timeout_seconds /
+	// scan.hwaccel from the settings table). Healarr's effective-config
+	// resolver picks per-path > global > env > default.
+	ThoroughDurationSeconds sql.NullInt64
+	ThoroughTimeoutSeconds  sql.NullInt64
+	Hwaccel                 sql.NullString
 }
 
 // ScanPathFields is the input shape shared by Create and Update — all the
@@ -48,6 +56,11 @@ type ScanPathFields struct {
 	DetectionMode            string
 	MaxRetries               int
 	VerificationTimeoutHours sql.NullInt64
+
+	// Per-path overrides; NULL/zero = inherit global (see ScanPath).
+	ThoroughDurationSeconds sql.NullInt64
+	ThoroughTimeoutSeconds  sql.NullInt64
+	Hwaccel                 sql.NullString
 }
 
 // ScanPathRepository wraps the scan_paths table.
@@ -62,7 +75,8 @@ func NewScanPathRepository(db *sql.DB) *ScanPathRepository {
 
 const scanPathColumns = `id, local_path, arr_path, arr_instance_id, enabled,
 	auto_remediate, dry_run, detection_method, detection_args, detection_mode,
-	max_retries, verification_timeout_hours`
+	max_retries, verification_timeout_hours,
+	thorough_duration_seconds, thorough_timeout_seconds, hwaccel`
 
 func scanScanPathRow(scanner interface {
 	Scan(dest ...interface{}) error
@@ -71,6 +85,7 @@ func scanScanPathRow(scanner interface {
 		&p.ID, &p.LocalPath, &p.ArrPath, &p.ArrInstanceID, &p.Enabled,
 		&p.AutoRemediate, &p.DryRun, &p.DetectionMethod, &p.DetectionArgs,
 		&p.DetectionMode, &p.MaxRetries, &p.VerificationTimeoutHours,
+		&p.ThoroughDurationSeconds, &p.ThoroughTimeoutSeconds, &p.Hwaccel,
 	)
 }
 
@@ -210,10 +225,12 @@ func (r *ScanPathRepository) Create(ctx context.Context, f ScanPathFields) (int6
 	}
 	res, err := r.db.ExecContext(ctx, `INSERT INTO scan_paths
 		(local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run,
-		 detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 detection_method, detection_args, detection_mode, max_retries, verification_timeout_hours,
+		 thorough_duration_seconds, thorough_timeout_seconds, hwaccel)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		f.LocalPath, f.ArrPath, f.ArrInstanceID, f.Enabled, f.AutoRemediate, f.DryRun,
 		f.DetectionMethod, detectionArgs, f.DetectionMode, f.MaxRetries, f.VerificationTimeoutHours,
+		f.ThoroughDurationSeconds, f.ThoroughTimeoutSeconds, f.Hwaccel,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("insert scan_path: %w", err)
@@ -234,11 +251,13 @@ func (r *ScanPathRepository) Update(ctx context.Context, id int64, f ScanPathFie
 	_, err := r.db.ExecContext(ctx, `UPDATE scan_paths SET
 		local_path = ?, arr_path = ?, arr_instance_id = ?, enabled = ?,
 		auto_remediate = ?, dry_run = ?, detection_method = ?, detection_args = ?,
-		detection_mode = ?, max_retries = ?, verification_timeout_hours = ?
+		detection_mode = ?, max_retries = ?, verification_timeout_hours = ?,
+		thorough_duration_seconds = ?, thorough_timeout_seconds = ?, hwaccel = ?
 		WHERE id = ?`,
 		f.LocalPath, f.ArrPath, f.ArrInstanceID, f.Enabled,
 		f.AutoRemediate, f.DryRun, f.DetectionMethod, detectionArgs,
-		f.DetectionMode, f.MaxRetries, f.VerificationTimeoutHours, id,
+		f.DetectionMode, f.MaxRetries, f.VerificationTimeoutHours,
+		f.ThoroughDurationSeconds, f.ThoroughTimeoutSeconds, f.Hwaccel, id,
 	)
 	if err != nil {
 		return fmt.Errorf("update scan_path: %w", err)

--- a/internal/repository/scan_path_test.go
+++ b/internal/repository/scan_path_test.go
@@ -23,6 +23,9 @@ CREATE TABLE scan_paths (
 	detection_mode             TEXT NOT NULL DEFAULT 'quick',
 	max_retries                INTEGER DEFAULT 3,
 	verification_timeout_hours INTEGER,
+	thorough_duration_seconds  INTEGER,
+	thorough_timeout_seconds   INTEGER,
+	hwaccel                    TEXT,
 	created_at                 TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 `

--- a/internal/services/recovery_test.go
+++ b/internal/services/recovery_test.go
@@ -63,7 +63,10 @@ func setupRecoveryTestDB(t *testing.T) *sql.DB {
 			detection_args TEXT,
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER
+			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT
 		);
 	`)
 	if err != nil {

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -875,15 +875,46 @@ func (s *ScannerService) loadScanPathSettings(pathID int64) scanPathSettings {
 		}
 	}
 
+	// Bundle the per-path overrides for the global scan tunables (Phase 2 of
+	// the /config redesign). nil-valued fields inside mean "inherit the
+	// global"; the resolver in health_checker handles the precedence.
+	overrides := buildScanOverrides(path)
+
 	return scanPathSettings{
 		AutoRemediate: autoRemediate,
 		DryRun:        dryRun,
 		DetectionConfig: integration.DetectionConfig{
-			Method: integration.DetectionMethod(detectionMethod),
-			Args:   detectionArgs,
-			Mode:   detectionMode,
+			Method:    integration.DetectionMethod(detectionMethod),
+			Args:      detectionArgs,
+			Mode:      detectionMode,
+			Overrides: overrides,
 		},
 	}
+}
+
+// buildScanOverrides translates the nullable per-path override columns on
+// a scan_paths row into the integration package's ScanOverrides bundle.
+// Returns nil when no override is set so the resolver short-circuits
+// straight to the live globals - cheaper than constructing a bundle of
+// nil pointers per file in a 25k-file library.
+func buildScanOverrides(path repository.ScanPath) *integration.ScanOverrides {
+	if !path.ThoroughDurationSeconds.Valid && !path.ThoroughTimeoutSeconds.Valid && !path.Hwaccel.Valid {
+		return nil
+	}
+	ov := &integration.ScanOverrides{}
+	if path.ThoroughDurationSeconds.Valid {
+		v := path.ThoroughDurationSeconds.Int64
+		ov.ThoroughDurationSeconds = &v
+	}
+	if path.ThoroughTimeoutSeconds.Valid {
+		v := path.ThoroughTimeoutSeconds.Int64
+		ov.ThoroughTimeoutSeconds = &v
+	}
+	if path.Hwaccel.Valid {
+		v := path.Hwaccel.String
+		ov.Hwaccel = &v
+	}
+	return ov
 }
 
 // walkStats tracks statistics during directory enumeration
@@ -1735,7 +1766,7 @@ func (s *ScannerService) detectFile(sfc *scanFileContext, cfg scanFilesConfig) d
 	healthy, healthErr := s.detector.CheckWithConfig(sfc.filePath, cfg.DetectionConfig)
 	if healthy && cfg.DetectionConfig.Mode == integration.ModeThorough {
 		// Thorough mode: structurally-healthy files get a content-analysis pass.
-		healthy, healthErr = s.detector.AnalyzeContent(sfc.filePath)
+		healthy, healthErr = s.detector.AnalyzeContent(sfc.filePath, cfg.DetectionConfig.Overrides)
 	}
 	if healthy {
 		return detectionResult{outcome: outcomeHealthy}

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4157,7 +4157,7 @@ func TestScannerService_ContentAnalysis_ThoroughMode(t *testing.T) {
 			return true, nil
 		},
 		// Content analysis detects black video
-		AnalyzeContentFunc: func(path string) (bool, *integration.HealthCheckError) {
+		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
 			return false, &integration.HealthCheckError{
 				Type:    integration.ErrorTypeBlackVideo,
 				Message: "video is 100% black",
@@ -4224,7 +4224,7 @@ func TestScannerService_ContentAnalysis_QuickMode_Skipped(t *testing.T) {
 		CheckWithConfigFunc: func(path string, config integration.DetectionConfig) (bool, *integration.HealthCheckError) {
 			return true, nil
 		},
-		AnalyzeContentFunc: func(path string) (bool, *integration.HealthCheckError) {
+		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
 			t.Error("AnalyzeContent should NOT be called in quick mode")
 			return true, nil
 		},

--- a/internal/services/scheduler_test.go
+++ b/internal/services/scheduler_test.go
@@ -150,7 +150,10 @@ func TestSchedulerService_LoadSchedules_WithValidSchedule(t *testing.T) {
 			detection_args TEXT,
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER
+			verification_timeout_hours INTEGER,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT
 		);
 		CREATE TABLE scan_schedules (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -538,7 +538,7 @@ func (m *MockPathMapper) CallCount(method string) int {
 type MockHealthChecker struct {
 	CheckFunc           func(path, mode string) (bool, *integration.HealthCheckError)
 	CheckWithConfigFunc func(path string, config integration.DetectionConfig) (bool, *integration.HealthCheckError)
-	AnalyzeContentFunc  func(path string) (bool, *integration.HealthCheckError)
+	AnalyzeContentFunc  func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError)
 
 	// Strict makes unconfigured methods panic rather than fall back to the
 	// "file is healthy" default. Opt-in (default false).
@@ -580,10 +580,10 @@ func (m *MockHealthChecker) CheckWithConfig(path string, config integration.Dete
 	return true, nil
 }
 
-func (m *MockHealthChecker) AnalyzeContent(path string) (bool, *integration.HealthCheckError) {
+func (m *MockHealthChecker) AnalyzeContent(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
 	m.recordCall("AnalyzeContent", path)
 	if m.AnalyzeContentFunc != nil {
-		return m.AnalyzeContentFunc(path)
+		return m.AnalyzeContentFunc(path, ov)
 	}
 	m.unconfigured("AnalyzeContent")
 	// Default: content is healthy

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -67,7 +67,7 @@ func initializeSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create event_type index: %w", err)
 	}
 
-	// Create scan_paths table
+	// Create scan_paths table (matches migrated schema after 008_scan_path_overrides.sql)
 	_, err = db.Exec(`
 		CREATE TABLE scan_paths (
 			id INTEGER PRIMARY KEY,
@@ -75,7 +75,6 @@ func initializeSchema(db *sql.DB) error {
 			arr_path TEXT NOT NULL,
 			arr_instance_id INTEGER,
 			enabled BOOLEAN DEFAULT 1,
-			health_check_mode TEXT DEFAULT 'thorough',
 			auto_remediate BOOLEAN DEFAULT 0,
 			dry_run BOOLEAN DEFAULT 0,
 			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
@@ -83,6 +82,10 @@ func initializeSchema(db *sql.DB) error {
 			detection_mode TEXT NOT NULL DEFAULT 'quick',
 			max_retries INTEGER DEFAULT 3,
 			verification_timeout_hours INTEGER DEFAULT NULL,
+			thorough_duration_seconds INTEGER,
+			thorough_timeout_seconds INTEGER,
+			hwaccel TEXT CHECK (hwaccel IS NULL OR hwaccel IN
+				('auto', 'off', 'cuda', 'vaapi', 'qsv', 'videotoolbox', 'vdpau', 'drm')),
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		)
 	`)


### PR DESCRIPTION
Second of three PRs in the /config redesign. Adds per-scan-path overrides for the three scan-related global tunables and cleans up a dead column.

## What changes

Each scan path can now pin its own value for any of:
- \`thorough_duration_seconds\` (\"first 60 seconds\" feature)
- \`thorough_timeout_seconds\`
- \`hwaccel\`

NULL means \"inherit the global\" (the existing behavior - no migration of existing data needed). A non-NULL value wins for that specific path. The resolver picks **per-path > global > env > default** at every per-file health-check call.

### Motivating case

The Healarr instance running across both:
- A fast local 4K AV1 library on a CUDA host
- A remote SMB share with no GPU

...wants \`hwaccel=cuda\` + \`thorough_duration=60s\` on the first, and \`hwaccel=off\` + longer thorough_timeout on the second. A single global value loses on one. Per-path overrides fix it without a second Healarr deployment.

### Other cleanup in the same PR

- **Per-path \`dry_run\` is now in the form.** The column has been on \`scan_paths\` for several versions but the form never surfaced it.
- **Dropped the dead \`health_check_mode\` column.** Defined in \`001_schema.sql\` with a CHECK on (\'quick\',\'thorough\') but never read or written by any Go code (the concept moved into \`detection_mode\`).

## Migration 008

```sql
ALTER TABLE scan_paths ADD COLUMN thorough_duration_seconds INTEGER;
ALTER TABLE scan_paths ADD COLUMN thorough_timeout_seconds INTEGER;
ALTER TABLE scan_paths ADD COLUMN hwaccel TEXT CHECK (...);
ALTER TABLE scan_paths DROP COLUMN health_check_mode;
```

DROP COLUMN is native to SQLite 3.35+. modernc.org/sqlite (Healarr's runtime driver) embeds SQLite well past that, so no table-rebuild dance.

## UI

New \"Override scanning defaults for this path\" disclosure on each scan path. Three selects: each defaults to \"Inherit global\" with explicit values to pin. Plus the long-overdue Dry Run checkbox.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` -> 0 issues
- [x] \`go test ./...\` -> all green (3 new override-precedence tests in integration package; 8 test files updated for the new columns)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run build\` succeeds (Config bundle grew 4 kB)
- [x] \`npx vitest run\` -> 166 passing, 1 skipped (no regressions)
- [ ] Manual: edit a scan path, expand \"Override scanning defaults\", set hwaccel=cuda, save. Confirm \`ffmpeg -hwaccel cuda ...\` is run for files in that path (regardless of the global setting).
- [ ] Manual: leave all overrides as \"Inherit global\", confirm scan uses the values from the /config Scanning defaults card (Phase 1 behavior unchanged).

## Phase plan recap

- Phase 1 (#263, merged): expose env-only knobs in UI
- **Phase 2 (this PR):** per-scan-path overrides + drop dead column
- Phase 3 (next): preset bundles, including user-defined custom presets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configure per-path scan parameters: Set thorough scan duration, timeout, and hardware acceleration for individual scan paths, with "Inherit global" options to use default settings.
  * Enable Dry Run mode per path: Use the new per-path Dry Run checkbox to preview remediation actions before deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->