### PR TITLE
test(api): error-branch coverage for scan-preset handlers

### DIFF
--- a/internal/api/handlers_presets_test.go
+++ b/internal/api/handlers_presets_test.go
@@ -192,3 +192,294 @@ func TestCreateScanPreset_RejectsBadHwaccel(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "hwaccel")
 }
+
+// =============================================================================
+// Coverage-driven error-branch tests (sonarqube new_coverage push)
+// =============================================================================
+
+// Malformed JSON on create should 400, not crash.
+func TestCreateScanPreset_RejectsMalformedJSON(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets",
+		bytes.NewReader([]byte("{not valid json")))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// Empty name on create should 400 (the validatePresetRequest "name is required" branch).
+func TestCreateScanPreset_RejectsEmptyName(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":             "",
+		"detection_method": "ffprobe",
+		"detection_mode":   "quick",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "name")
+}
+
+// Bad detection_method on create should 400 via the ParseDetectionMethod gate.
+func TestCreateScanPreset_RejectsBadDetectionMethod(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":             "BadMethod",
+		"detection_method": "not-a-real-method",
+		"detection_mode":   "quick",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "detection_method")
+}
+
+// Bad detection_mode on create should 400 via the ParseDetectionMode gate.
+func TestCreateScanPreset_RejectsBadDetectionMode(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":             "BadMode",
+		"detection_method": "ffprobe",
+		"detection_mode":   "lightning-fast",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "detection_mode")
+}
+
+// thorough_duration_seconds out of range -> 400.
+func TestCreateScanPreset_RejectsOutOfRangeDuration(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":                      "TooLong",
+		"detection_method":          "ffprobe",
+		"detection_mode":            "thorough",
+		"thorough_duration_seconds": 99999, // > 86400 (24h cap)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "thorough_duration_seconds")
+}
+
+// thorough_timeout_seconds below minimum (30s) -> 400.
+func TestCreateScanPreset_RejectsTooSmallTimeout(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":                     "TooShort",
+		"detection_method":         "ffprobe",
+		"detection_mode":           "thorough",
+		"thorough_timeout_seconds": 5, // < 30s minimum
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "thorough_timeout_seconds")
+}
+
+// PUT on a nonexistent preset id should 404 (covers the GetByID -> ErrNotFound branch).
+func TestUpdateScanPreset_NotFound(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":             "Renamed",
+		"detection_method": "ffprobe",
+		"detection_mode":   "quick",
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/presets/9999", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// Non-integer id in the URL should 400 (covers strconv.ParseInt error).
+func TestUpdateScanPreset_RejectsBadID(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/config/presets/not-a-number",
+		bytes.NewReader([]byte(`{"name":"x"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// PUT with malformed JSON on an editable preset should 400 (post-existence-check
+// BindJSON branch).
+func TestUpdateScanPreset_RejectsMalformedJSON(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	// First create a custom preset to update (built-ins are rejected before BindJSON).
+	createBody, _ := json.Marshal(map[string]interface{}{
+		"name":             "Target",
+		"detection_method": "ffprobe",
+		"detection_mode":   "quick",
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("X-API-Key", apiKey)
+	createW := httptest.NewRecorder()
+	r.ServeHTTP(createW, createReq)
+	require.Equal(t, http.StatusCreated, createW.Code)
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(createW.Body.Bytes(), &created))
+	id := int(created["id"].(float64))
+
+	// Now PUT malformed JSON
+	req := httptest.NewRequest(http.MethodPut, "/api/config/presets/"+strconv.Itoa(id),
+		bytes.NewReader([]byte("{also not valid json")))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// PUT with invalid field values on an editable preset should 400 (post-existence-
+// check validation branch).
+func TestUpdateScanPreset_RejectsBadValues(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	createBody, _ := json.Marshal(map[string]interface{}{
+		"name":             "Updatable",
+		"detection_method": "ffprobe",
+		"detection_mode":   "quick",
+	})
+	cReq := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(createBody))
+	cReq.Header.Set("Content-Type", "application/json")
+	cReq.Header.Set("X-API-Key", apiKey)
+	cW := httptest.NewRecorder()
+	r.ServeHTTP(cW, cReq)
+	require.Equal(t, http.StatusCreated, cW.Code)
+	var created map[string]interface{}
+	require.NoError(t, json.Unmarshal(cW.Body.Bytes(), &created))
+	id := int(created["id"].(float64))
+
+	updateBody, _ := json.Marshal(map[string]interface{}{
+		"name":             "Updatable",
+		"detection_method": "ffprobe",
+		"detection_mode":   "quick",
+		"hwaccel":          "not-a-real-accel",
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/config/presets/"+strconv.Itoa(id), bytes.NewReader(updateBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "hwaccel")
+}
+
+// DELETE on a nonexistent preset id should 404.
+func TestDeleteScanPreset_NotFound(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/config/presets/9999", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// Non-integer id on DELETE should 400.
+func TestDeleteScanPreset_RejectsBadID(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/config/presets/abc", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// presetToJSON must round-trip detection_args (the JSON-array decode branch).
+func TestCreateAndGetScanPreset_DetectionArgsRoundTrip(t *testing.T) {
+	r, apiKey, cleanup := setupPresetsTestServer(t)
+	defer cleanup()
+
+	createBody, _ := json.Marshal(map[string]interface{}{
+		"name":             "Custom Args",
+		"detection_method": "ffprobe",
+		"detection_mode":   "thorough",
+		"detection_args":   []string{"-loglevel", "warning", "-probesize", "5000000"},
+	})
+	cReq := httptest.NewRequest(http.MethodPost, "/api/config/presets", bytes.NewReader(createBody))
+	cReq.Header.Set("Content-Type", "application/json")
+	cReq.Header.Set("X-API-Key", apiKey)
+	cW := httptest.NewRecorder()
+	r.ServeHTTP(cW, cReq)
+	require.Equal(t, http.StatusCreated, cW.Code, "body=%s", cW.Body.String())
+
+	// GET should return detection_args as an array, not the JSON string.
+	gReq := httptest.NewRequest(http.MethodGet, "/api/config/presets", nil)
+	gReq.Header.Set("X-API-Key", apiKey)
+	gW := httptest.NewRecorder()
+	r.ServeHTTP(gW, gReq)
+	require.Equal(t, http.StatusOK, gW.Code)
+
+	var presets []map[string]interface{}
+	require.NoError(t, json.Unmarshal(gW.Body.Bytes(), &presets))
+	var found map[string]interface{}
+	for _, p := range presets {
+		if p["name"] == "Custom Args" {
+			found = p
+			break
+		}
+	}
+	require.NotNil(t, found, "newly-created preset not in list response")
+	args, ok := found["detection_args"].([]interface{})
+	require.True(t, ok, "detection_args was not a JSON array: %v", found["detection_args"])
+	require.Equal(t, []interface{}{"-loglevel", "warning", "-probesize", "5000000"}, args)
+}


### PR DESCRIPTION
SonarCloud's quality gate was failing on new_coverage = 78.6% (threshold 80%) after v1.3.5. \`handlers_presets.go\` was the largest contributor — 65 uncovered out of 151 new lines (57% coverage). The 6 existing tests from #271 covered the happy paths and the \`is_builtin\` 403-gate, but the validation error branches in \`validatePresetRequest\` and the handler-level guards weren't exercised.

## What this adds

13 new tests targeting the uncovered branches:

| Test | Branch covered |
|---|---|
| \`RejectsMalformedJSON\` × 2 | BindJSON failure on POST and PUT |
| \`RejectsEmptyName\` | "name is required" branch |
| \`RejectsBadDetectionMethod\` | ParseDetectionMethod gate |
| \`RejectsBadDetectionMode\` | ParseDetectionMode gate |
| \`RejectsOutOfRangeDuration\` | thorough_duration_seconds upper-bound |
| \`RejectsTooSmallTimeout\` | thorough_timeout_seconds lower-bound |
| \`UpdateScanPreset_NotFound\` | GetByID -> ErrNotFound -> respondNotFound |
| \`UpdateScanPreset_RejectsBadID\` | strconv.ParseInt failure on URL id |
| \`UpdateScanPreset_RejectsBadValues\` | validation rerun post-existence-check |
| \`DeleteScanPreset_NotFound\` | GetByID -> ErrNotFound on DELETE |
| \`DeleteScanPreset_RejectsBadID\` | strconv.ParseInt failure on DELETE |
| \`DetectionArgsRoundTrip\` | \`presetToJSON\`'s json.Unmarshal branch |

Each test is tightly focused on one branch — minimal setup, single assertion path.

## Expected outcome

- \`handlers_presets.go\`: 57% -> ~85% coverage
- Project-wide \`new_coverage\`: 78.6% -> comfortably above 80%
- Quality gate goes green on the next SonarCloud analysis

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` -> 0 issues
- [x] \`go test ./internal/api/\` -> all 13 new tests pass, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for scan preset functionality, including validation of input parameters, error handling for invalid requests, and data serialization verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->