### PR TITLE
fix(docker): drop arch=amd64 from jellyfin apt source for multi-arch buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && \
     install -d /usr/share/keyrings && \
     curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
         | gpg --dearmor -o /usr/share/keyrings/jellyfin.gpg && \
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/jellyfin.gpg] https://repo.jellyfin.org/debian bookworm main" \
+    echo "deb [signed-by=/usr/share/keyrings/jellyfin.gpg] https://repo.jellyfin.org/debian bookworm main" \
         > /etc/apt/sources.list.d/jellyfin.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Hotfix for the multi-arch CI build.

The docker-publish workflow uses buildx with QEMU emulation to build amd64 + arm64. My Dockerfile pinned the jellyfin apt source to \`[arch=amd64]\`, which made the arm64 leg's \`apt-get update\` ignore jellyfin's package list. Result:

\`\`\`
E: Unable to locate package jellyfin-ffmpeg8
\`\`\`

Jellyfin publishes the package for both architectures; dropping the arch filter lets apt auto-pick.