### PR TITLE
fix(ui): portal notification provider dropdown so it escapes overflow:hidden parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Notification provider dropdown no longer gets clipped by its parent card.** The dropdown was rendered inline with `position: absolute`, which respects ancestor `overflow: hidden` (set on the Settings card for rounded-corner clipping) and Framer Motion's height-animated container. Listed options past the card's bottom were cut off and unselectable. Dropdown now renders via a React portal into `document.body` with `position: fixed` coordinates computed from the trigger's bounding rect, so it escapes all overflow contexts and floats over the rest of the page.
+
 - **Cancelling a scan now actually stops the in-process scan loop, and previously-cancelled scans no longer come back as "running" after a restart.** Three composing bugs were producing zombie scans (see [#274](https://github.com/mescon/Healarr/issues/274)):
   1. `CancelScan` looked up the in-memory scan map by the DB integer id, but the map is keyed by an internal UUID, so the in-memory `ctx.cancel()` never fired. The scan loop kept iterating files after the user clicked cancel - only the DB row was updated. `CancelScan` now also matches by `ScanDBID`, so the HTTP cancel (which routes by DB id) properly signals the in-process scan; `PauseScan` and `ResumeScan` got the same fix.
   2. `ListInterrupted` (the resume-at-startup query) did not filter out rows with `completed_at` set. A scan that was cancelled and later had its status overwritten to `interrupted` by a graceful shutdown was being **resumed** on the next startup, resurrecting the cancellation as `status='running'`. It now filters on `completed_at IS NULL`.

--- a/frontend/src/components/notifications/ProviderSelect.tsx
+++ b/frontend/src/components/notifications/ProviderSelect.tsx
@@ -2,7 +2,8 @@
  * ProviderSelect - Categorized dropdown for selecting notification providers.
  * Supports both Config page styling (pink accent) and Wizard styling (green accent).
  */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useLayoutEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import { PROVIDER_CONFIGS, PROVIDER_CATEGORIES } from '../../lib/notificationProviders';
@@ -43,25 +44,69 @@ export function ProviderSelect({
     noneLabel = 'Skip (no notifications)',
 }: ProviderSelectProps) {
     const [isOpen, setIsOpen] = useState(false);
-    const dropdownRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
     const styles = variantStyles[variant];
 
-    // Close on click outside
+    // The dropdown is rendered into document.body via a portal so it
+    // escapes overflow:hidden ancestors (the Config-page card and the
+    // Framer Motion height-animated container both clip otherwise).
+    // Position is computed from the trigger's bounding rect each time
+    // the menu opens, and refreshed on scroll / resize while open.
+    const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null);
+
+    const updateMenuPosition = useCallback(() => {
+        if (!triggerRef.current) return;
+        const rect = triggerRef.current.getBoundingClientRect();
+        setMenuPos({
+            top: rect.bottom + 4, // 4px gap matches the previous mt-1
+            left: rect.left,
+            width: rect.width,
+        });
+    }, []);
+
+    // useLayoutEffect + setState is intentional: this is the standard
+    // "measure DOM after layout then position the portal" pattern for
+    // popovers/dropdowns. The setState fires synchronously after layout
+    // so the menu paints in the right place on the first frame instead
+    // of flashing at (0,0).
+    useLayoutEffect(() => {
+        if (!isOpen) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setMenuPos(null);
+            return;
+        }
+        updateMenuPosition();
+        const onScroll = () => updateMenuPosition();
+        const onResize = () => updateMenuPosition();
+        window.addEventListener('scroll', onScroll, true); // capture-phase: catches nested scroll
+        window.addEventListener('resize', onResize);
+        return () => {
+            window.removeEventListener('scroll', onScroll, true);
+            window.removeEventListener('resize', onResize);
+        };
+    }, [isOpen, updateMenuPosition]);
+
+    // Close on click outside. With the portal in place the menu is not
+    // a DOM child of the trigger, so we check BOTH refs - a click is
+    // outside only if it hit neither.
     useEffect(() => {
+        if (!isOpen) return;
         const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-            }
+            const target = event.target as Node;
+            if (triggerRef.current?.contains(target)) return;
+            if (menuRef.current?.contains(target)) return;
+            setIsOpen(false);
         };
         document.addEventListener('mousedown', handleClickOutside);
         return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
+    }, [isOpen]);
 
     const selectedConfig = PROVIDER_CONFIGS[value];
     const displayLabel = value === 'none' ? noneLabel : selectedConfig?.label || 'Select provider';
 
     return (
-        <div ref={dropdownRef} className={clsx("relative", className)}>
+        <div ref={triggerRef} className={clsx("relative", className)}>
             {/* Selected value button */}
             <button
                 type="button"
@@ -91,9 +136,20 @@ export function ProviderSelect({
                 <ChevronDown className={clsx("w-4 h-4 transition-transform", isOpen && "rotate-180")} />
             </button>
 
-            {/* Dropdown menu */}
-            {isOpen && (
-                <div role="listbox" aria-label="Notification providers" className="absolute z-50 w-full mt-1 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg shadow-lg max-h-80 overflow-y-auto">
+            {/* Dropdown menu - rendered into document.body via a portal so
+                it escapes any overflow:hidden ancestor (the Config-page
+                card uses overflow-hidden to clip its rounded corners, and
+                the Framer-Motion height-animated wrapper also clips
+                during/after the expand animation). Position is computed
+                from the trigger's bounding rect in updateMenuPosition. */}
+            {isOpen && menuPos && createPortal(
+                <div
+                    ref={menuRef}
+                    role="listbox"
+                    aria-label="Notification providers"
+                    className="fixed z-50 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg shadow-lg max-h-80 overflow-y-auto"
+                    style={{ top: menuPos.top, left: menuPos.left, width: menuPos.width }}
+                >
                     {/* None/Skip option */}
                     {includeNone && (
                         <button
@@ -150,7 +206,8 @@ export function ProviderSelect({
                             </div>
                         );
                     })}
-                </div>
+                </div>,
+                document.body,
             )}
         </div>
     );


### PR DESCRIPTION
The /config Notifications card wraps each subsection in a div with \`overflow-hidden\` (clips the inner hover bg against rounded corners) plus a Framer Motion height-animated container. \`ProviderSelect\`'s dropdown was rendered inline with \`position: absolute z-50\`, respecting both overflow contexts — the dropdown got cut off when the list extended past the card's bottom and lower items were unselectable.

Fix: render the dropdown via \`createPortal\` into \`document.body\` with \`position: fixed\` coordinates computed from the trigger's \`getBoundingClientRect\`. \`useLayoutEffect\` re-measures on open and on scroll/resize. Click-outside detection now checks both the trigger ref and the (portaled) menu ref since the menu is no longer a DOM child of the trigger.

Standard "menu library" pattern — every modern popover component (Radix, Floating UI, etc.) uses portals for the same reason.

## What this PR *no longer* includes

Originally this PR also added cuvid decoder selection for the AV1/VP9/VP8 case from #276. **Pulled out** after live testing on Sokaris revealed the cuvid decoders SIGSEGV on this host's NVIDIA Container Toolkit setup. With Healarr's current \`classifyDetectorError\` fall-through path treating unrecognized ffmpeg errors as \`ErrorTypeCorruptHeader\`, adding cuvid args while the decoders crash would have made every AV1/VP9/VP8 file get classified as corrupt and routed to the remediation/delete pipeline. That's the silent-mass-deletion failure mode the project shouldn't ship.

See updated [#276](https://github.com/mescon/Healarr/issues/276) for the prerequisites before re-attempting cuvid:
1. Root-cause the cuvid SIGSEGV (likely \`libcuda.so\` not visible inside our Alpine+gcompat container — present for jellyfin-ffmpeg in Tdarr on the same host)
2. Add Healarr-side defensive fallback that retries with hwaccel disabled when a decode looks like an init/hwaccel failure rather than corrupt content

(2) is independently valuable defense-in-depth and would prevent any future hwaccel regression from triggering deletes.

## Test plan

- [x] \`npm run typecheck\` / \`lint\` / \`build\` / \`vitest\` clean
- [ ] Manual: /config → Notifications → Add Notification → Notification Service dropdown opens past the card boundary and stays clickable, including the last items in the list

Target: v1.3.5 (alongside #275's zombie-scan fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification provider dropdown positioning to prevent clipping by parent container animations or overflow constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->