### PR TITLE
docs: hardware acceleration setup guide (README + in-app Help)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,119 @@ environment:
 | `HEALARR_MEDIAINFO_PATH` | `mediainfo` | Path to mediainfo binary |
 | `HEALARR_HANDBRAKE_PATH` | `HandBrakeCLI` | Path to HandBrakeCLI binary |
 
-> **Note:** The Docker image (Alpine 3.23) includes ffmpeg 8.0.1, HandBrake 1.10.2, and MediaInfo 25.09. Custom binaries are only needed for specific requirements.
+> **Note:** The Docker image (Debian Bookworm slim) includes jellyfin-ffmpeg 8.1, HandBrake CLI, and MediaInfo. Custom binaries are only needed for specific requirements.
+
+## Hardware Acceleration
+
+Thorough scans decode video to detect mid-file corruption. By default that work runs on the CPU and pins one core per scan worker. For AV1, VP9, HEVC and H.264 you can offload the decode to your GPU and dramatically reduce scan time — a `Fast triage` preset against a 7,000-file AV1 library on an RTX 4070 finishes in minutes rather than hours.
+
+Quick mode (the default for new paths) only reads container headers and does not benefit from hardware decode.
+
+### Codec coverage
+
+| Codec | Hardware decode? | Setup notes |
+|---|---|---|
+| H.264, HEVC, MPEG2, VC-1 | yes | Work via ffmpeg's `-hwaccel` flag alone on every vendor |
+| **AV1**, **VP9**, **VP8** | yes (v1.3.5+) | Healarr auto-selects the vendor-specific decoder (`av1_cuvid` / `av1_qsv` / VAAPI internal) because the software defaults (`libdav1d`, `libvpx`) have no hwaccel hooks |
+
+Healarr probes each file's codec with `ffprobe` and adds the correct `-c:v` override at scan time. You do not need to configure decoders per codec — just enable hardware acceleration globally or per scan path.
+
+### NVIDIA (CUDA / NVDEC)
+
+**Prerequisite:** [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host.
+
+```yaml
+services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    runtime: nvidia
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - NVIDIA_VISIBLE_DEVICES=all
+      - HEALARR_HEALTH_CHECK_HWACCEL=auto   # auto-detects nvidia
+    devices:
+      - /dev/dri:/dev/dri
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    volumes:
+      - ./config:/config
+      - /path/to/media:/media:ro
+```
+
+**Verify:**
+
+```bash
+# Inside the container, cuda should be listed
+docker exec healarr ffmpeg -hwaccels
+
+# During a thorough scan, Healarr's ffmpeg should appear here
+nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+```
+
+### Intel iGPU (Quick Sync — QSV)
+
+```yaml
+services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    environment:
+      - HEALARR_HEALTH_CHECK_HWACCEL=qsv
+    devices:
+      - /dev/dri:/dev/dri
+    volumes:
+      - ./config:/config
+      - /path/to/media:/media:ro
+```
+
+AV1 NVDEC for Intel iGPUs requires 12th-gen Core (Arc) or later. Older iGPUs handle HEVC / H.264 / VP9 fine via QSV.
+
+### Intel iGPU and AMD GPU (VAAPI)
+
+The universal Linux GPU decode path. Works on Intel HD Graphics, Intel Arc, and AMD RDNA GPUs.
+
+```yaml
+services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    environment:
+      - HEALARR_HEALTH_CHECK_HWACCEL=auto   # auto-detects vaapi when no NVIDIA card is present
+    devices:
+      - /dev/dri:/dev/dri
+    volumes:
+      - ./config:/config
+      - /path/to/media:/media:ro
+```
+
+AV1 hardware decode on AMD requires RDNA 2 (RX 6000 series) or later. Older AMD GPUs handle HEVC / H.264 fine via VAAPI.
+
+### Per-scan-path overrides
+
+The `HEALARR_HEALTH_CHECK_HWACCEL` env var is the **global default**. The Scan Paths panel under `/config` lets each path override the global with its own setting (`auto`, `off`, `cuda`, `vaapi`, `qsv`, or any specific accelerator). This is useful for mixed setups:
+
+- A local 4K AV1 library on a CUDA host: `cuda` with `Fast triage` preset
+- A remote SMB share scanned by the same Healarr instance: `off` with a longer timeout
+
+Set HW accel per path in the UI under **Settings → Scan Paths → expand row → Override scanning defaults**.
+
+### Recommended presets
+
+| Preset | Decodes | Best for |
+|---|---|---|
+| **Quick** (default) | container headers only | Fast pre-screen, no GPU benefit |
+| **Fast triage** | first 60 seconds | The killer preset when HW decode is enabled — most files scan in milliseconds |
+| **Deep scan** | full file, 30-min timeout | Catches mid-file corruption, practical only with HW decode |
+| **Paranoid** | full file via HandBrake, software only | When you don't trust ffmpeg's tolerance |
+
+Set the preset per scan path in **Settings → Scan Paths → Apply preset**.
+
+### Safety net
+
+If a hardware decoder fails in a way that suggests the GPU runtime is broken (SIGSEGV, `Cannot load libcuda`, "Failed to setup hwaccel", etc.) Healarr automatically retries the same file with hardware acceleration disabled. A broken driver / missing library / decoder crash can never trigger a false-positive corruption flag, so no file gets routed to remediation because of a GPU issue. The retry costs one extra ffmpeg invocation per affected file in the worst case.
 
 ## Notifications
 

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -446,6 +446,163 @@ const Help = () => {
                 </Accordion>
             </motion.div>
 
+            {/* Hardware Acceleration - Accordion */}
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.33 }}
+            >
+                <Accordion
+                    title="Hardware Acceleration"
+                    icon={<Zap className="w-5 h-5 text-emerald-400" />}
+                    iconBgClass="bg-emerald-500/10 border-emerald-500/20"
+                >
+                    <p className="text-slate-700 dark:text-slate-300">
+                        Thorough scans decode video to detect mid-file corruption. Healarr can offload that work to your GPU instead of pinning a CPU core per scan worker. With hardware decode enabled, a Fast triage scan against a 7,000-file AV1 library on an RTX 4070 finishes in minutes instead of hours.
+                    </p>
+
+                    <p className="text-slate-700 dark:text-slate-300 mt-3">
+                        Quick mode (the default for new paths) only reads container headers and does not benefit from hardware decode.
+                    </p>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Codec coverage</h3>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="border-b border-slate-300 dark:border-slate-700">
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Codec</th>
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Hardware decode</th>
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr className="border-b border-slate-200 dark:border-slate-800">
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">H.264 / HEVC / MPEG2 / VC-1</td>
+                                    <td className="py-2 px-3 text-emerald-700 dark:text-emerald-400">Yes</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">Works via <code className="bg-slate-200 dark:bg-slate-800 px-1 rounded">-hwaccel</code> on every vendor</td>
+                                </tr>
+                                <tr>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">AV1, VP9, VP8</td>
+                                    <td className="py-2 px-3 text-emerald-700 dark:text-emerald-400">Yes (v1.3.5+)</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">Healarr auto-selects the vendor-specific decoder (<code className="bg-slate-200 dark:bg-slate-800 px-1 rounded">av1_cuvid</code>, <code className="bg-slate-200 dark:bg-slate-800 px-1 rounded">av1_qsv</code>, etc.)</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">NVIDIA (CUDA / NVDEC)</h3>
+                    <p className="text-slate-700 dark:text-slate-300">
+                        Requires the <a href="https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html" target="_blank" rel="noopener noreferrer" className="text-blue-600 dark:text-blue-400 hover:underline">NVIDIA Container Toolkit</a> on the host.
+                    </p>
+                    <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg overflow-x-auto text-sm">
+{`services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    runtime: nvidia
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+      - NVIDIA_VISIBLE_DEVICES=all
+      - HEALARR_HEALTH_CHECK_HWACCEL=auto
+    devices:
+      - /dev/dri:/dev/dri
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]`}
+                    </pre>
+                    <p className="text-slate-700 dark:text-slate-300 mt-2">Verify with:</p>
+                    <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg overflow-x-auto text-sm">
+{`# Inside the container - 'cuda' should be listed
+docker exec healarr ffmpeg -hwaccels
+
+# During a thorough scan - Healarr's ffmpeg should appear here
+nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv`}
+                    </pre>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Intel iGPU (Quick Sync / QSV)</h3>
+                    <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg overflow-x-auto text-sm">
+{`services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    environment:
+      - HEALARR_HEALTH_CHECK_HWACCEL=qsv
+    devices:
+      - /dev/dri:/dev/dri`}
+                    </pre>
+                    <p className="text-slate-700 dark:text-slate-300 mt-2 text-sm">
+                        AV1 hardware decode for Intel iGPUs requires 12th-gen Core (Arc) or later. Older iGPUs handle HEVC / H.264 / VP9 via QSV.
+                    </p>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Intel and AMD (VAAPI)</h3>
+                    <p className="text-slate-700 dark:text-slate-300">
+                        The universal Linux GPU decode path. Works on Intel HD Graphics, Intel Arc, and AMD RDNA GPUs.
+                    </p>
+                    <pre className="bg-slate-100 dark:bg-slate-800 p-3 rounded-lg overflow-x-auto text-sm">
+{`services:
+  healarr:
+    image: ghcr.io/mescon/healarr:latest
+    environment:
+      - HEALARR_HEALTH_CHECK_HWACCEL=auto   # auto-detects vaapi when no NVIDIA card
+    devices:
+      - /dev/dri:/dev/dri`}
+                    </pre>
+                    <p className="text-slate-700 dark:text-slate-300 mt-2 text-sm">
+                        AV1 hardware decode on AMD requires RDNA 2 (RX 6000 series) or later.
+                    </p>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Per-scan-path overrides</h3>
+                    <p className="text-slate-700 dark:text-slate-300">
+                        <code className="bg-slate-200 dark:bg-slate-800 px-1 rounded">HEALARR_HEALTH_CHECK_HWACCEL</code> is the global default. Each scan path can override the global with its own setting under <span className="font-semibold">Settings → Scan Paths → expand row → Override scanning defaults</span>. Useful for mixed setups — a 4K AV1 library on CUDA plus a slow remote SMB share on software decode.
+                    </p>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Recommended presets</h3>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="border-b border-slate-300 dark:border-slate-700">
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Preset</th>
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Decodes</th>
+                                    <th className="text-left py-2 px-3 text-slate-700 dark:text-slate-300 font-semibold">Best for</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr className="border-b border-slate-200 dark:border-slate-800">
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300"><span className="font-semibold">Quick</span> (default)</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">container headers only</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">Fast pre-screen, no GPU benefit</td>
+                                </tr>
+                                <tr className="border-b border-slate-200 dark:border-slate-800">
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300"><span className="font-semibold">Fast triage</span></td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">first 60 seconds</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">The killer preset with HW decode - most files scan in milliseconds</td>
+                                </tr>
+                                <tr className="border-b border-slate-200 dark:border-slate-800">
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300"><span className="font-semibold">Deep scan</span></td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">full file, 30-min timeout</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">Catches mid-file corruption, practical only with HW decode</td>
+                                </tr>
+                                <tr>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300"><span className="font-semibold">Paranoid</span></td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">full file via HandBrake, software only</td>
+                                    <td className="py-2 px-3 text-slate-700 dark:text-slate-300">When you do not trust ffmpeg's tolerance</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p className="text-slate-700 dark:text-slate-300 mt-2">
+                        Apply per scan path under <span className="font-semibold">Settings → Scan Paths → Apply preset</span>.
+                    </p>
+
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mt-6">Safety net</h3>
+                    <p className="text-slate-700 dark:text-slate-300">
+                        If a hardware decoder fails in a way that suggests the GPU runtime is broken (SIGSEGV, <code className="bg-slate-200 dark:bg-slate-800 px-1 rounded">Cannot load libcuda</code>, "Failed to setup hwaccel", etc.) Healarr automatically retries the same file with hardware acceleration disabled. A broken driver / missing library / decoder crash can never trigger a false-positive corruption flag, so no file is ever routed to remediation because of a GPU issue. The retry costs one extra ffmpeg invocation per affected file in the worst case.
+                    </p>
+                </Accordion>
+            </motion.div>
+
             {/* Reverse Proxy Setup - Accordion */}
             <motion.div
                 initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
With v1.3.5 making AV1/VP9 hardware decode actually work, there was zero documentation telling users how to configure it. This PR adds two parallel docs touchpoints — both with copy-paste-able compose snippets per vendor.

## What lands

### README.md
New top-level "Hardware Acceleration" section between Detection Methods and Notifications:
- When it matters (thorough scans only; quick mode unaffected)
- Codec coverage table (H.264/HEVC/MPEG2/VC-1 via \`-hwaccel\` alone; AV1/VP9/VP8 via auto-selected vendor decoders)
- Compose snippet per vendor: NVIDIA (with NVIDIA Container Toolkit + runtime: nvidia + deploy resources), Intel QSV (\`HEALARR_HEALTH_CHECK_HWACCEL=qsv\` + /dev/dri), Intel/AMD VAAPI (\`HEALARR_HEALTH_CHECK_HWACCEL=auto\` + /dev/dri)
- Verification commands (ffmpeg -hwaccels inside container, nvidia-smi --query-compute-apps)
- Per-scan-path overrides pointer
- Preset recommendations table
- Safety-net description (#278's retry-without-hwaccel)

Also fixed the outdated "Docker image (Alpine 3.23) includes ffmpeg 8.0.1" note — v1.3.5 ships Debian + jellyfin-ffmpeg 8.1.

### frontend/src/pages/Help.tsx
New "Hardware Acceleration" accordion right after Docker Configuration. Mirrors the README content with the same tables and compose snippets, styled to match the existing Help sections (Zap icon, emerald colour scheme to differentiate from the cyan Docker section). Users landing here from /config → Settings will find concrete setup help instead of having to switch to the README on GitHub.

## What this does NOT include

- No agents/ docs touched (those are developer-facing, separate concern)
- No GitHub wiki updates (Healarr's user-facing docs are README + in-app Help, no separate wiki source exists)

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run build\` succeeds
- [ ] Visual check on the in-app Help page (renders correctly, code blocks readable, tables don't overflow)

Target: ships in v1.3.6 alongside whatever other changes land, or merge to main now and the next docker-publish run picks it up on \`:main\`.