### PR TITLE
fix(docker): bump jellyfin-ffmpeg7 to jellyfin-ffmpeg8 (CI build fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 # falling back to software.
 FROM debian:bookworm-slim
 
-# Add the jellyfin apt repo (it ships jellyfin-ffmpeg as a separate
-# package, currently v7.x tracking ffmpeg 7.1).
+# Add the jellyfin apt repo. The package is named jellyfin-ffmpegN where N
+# is the major ffmpeg version (8 = ffmpeg 8.x, 7 = ffmpeg 7.x). The
+# repo only keeps the current major, so this version pin needs a bump
+# every ~year as upstream majors out.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         curl gnupg ca-certificates && \
@@ -78,7 +80,7 @@ RUN apt-get update && \
         > /etc/apt/sources.list.d/jellyfin.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        jellyfin-ffmpeg7 \
+        jellyfin-ffmpeg8 \
         mediainfo \
         handbrake-cli \
         tzdata \


### PR DESCRIPTION
Hotfix for the broken main-push CI build after #278.

The jellyfin apt repo retired \`jellyfin-ffmpeg7\` (tracks ffmpeg 7.x) in favor of \`jellyfin-ffmpeg8\` (tracks ffmpeg 8.x) between when I built the test image locally and when CI tried to build the merged commit. CI failed with:

\`\`\`
E: Package 'jellyfin-ffmpeg7' has no installation candidate
However the following packages replace it:
  jellyfin-ffmpeg8:amd64
\`\`\`

One-line Dockerfile change to pin to \`jellyfin-ffmpeg8\`. Same NVDEC/NVENC support, ffmpeg version bumps from 7.1.4 to 8.x. Added a comment that this pin needs a bump every ~year as the upstream major rolls over (or we should switch to a more durable distribution mechanism like the static tarball from jellyfin's GitHub releases).

CI will verify on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ffmpeg runtime from version 7 to version 8 for enhanced media processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->