### PR TITLE
fix(scanner): zombie cancelled scans coming back as 'running' after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Cancelling a scan now actually stops the in-process scan loop, and previously-cancelled scans no longer come back as "running" after a restart.** Three composing bugs were producing zombie scans (see [#274](https://github.com/mescon/Healarr/issues/274)):
+  1. `CancelScan` looked up the in-memory scan map by the DB integer id, but the map is keyed by an internal UUID, so the in-memory `ctx.cancel()` never fired. The scan loop kept iterating files after the user clicked cancel - only the DB row was updated. `CancelScan` now also matches by `ScanDBID`, so the HTTP cancel (which routes by DB id) properly signals the in-process scan; `PauseScan` and `ResumeScan` got the same fix.
+  2. `ListInterrupted` (the resume-at-startup query) did not filter out rows with `completed_at` set. A scan that was cancelled and later had its status overwritten to `interrupted` by a graceful shutdown was being **resumed** on the next startup, resurrecting the cancellation as `status='running'`. It now filters on `completed_at IS NULL`.
+  3. `MarkCancelled` / `MarkOrphansCancelled` used `WHERE completed_at IS NULL` as the guard against clobbering a real terminal state. That guard also blocked recovery of the inconsistent rows the other two bugs created (`status='running'` with `completed_at` set), leaving them permanently stuck. The guard is now `status NOT IN ('cancelled', 'completed', 'aborted')` - same protection against the cancel-vs-completion race, but also catches the zombie rows.
+
+  Any installs that previously hit this state have rows like `status IN ('running', 'enumerating', 'scanning', 'interrupted') AND completed_at IS NOT NULL` in the `scans` table; the `MarkOrphansCancelled` startup hook will now clean them up automatically on the next restart.
+
 ## [1.3.4] - 2026-06-01
 
 The headline of this release is the three-phase **`/config` redesign**: every scan-related setting that was previously env-only is now editable from the UI, can be overridden per scan path, and is bundled into one-click presets. Plus AV1 hardware decode finally works out of the box on NVIDIA hosts.

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -285,15 +285,23 @@ func (r *ScanRepository) MarkAborted(ctx context.Context, scanID int64, errorMes
 	return nil
 }
 
-// MarkCancelled records a user-initiated cancellation. The "AND completed_at IS
-// NULL" guard makes this a no-op for a scan that has already finished (benign
-// race between cancel and completion) so we never clobber a real terminal
-// state. Returns true iff a row was updated, so callers can distinguish "no
-// such scan" from "scan was already done" for error reporting.
+// MarkCancelled records a user-initiated cancellation.
+//
+// The "status NOT IN ('cancelled', 'completed', 'aborted')" guard makes this
+// a no-op for a scan that already reached a terminal state (benign race
+// between cancel and completion / abort) so we never clobber it. It also
+// catches inconsistent rows like status='running' + completed_at IS NOT NULL
+// (the failure mode in #274 where an earlier-fixed bug left rows mid-state):
+// the old "completed_at IS NULL" guard refused to touch those, leaving the
+// row permanently zombified through every restart. The new guard cancels
+// them.
+//
+// Returns true iff a row was updated, so callers can distinguish "no such
+// scan" from "scan was already done" for error reporting.
 func (r *ScanRepository) MarkCancelled(ctx context.Context, scanID int64, reason string) (bool, error) {
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE scans SET status = 'cancelled', completed_at = datetime('now'), error_message = ?
-		WHERE id = ? AND completed_at IS NULL
+		WHERE id = ? AND status NOT IN ('cancelled', 'completed', 'aborted')
 	`, reason, scanID)
 	if err != nil {
 		return false, fmt.Errorf("mark scan cancelled: %w", err)
@@ -314,13 +322,19 @@ func (r *ScanRepository) MarkCancelled(ctx context.Context, scanID int64, reason
 // those are legitimate resumable states the user (or graceful shutdown) put
 // the scan into. Returns the number of rows updated.
 func (r *ScanRepository) MarkOrphansCancelled(ctx context.Context) (int64, error) {
+	// The status filter (no "completed_at IS NULL") is intentional: an
+	// inconsistent row with status='running' but completed_at already set
+	// (the #274 zombie pattern) IS exactly what this query is supposed to
+	// reap. The old completed_at-based guard meant such rows survived
+	// every restart. The status filter alone is sufficient because
+	// activeScans is empty at startup, so any row in an active status is
+	// by definition an orphan.
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE scans
 		SET status = 'cancelled',
 		    completed_at = datetime('now'),
 		    error_message = 'abandoned on Healarr restart'
-		WHERE completed_at IS NULL
-		  AND status IN ('running', 'enumerating', 'scanning')
+		WHERE status IN ('running', 'enumerating', 'scanning')
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("mark orphan scans cancelled: %w", err)
@@ -352,11 +366,17 @@ func (r *ScanRepository) IncrementCorruptions(scanID int64) error {
 
 // ListInterrupted returns scans left in the 'interrupted' state with a
 // persisted file_list, newest first — the resume queue consumed at startup.
+//
+// The "completed_at IS NULL" filter prevents zombifying a previously-
+// terminal scan: a row that was cancelled (completed_at set) and then
+// later had its status overwritten to 'interrupted' by a graceful
+// shutdown is NOT something we want to resume. The user already decided
+// they were done with it. See #274 for the bug chain that surfaced this.
 func (r *ScanRepository) ListInterrupted(ctx context.Context) ([]InterruptedScan, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, path_id, path, total_files, current_file_index, file_list, detection_config, auto_remediate, COALESCE(dry_run, 0)
 		FROM scans
-		WHERE status = 'interrupted' AND file_list IS NOT NULL
+		WHERE status = 'interrupted' AND file_list IS NOT NULL AND completed_at IS NULL
 		ORDER BY started_at DESC
 	`)
 	if err != nil {

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -446,3 +446,119 @@ func TestScanRepository_MarkOrphansCancelled(t *testing.T) {
 		t.Errorf("MarkOrphansCancelled (second call): got (%d, %v), want (0, nil)", n, err)
 	}
 }
+
+// =============================================================================
+// Regression tests for #274: zombie cancelled-then-interrupted scans
+// =============================================================================
+
+// A row that was cancelled (completed_at set) and later overwritten with
+// status='interrupted' by a graceful shutdown must NOT be picked up by
+// ListInterrupted: the user already decided they were done with it.
+func TestScanRepository_ListInterrupted_SkipsCancelledThenInterrupted(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// Build the #274 row shape directly: status='interrupted' AND
+	// completed_at IS NOT NULL AND file_list IS NOT NULL.
+	mustExecScan(t, db, `
+		INSERT INTO scans (path, status, file_list, completed_at, error_message)
+		VALUES ('/zombie', 'interrupted', '["/x.mkv"]', datetime('now', '-1 hour'), 'cancelled by user')
+	`)
+
+	rows, err := repo.ListInterrupted(ctx)
+	if err != nil {
+		t.Fatalf("ListInterrupted: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("zombie row returned: %+v - the completed_at IS NULL filter is missing", rows)
+	}
+}
+
+// MarkCancelled must catch an inconsistent active-status row that already
+// has completed_at set (the #274 zombie shape). The old completed_at-based
+// guard rejected this update, leaving the row stuck forever.
+func TestScanRepository_MarkCancelled_RecoversInconsistentZombieRow(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// Inconsistent row: status='running' but completed_at is set.
+	mustExecScan(t, db, `
+		INSERT INTO scans (id, path, status, file_list, completed_at, error_message)
+		VALUES (42, '/zombie', 'running', '["/x.mkv"]', datetime('now', '-1 hour'), 'cancelled by user')
+	`)
+
+	ok, err := repo.MarkCancelled(ctx, 42, "user cancel retry")
+	if err != nil || !ok {
+		t.Fatalf("MarkCancelled zombie: got (%v, %v), want (true, nil)", ok, err)
+	}
+	var status, errMsg string
+	_ = db.QueryRow(`SELECT status, error_message FROM scans WHERE id = 42`).Scan(&status, &errMsg)
+	if status != "cancelled" || errMsg != "user cancel retry" {
+		t.Errorf("after recovery: status/msg = %q/%q, want cancelled/user cancel retry", status, errMsg)
+	}
+}
+
+// MarkCancelled must still no-op on a fresh-cancelled row (idempotency)
+// and on rows that reached other terminal states.
+func TestScanRepository_MarkCancelled_NoOpOnTerminalStates(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// already cancelled
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status, completed_at) VALUES (1, '/c', 'cancelled', datetime('now'))`)
+	// completed
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status, completed_at) VALUES (2, '/d', 'completed', datetime('now'))`)
+	// aborted
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (3, '/e', 'aborted')`)
+
+	for _, id := range []int64{1, 2, 3} {
+		ok, err := repo.MarkCancelled(ctx, id, "should not apply")
+		if err != nil || ok {
+			t.Errorf("MarkCancelled terminal id=%d: got (%v, %v), want (false, nil)", id, ok, err)
+		}
+	}
+}
+
+// MarkOrphansCancelled must catch zombie active-with-completed_at rows
+// at startup (the #274 fix). Paused and interrupted are still spared.
+func TestScanRepository_MarkOrphansCancelled_CatchesZombieRows(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// The #274 zombie: status='running' with completed_at set.
+	mustExecScan(t, db, `
+		INSERT INTO scans (id, path, status, completed_at, error_message)
+		VALUES (10, '/zombie', 'running', datetime('now', '-1 hour'), 'cancelled by user')
+	`)
+	// A clean orphan: status='running', completed_at NULL.
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (11, '/clean', 'running')`)
+	// Paused: must NOT be touched.
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (12, '/p', 'paused')`)
+	// Interrupted: must NOT be touched.
+	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (13, '/i', 'interrupted')`)
+
+	n, err := repo.MarkOrphansCancelled(ctx)
+	if err != nil || n != 2 {
+		t.Fatalf("MarkOrphansCancelled: got (%d, %v), want (2, nil)", n, err)
+	}
+
+	check := func(id int64, want string) {
+		var got string
+		_ = db.QueryRow(`SELECT status FROM scans WHERE id = ?`, id).Scan(&got)
+		if got != want {
+			t.Errorf("scan %d: status = %q, want %q", id, got, want)
+		}
+	}
+	check(10, "cancelled")   // zombie reaped
+	check(11, "cancelled")   // clean orphan reaped
+	check(12, "paused")      // spared
+	check(13, "interrupted") // spared
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1941,6 +1941,32 @@ func (s *ScannerService) ReconcileOrphanScans() {
 	}
 }
 
+// findActiveScanLocked returns the activeScans entry matching scanID, trying
+// the in-memory UUID (the map key) first, then falling back to matching
+// against ScanDBID. The HTTP handlers route by DB integer id (the only
+// stable identifier the frontend has from /api/scans); internal callers
+// like CancelAllScans iterate activeScans and pass the UUID directly. Both
+// shapes are valid scanID inputs and we want both to find the same entry.
+//
+// Caller must hold s.mu. activeScans is small (one entry per concurrent
+// scan), so the linear DB-id fallback is cheaper than maintaining a
+// secondary index.
+func (s *ScannerService) findActiveScanLocked(scanID string) (*ScanProgress, bool) {
+	if scan, ok := s.activeScans[scanID]; ok {
+		return scan, true
+	}
+	dbID, err := strconv.ParseInt(scanID, 10, 64)
+	if err != nil {
+		return nil, false
+	}
+	for _, p := range s.activeScans {
+		if p.ScanDBID == dbID {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
 // CancelScan cancels a scan. It signals the in-memory ctx if the scan is
 // actually running in this process AND persists "cancelled" to the DB row,
 // so the page reflects the new state on reload. Both halves run regardless
@@ -1949,8 +1975,11 @@ func (s *ScannerService) ReconcileOrphanScans() {
 // an error only when neither half found anything (no such scan id anywhere).
 func (s *ScannerService) CancelScan(scanID string) error {
 	// 1. Signal the in-memory scan to stop, if it is running in this process.
+	//    Use findActiveScanLocked so both UUID and DB-id forms of scanID find
+	//    the same entry (the HTTP handler passes the DB id, internal callers
+	//    pass the UUID — both reach this code path).
 	s.mu.Lock()
-	scan, exists := s.activeScans[scanID]
+	scan, exists := s.findActiveScanLocked(scanID)
 	if exists && scan.cancel != nil {
 		scan.cancel()
 	}
@@ -1963,7 +1992,14 @@ func (s *ScannerService) CancelScan(scanID string) error {
 	//    cancelled" toast was misleading). Doing the UPDATE here also cleans
 	//    up stale rows from a previous hard restart where there is nothing
 	//    to signal in memory.
+	// Resolve the DB id: prefer parsing scanID directly (HTTP path), else
+	// fall back to the in-memory entry's ScanDBID (callers that passed the
+	// UUID still want the DB row updated).
 	dbID, parseErr := strconv.ParseInt(scanID, 10, 64)
+	if parseErr != nil && exists && scan.ScanDBID > 0 {
+		dbID = scan.ScanDBID
+		parseErr = nil
+	}
 	updated := false
 	if parseErr == nil && s.scanRepo() != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -1986,7 +2022,7 @@ func (s *ScannerService) PauseScan(scanID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	scan, exists := s.activeScans[scanID]
+	scan, exists := s.findActiveScanLocked(scanID)
 	if !exists {
 		return fmt.Errorf("scan not found: %s", scanID)
 	}
@@ -2015,7 +2051,7 @@ func (s *ScannerService) ResumeScan(scanID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	scan, exists := s.activeScans[scanID]
+	scan, exists := s.findActiveScanLocked(scanID)
 	if !exists {
 		return fmt.Errorf("scan not found: %s", scanID)
 	}

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -691,6 +691,37 @@ func TestScannerService_CancelScan(t *testing.T) {
 		delete(scanner.activeScans, "scan-2")
 		scanner.mu.Unlock()
 	})
+
+	// Regression for #274: the HTTP handler routes by DB id, but activeScans
+	// is keyed by UUID. CancelScan must match the entry by ScanDBID when
+	// the direct map lookup misses, so the in-memory ctx actually gets
+	// cancelled (otherwise the scan loop keeps running past the user's
+	// cancel click).
+	t.Run("matches by ScanDBID when scanID is the DB integer", func(t *testing.T) {
+		cancelled := false
+		uuid := "abc-def-uuid"
+
+		scanner.mu.Lock()
+		scanner.activeScans[uuid] = &ScanProgress{
+			ID:       uuid,
+			ScanDBID: 42,
+			cancel:   func() { cancelled = true },
+		}
+		scanner.mu.Unlock()
+
+		// Caller passes the DB id as a string (what the HTTP layer does).
+		err := scanner.CancelScan("42")
+		if err != nil {
+			t.Errorf("CancelScan by DB id: unexpected error %v", err)
+		}
+		if !cancelled {
+			t.Error("cancel function was not called - lookup did not fall back to ScanDBID")
+		}
+
+		scanner.mu.Lock()
+		delete(scanner.activeScans, uuid)
+		scanner.mu.Unlock()
+	})
 }
 
 func TestScannerService_PauseScan(t *testing.T) {


### PR DESCRIPTION
Closes #274.

Three composing bugs let a user-cancelled scan reappear in \`running\` status after a Healarr restart, with subsequent cancel clicks becoming silent no-ops. The scan loop also kept iterating files in the background past the original cancel because the in-memory cancel signal never fired.

See #274 for the full reconstruction. Reproduced in production on 2026-06-01.

## What changes

### Bug 1: \`CancelScan\` looks up \`activeScans\` by DB id (was: by UUID only)

\`internal/services/scanner.go\` - the HTTP cancel handler routes by DB integer id (the only stable identifier the frontend has from \`/api/scans\`), but \`activeScans\` is keyed by the UUID generated in \`recordScanStart\`. The direct map lookup always missed, so the in-memory \`ctx.cancel()\` never fired. New \`findActiveScanLocked\` helper tries the UUID first, then falls back to matching by \`ScanDBID\`. \`CancelScan\`, \`PauseScan\`, and \`ResumeScan\` all use it now.

### Bug 2: \`ListInterrupted\` resurrected cancelled scans on startup

\`internal/repository/scan.go\` - the resume-at-startup query was \`WHERE status = 'interrupted' AND file_list IS NOT NULL\` with no filter on \`completed_at\`. A scan that was cancelled (so \`completed_at\` is set) and then later had its status overwritten to \`interrupted\` by a graceful shutdown was being resumed at the next startup. Added \`AND completed_at IS NULL\`.

### Bug 3: \`completed_at IS NULL\` was the wrong guard for \`MarkCancelled\` / \`MarkOrphansCancelled\`

\`internal/repository/scan.go\` - the old guard prevented clobbering a real terminal state in the cancel-vs-completion race. But once Bugs 1+2 left a row in an inconsistent active-status-with-completed_at state, neither user-cancel nor orphan-reconcile could touch it. New guard: \`status NOT IN ('cancelled', 'completed', 'aborted')\`. Equivalent protection against the original race, and additionally catches the zombie rows.

## Recovery for existing installs

The next restart of any install running this build will run \`ReconcileOrphanScans\` which (with the new guard) cleans up the inconsistent rows automatically. No migration needed.

For ops that want to check ahead of time:
\`\`\`sql
SELECT id, path, status, completed_at, error_message
FROM scans
WHERE completed_at IS NOT NULL
  AND status IN ('running', 'enumerating', 'scanning', 'interrupted', 'paused');
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` -> 0 issues
- [x] \`go test ./...\` -> all green
- [x] 4 new repo tests cover each bug's failure mode and fixed behaviour:
  - \`ListInterrupted\` excludes zombie rows
  - \`MarkCancelled\` recovers an inconsistent zombie
  - \`MarkCancelled\` still no-ops on legitimate terminal states (race protection preserved)
  - \`MarkOrphansCancelled\` catches both zombie + clean orphan, spares paused/interrupted
- [x] 1 new service subtest: \`CancelScan\` by DB integer id fires the in-memory cancel
- [ ] Manual: deploy on Sokaris, click cancel on a long-running scan, confirm scan goroutine actually stops (logs stop emitting ScanProgress), confirm row is \`cancelled\` and stays cancelled across a restart

Target: v1.3.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scan cancellation, pause, and resume operations to correctly target in-process scans.
  * Fixed handling of interrupted scans during startup to prevent resuming already-completed or cancelled scans.
  * Enhanced orphaned scan cleanup to properly manage scan states and recover from inconsistent data.
  * Scan cancellation now supports both UUID and database ID formats.

* **Tests**
  * Added regression tests for scan state consistency edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->