### PR TITLE
test(api): cover prepareScanPathRequest per-path validation branches

### DIFF
--- a/internal/api/handlers_paths_test.go
+++ b/internal/api/handlers_paths_test.go
@@ -2025,3 +2025,116 @@ func TestRelPathOrName(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateScanPath_InvalidThoroughDuration covers the per-path
+// thorough_duration_seconds bounds check (0..86400).
+func TestCreateScanPath_InvalidThoroughDuration(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	router, apiKey, srv := setupPathsTestServer(t, db)
+	defer srv()
+
+	cases := []struct {
+		name    string
+		seconds int64
+	}{
+		{"negative", -1},
+		{"too_large", 86401},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewBufferString(fmt.Sprintf(`{
+				"local_path": "/media/dur-%s",
+				"arr_instance_id": %d,
+				"enabled": true,
+				"thorough_duration_seconds": %d
+			}`, tc.name, arrID, tc.seconds))
+			req, _ := http.NewRequest("POST", "/api/config/paths", body)
+			req.Header.Set("X-API-Key", apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			require.Contains(t, w.Body.String(), "thorough_duration_seconds")
+		})
+	}
+}
+
+// TestCreateScanPath_InvalidThoroughTimeout covers the per-path
+// thorough_timeout_seconds bounds check (30..21600).
+func TestCreateScanPath_InvalidThoroughTimeout(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	router, apiKey, srv := setupPathsTestServer(t, db)
+	defer srv()
+
+	cases := []struct {
+		name    string
+		seconds int64
+	}{
+		{"too_small", 29},
+		{"too_large", 21601},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := bytes.NewBufferString(fmt.Sprintf(`{
+				"local_path": "/media/timeout-%s",
+				"arr_instance_id": %d,
+				"enabled": true,
+				"thorough_timeout_seconds": %d
+			}`, tc.name, arrID, tc.seconds))
+			req, _ := http.NewRequest("POST", "/api/config/paths", body)
+			req.Header.Set("X-API-Key", apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+			require.Contains(t, w.Body.String(), "thorough_timeout_seconds")
+		})
+	}
+}
+
+// TestCreateScanPath_InvalidHwaccel covers the per-path hwaccel allowlist.
+// Empty string and nil mean "inherit"; only the named codec backends are
+// accepted otherwise.
+func TestCreateScanPath_InvalidHwaccel(t *testing.T) {
+	db, cleanup := setupPathsTestDB(t)
+	defer cleanup()
+
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	result, _ := db.Exec("INSERT INTO arr_instances (name, type, url, api_key) VALUES (?, ?, ?, ?)",
+		"Sonarr", "sonarr", "http://localhost:8989", encryptedKey)
+	arrID, _ := result.LastInsertId()
+
+	router, apiKey, srv := setupPathsTestServer(t, db)
+	defer srv()
+
+	body := bytes.NewBufferString(fmt.Sprintf(`{
+		"local_path": "/media/hwaccel-bad",
+		"arr_instance_id": %d,
+		"enabled": true,
+		"hwaccel": "not-a-backend"
+	}`, arrID))
+	req, _ := http.NewRequest("POST", "/api/config/paths", body)
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	require.Contains(t, w.Body.String(), "invalid hwaccel")
+}


### PR DESCRIPTION
## Summary

#285 lifted handlers_arr coverage but the project landed at 79.9% on the new_code window (gate is 80%). Adds three validation-error tests against the per-path override branches in `prepareScanPathRequest`:

- `thorough_duration_seconds` bounds (negative, > 86400)
- `thorough_timeout_seconds` bounds (< 30, > 21600)
- `hwaccel` allowlist (rejects strings outside the codec backend set)

These are the per-path overrides added for the v1.3.4/v1.3.5 hwaccel work, and they sat among the largest blocks of uncovered new lines (28 in `handlers_paths.go` alone). Crossing them should push new_coverage from 79.9% over the 80% threshold.

Test-only PR.

## Test plan
- [x] `go test ./internal/api/ -run 'TestCreateScanPath_InvalidThoroughDuration|TestCreateScanPath_InvalidThoroughTimeout|TestCreateScanPath_InvalidHwaccel' -v` — all pass
- [x] `/usr/bin/golangci-lint run ./internal/api/...` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for the `/api/config/paths` endpoint to ensure proper enforcement of parameter constraints for scan settings, including duration and timeout bounds validation, and hardware acceleration backend allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->