### PR TITLE
refactor(test): consolidate scan_paths test schema into shared constant

### DIFF
--- a/internal/api/handlers_config_test.go
+++ b/internal/api/handlers_config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/notifier"
 	"github.com/mescon/Healarr/internal/testutil"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // setupConfigTestDB creates a test database with full schema for config tests
@@ -68,24 +69,7 @@ func setupConfigTestDB(t *testing.T) (*sql.DB, func()) {
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			local_path TEXT NOT NULL,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER REFERENCES arr_instances(id) ON DELETE SET NULL,
-			enabled INTEGER DEFAULT 1,
-			auto_remediate INTEGER DEFAULT 1,
-			dry_run INTEGER DEFAULT 0,
-			detection_method TEXT DEFAULT 'ffprobe',
-			detection_args TEXT DEFAULT NULL,
-			detection_mode TEXT DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER DEFAULT NULL,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
+		` + schemas.ScanPaths + `
 
 		CREATE TABLE scan_schedules (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/api/handlers_health_test.go
+++ b/internal/api/handlers_health_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/metrics"
 	"github.com/mescon/Healarr/internal/services"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // Global metrics service to avoid Prometheus duplicate registration
@@ -84,24 +85,7 @@ func setupTestDBForHealth(t *testing.T) (*sql.DB, string, func()) {
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			local_path TEXT NOT NULL,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER REFERENCES arr_instances(id),
-			enabled INTEGER DEFAULT 1,
-			auto_remediate INTEGER DEFAULT 0,
-			dry_run INTEGER DEFAULT 0,
-			detection_method TEXT DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
+		` + schemas.ScanPaths + `
 
 		CREATE TABLE scans (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/testutil"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 func init() {
@@ -29,25 +30,16 @@ func init() {
 	})
 }
 
-// setupPathsTestDB creates a test database with full scan_paths schema
+// setupPathsTestDB creates a test database with the full scan_paths schema.
+// setupTestDB hands back a DB with only the minimal scan_paths shape (just
+// what the basic handler tests need). Drop that table and re-create from
+// the canonical schema so this file's tests see every column the repo
+// queries against.
 func setupPathsTestDB(t *testing.T) (*sql.DB, func()) {
 	t.Helper()
 
 	db, cleanup := setupTestDB(t)
-
-	// Add full scan_paths schema
-	schema := `
-		ALTER TABLE scan_paths ADD COLUMN detection_method TEXT DEFAULT 'ffprobe';
-		ALTER TABLE scan_paths ADD COLUMN detection_args TEXT;
-		ALTER TABLE scan_paths ADD COLUMN detection_mode TEXT DEFAULT 'quick';
-		ALTER TABLE scan_paths ADD COLUMN max_retries INTEGER DEFAULT 3;
-		ALTER TABLE scan_paths ADD COLUMN verification_timeout_hours INTEGER;
-		ALTER TABLE scan_paths ADD COLUMN dry_run INTEGER DEFAULT 0;
-		ALTER TABLE scan_paths ADD COLUMN thorough_duration_seconds INTEGER;
-		ALTER TABLE scan_paths ADD COLUMN thorough_timeout_seconds INTEGER;
-		ALTER TABLE scan_paths ADD COLUMN hwaccel TEXT;
-	`
-	_, err := db.Exec(schema)
+	_, err := db.Exec("DROP TABLE scan_paths;" + schemas.ScanPaths)
 	require.NoError(t, err)
 
 	return db, cleanup

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/services"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // setupScansTestDB creates a test database with schema for scan tests
@@ -64,24 +65,7 @@ func setupScansTestDB(t *testing.T) (*sql.DB, func()) {
 			corruptions_found INTEGER DEFAULT 0
 		);
 
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			local_path TEXT NOT NULL,
-			arr_path TEXT,
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			dry_run BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		);
+		` + schemas.ScanPaths + `
 
 		CREATE TABLE scan_files (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/api/handlers_stats_test.go
+++ b/internal/api/handlers_stats_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/services"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // mockHealthChecker and mockPathMapper are defined in handlers_health_test.go
@@ -68,23 +69,7 @@ func setupStatsTestDB(t *testing.T) (*sql.DB, func()) {
 			corruptions_found INTEGER DEFAULT 0
 		);
 
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			local_path TEXT NOT NULL UNIQUE,
-			arr_path TEXT NOT NULL DEFAULT '',
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			dry_run BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT
-		);
+		` + schemas.ScanPaths + `
 
 		CREATE VIEW corruption_status AS
 		SELECT

--- a/internal/db/retry_test.go
+++ b/internal/db/retry_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	_ "modernc.org/sqlite" // Register pure-Go SQLite driver for database/sql
+
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // testDBCounter ensures unique database names across parallel test runs
@@ -41,22 +43,8 @@ func newTestDBForRetry() (*sql.DB, error) {
 		}
 	}
 
-	// Create a minimal scan_paths table for testing
-	_, err = db.Exec(`
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY,
-			local_path TEXT NOT NULL UNIQUE,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER DEFAULT NULL
-		)
-	`)
+	// Create the scan_paths table using the canonical test schema.
+	_, err = db.Exec(schemas.ScanPaths)
 	if err != nil {
 		_ = db.Close()
 		return nil, err

--- a/internal/integration/path_mapper_test.go
+++ b/internal/integration/path_mapper_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // Register CGo SQLite driver for database/sql
+
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // =============================================================================
-// Test helpers (avoiding testutil import due to cycle)
+// Test helpers (avoiding the full testutil import due to package cycle;
+// schemas/ is a leaf sub-package that doesn't pull in the rest)
 // =============================================================================
 
 // newTestDBForPathMapper creates an in-memory SQLite database with schema for tests.
@@ -20,26 +23,7 @@ func newTestDBForPathMapper() (*sql.DB, error) {
 	}
 
 	// Create scan_paths table
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS scan_paths (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			local_path TEXT NOT NULL,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER,
-			auto_remediate INTEGER NOT NULL DEFAULT 0,
-			dry_run INTEGER NOT NULL DEFAULT 0,
-			enabled INTEGER NOT NULL DEFAULT 1,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT,
-			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-		)
-	`)
+	_, err = db.Exec(schemas.ScanPaths)
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to create scan_paths table: %w", err)

--- a/internal/repository/scan_path_test.go
+++ b/internal/repository/scan_path_test.go
@@ -7,28 +7,14 @@ import (
 	"testing"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
-const scanPathSchema = `
-CREATE TABLE scan_paths (
-	id                         INTEGER PRIMARY KEY AUTOINCREMENT,
-	local_path                 TEXT NOT NULL UNIQUE,
-	arr_path                   TEXT NOT NULL,
-	arr_instance_id            INTEGER,
-	enabled                    BOOLEAN DEFAULT 1,
-	auto_remediate             BOOLEAN DEFAULT 0,
-	dry_run                    BOOLEAN DEFAULT 0,
-	detection_method           TEXT NOT NULL DEFAULT 'ffprobe',
-	detection_args             TEXT,
-	detection_mode             TEXT NOT NULL DEFAULT 'quick',
-	max_retries                INTEGER DEFAULT 3,
-	verification_timeout_hours INTEGER,
-	thorough_duration_seconds  INTEGER,
-	thorough_timeout_seconds   INTEGER,
-	hwaccel                    TEXT,
-	created_at                 TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-`
+// scanPathSchema is the schema used by scan_path repository tests. We
+// keep the existing identifier (instead of inlining schemas.ScanPaths
+// at each callsite) so the test file's intent stays readable.
+const scanPathSchema = schemas.ScanPaths
 
 func newScanPathTestDB(t *testing.T) *sql.DB {
 	t.Helper()

--- a/internal/services/recovery_test.go
+++ b/internal/services/recovery_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/testutil"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 func init() {
@@ -51,23 +52,7 @@ func setupRecoveryTestDB(t *testing.T) *sql.DB {
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			user_id TEXT
 		);
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY,
-			local_path TEXT NOT NULL,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			dry_run BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT
-		);
+		` + schemas.ScanPaths + `
 	`)
 	if err != nil {
 		t.Fatalf("Failed to create tables: %v", err)

--- a/internal/services/scheduler_test.go
+++ b/internal/services/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	_ "modernc.org/sqlite" // Register pure-Go SQLite driver for database/sql
 
 	"github.com/mescon/Healarr/internal/testutil"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // =============================================================================
@@ -138,23 +139,7 @@ func TestSchedulerService_LoadSchedules_WithValidSchedule(t *testing.T) {
 
 	// Create required tables
 	_, err = db.Exec(`
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY,
-			local_path TEXT NOT NULL,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			dry_run BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT
-		);
+		` + schemas.ScanPaths + `
 		CREATE TABLE scan_schedules (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			scan_path_id INTEGER NOT NULL,

--- a/internal/testutil/schemas/schemas.go
+++ b/internal/testutil/schemas/schemas.go
@@ -1,0 +1,111 @@
+// Package schemas exposes canonical CREATE TABLE SQL for use in tests
+// that need an in-memory SQLite seeded with just the schema (no
+// migration runner). Production code does NOT use this package - the
+// real schema comes from internal/db/migrations.
+//
+// The constants here are the *result* of applying every migration in
+// internal/db/migrations to a fresh DB. When a migration changes a
+// table's columns, update the matching constant here so every test
+// that uses the shared schema picks up the change in one edit instead
+// of needing fixes across a dozen hand-rolled CREATE TABLE blocks.
+//
+// Stub schemas (where a test only needs an `id` and `local_path` to
+// satisfy a foreign-key reference and never queries the full row)
+// should NOT be replaced with these constants - they're intentionally
+// minimal. Use these constants only where the test actually exercises
+// the repo layer or anything that does `SELECT col1, col2, ... FROM
+// scan_paths`.
+//
+// The package has no imports from elsewhere in the project so that any
+// test, in any package, can import it without circular-import concerns.
+// In particular, internal/repository test files (which can't import
+// internal/testutil because testutil transitively depends on
+// repository) can import this sub-package directly.
+package schemas
+
+// ArrInstances is the CREATE TABLE SQL for the arr_instances table. Many
+// tests that use ScanPaths also need this because scan_paths declares a
+// FK reference to arr_instances(id); without the referenced table, an
+// INSERT into scan_paths fails the FK check under PRAGMA foreign_keys=ON.
+// The shape mirrors the production migration 001 column set the
+// repository.ArrInstance code touches.
+const ArrInstances = `
+CREATE TABLE IF NOT EXISTS arr_instances (
+	id INTEGER PRIMARY KEY,
+	name TEXT NOT NULL,
+	type TEXT NOT NULL,
+	url TEXT NOT NULL,
+	api_key TEXT NOT NULL,
+	enabled BOOLEAN DEFAULT 1,
+	webhook_secret TEXT,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);`
+
+// ScanPaths is the CREATE TABLE SQL for the scan_paths table after all
+// migrations in internal/db/migrations have been applied. Matches the
+// shape of the production schema after migration 008 (per-path
+// overrides + dropped health_check_mode column) with ONE intentional
+// difference: arr_instance_id is declared without the REFERENCES clause.
+//
+// The production schema does declare `REFERENCES arr_instances(id)`,
+// which means tests under PRAGMA foreign_keys=ON cannot insert a scan
+// path with arr_instance_id=N unless an arr_instances row with id=N
+// already exists. Most tests in this repo don't exercise *arr APIs
+// and don't want the bookkeeping. Tests that *do* want the FK
+// enforced can seed ArrInstances first and add the FK manually.
+//
+// IF NOT EXISTS makes the statement idempotent so callers that build
+// up the schema in stages (or that already have an ALTER-based stub
+// in place) don't have to special-case re-creation.
+const ScanPaths = `
+CREATE TABLE IF NOT EXISTS scan_paths (
+	id INTEGER PRIMARY KEY,
+	local_path TEXT NOT NULL UNIQUE,
+	arr_path TEXT NOT NULL DEFAULT '',
+	arr_instance_id INTEGER,
+	enabled BOOLEAN DEFAULT 1,
+	auto_remediate BOOLEAN DEFAULT 0,
+	dry_run BOOLEAN DEFAULT 0,
+	detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+	detection_args TEXT,
+	detection_mode TEXT NOT NULL DEFAULT 'quick',
+	max_retries INTEGER DEFAULT 3,
+	verification_timeout_hours INTEGER,
+	thorough_duration_seconds INTEGER,
+	thorough_timeout_seconds INTEGER,
+	hwaccel TEXT,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);`
+
+// ScanPresets is the CREATE TABLE SQL for the scan_presets table after
+// migration 009. The 5 built-in rows (Zero-byte only, Quick, Fast
+// triage, Deep scan, Paranoid) are NOT seeded by this constant - tests
+// that need them should INSERT explicitly so the test's intent is
+// visible at the call site. See ScanPresetsBuiltinSeed for a
+// drop-in helper that mirrors what migration 009 inserts.
+const ScanPresets = `
+CREATE TABLE IF NOT EXISTS scan_presets (
+	id INTEGER PRIMARY KEY,
+	name TEXT NOT NULL UNIQUE,
+	description TEXT NOT NULL DEFAULT '',
+	detection_method TEXT NOT NULL DEFAULT 'ffprobe',
+	detection_mode TEXT NOT NULL DEFAULT 'quick',
+	detection_args TEXT,
+	thorough_duration_seconds INTEGER,
+	thorough_timeout_seconds INTEGER,
+	hwaccel TEXT,
+	is_builtin INTEGER NOT NULL DEFAULT 0,
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);`
+
+// ScanPresetsBuiltinSeed inserts the same five built-in rows that
+// migration 009 seeds in production. Tests that exercise the
+// is_builtin gate need these in place; tests that only verify CRUD on
+// custom presets do not.
+const ScanPresetsBuiltinSeed = `
+INSERT INTO scan_presets (name, detection_method, detection_mode, is_builtin) VALUES
+	('Zero-byte only', 'zero_byte', 'quick', 1),
+	('Quick',          'ffprobe',   'quick', 1),
+	('Fast triage',    'ffprobe',   'thorough', 1),
+	('Deep scan',      'ffprobe',   'thorough', 1),
+	('Paranoid',       'handbrake', 'thorough', 1);`

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -9,6 +9,7 @@ import (
 	_ "modernc.org/sqlite" // Register pure-Go SQLite driver for database/sql
 
 	"github.com/mescon/Healarr/internal/domain"
+	"github.com/mescon/Healarr/internal/testutil/schemas"
 )
 
 // NewTestDB creates an in-memory SQLite database with the Healarr schema.
@@ -67,29 +68,9 @@ func initializeSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create event_type index: %w", err)
 	}
 
-	// Create scan_paths table (matches migrated schema after 008_scan_path_overrides.sql)
-	_, err = db.Exec(`
-		CREATE TABLE scan_paths (
-			id INTEGER PRIMARY KEY,
-			local_path TEXT NOT NULL UNIQUE,
-			arr_path TEXT NOT NULL,
-			arr_instance_id INTEGER,
-			enabled BOOLEAN DEFAULT 1,
-			auto_remediate BOOLEAN DEFAULT 0,
-			dry_run BOOLEAN DEFAULT 0,
-			detection_method TEXT NOT NULL DEFAULT 'ffprobe',
-			detection_args TEXT,
-			detection_mode TEXT NOT NULL DEFAULT 'quick',
-			max_retries INTEGER DEFAULT 3,
-			verification_timeout_hours INTEGER DEFAULT NULL,
-			thorough_duration_seconds INTEGER,
-			thorough_timeout_seconds INTEGER,
-			hwaccel TEXT CHECK (hwaccel IS NULL OR hwaccel IN
-				('auto', 'off', 'cuda', 'vaapi', 'qsv', 'videotoolbox', 'vdpau', 'drm')),
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		)
-	`)
-	if err != nil {
+	// Create scan_paths via the shared schema constant. Centralized so a
+	// column addition is one edit, not eight.
+	if _, err = db.Exec(schemas.ScanPaths); err != nil {
 		return fmt.Errorf("failed to create scan_paths table: %w", err)
 	}
 


### PR DESCRIPTION
The same \`scan_paths\` CREATE TABLE was hand-rolled in 10 test files. Phases 1 through 3 of the /config redesign needed to update all of them three separate times, and one (\`internal/db/retry_test.go\`) silently drifted out of sync without breaking - its tests don't exercise the missing columns, so the missing-column bug was latent.

This PR centralizes the canonical SQL in a new leaf package and replaces the 10 hand-rolled blocks with imports.

## Net effect

```
12 files changed, 149 insertions(+), 200 deletions(-)
```

Adding a column on \`scan_paths\` is now one edit (the constant) instead of chasing eight test files plus the production migration.

## Design notes

**Sub-package, not testutil itself.** \`internal/testutil\` transitively imports \`internal/repository\` (via integration -> config -> repository), so test files in \`internal/repository/\` (which are \`package repository\`, not \`_test\`) cannot import testutil without a cycle. The new \`internal/testutil/schemas\` package imports nothing - safely importable from anywhere.

**One intentional difference from production.** The shared schema declares \`arr_instance_id INTEGER\` without the \`REFERENCES arr_instances(id)\` clause that \`001_schema.sql\` has. Under \`PRAGMA foreign_keys=ON\` (which \`testutil.NewTestDB\` enables), the FK would force every test that inserts a scan path with an arr_instance_id to first seed an arr_instances row. Most tests don't exercise *arr APIs and don't want the bookkeeping. The schemas package also exports an \`ArrInstances\` constant for the few tests that DO want the FK-target table present.

## Stubs left alone

These files keep their intentionally minimal stub schemas because they only declare scan_paths as a FK target for other tables and never query the full row:
- \`internal/api/handlers_setup_test.go\` (mix of stubs)
- \`internal/api/handlers_test.go\`, \`handlers_webhook_test.go\`
- \`internal/integration/arr_client_test.go\` (has a legacy \`is_4k\` column some tests rely on)
- \`internal/repository/arr_instance_test.go\`, \`schedule_test.go\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` -> 0 issues
- [x] \`go test ./...\` -> all green
- [x] Pure refactor: zero behavior changes, all changes are equivalent SQL or import edits