### PR TITLE
chore(api): drop noisy SQLITE_BUSY log on best-effort session-touch

### DIFF
--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -674,12 +674,14 @@ func (s *RESTServer) verifyAPIToken(token string) error {
 	// Session token path (browsers).
 	sessErr := s.sessions.Validate(ctx, token)
 	if sessErr == nil {
-		// Bump last_used_at on a successful validation. We don't fail the
-		// request if this update errors — the session is valid, the bump
-		// is purely diagnostic ("when did this session last act?").
-		if bumpErr := s.sessions.BumpLastUsed(ctx, token); bumpErr != nil {
-			logger.Debugf("session last_used_at update failed: %v", bumpErr)
-		}
+		// Bump last_used_at on a successful validation. The update is
+		// best-effort: the session is valid, the bump is purely
+		// diagnostic ("when did this session last act?"). Any error
+		// here is discarded — under page-load fanout multiple requests
+		// race on the same UPDATE and all-but-one hit SQLITE_BUSY,
+		// which would otherwise spam the log viewer with misleading
+		// "database is locked" lines.
+		_ = s.sessions.BumpLastUsed(ctx, token)
 		return nil
 	}
 	if !errors.Is(sessErr, repository.ErrNotFound) && !errors.Is(sessErr, repository.ErrSessionExpired) {


### PR DESCRIPTION
## Summary

The session \`last_used_at\` update at the end of \`validateAPIKeyOrSession\` is best-effort by design (the existing comment says so), but we still logged the error at DEBUG level. Under page-load fanout the frontend fires ~4 parallel API calls that all race on the same UPDATE; SQLite WAL serializes writers, so all-but-one get SQLITE_BUSY and the in-app log viewer fills with:

    [DEBUG] session last_used_at update failed: database is locked (5) (SQLITE_BUSY)

…which looks like a real error to operators using the in-app Logs page.

Fix: discard the bump error silently. No behavior change — the bump was already being ignored on error, only the log line was misleading.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`/usr/bin/golangci-lint run ./internal/api/...\` — 0 issues
- [x] \`go test ./internal/api/\` — pass
- [ ] After deploy: confirm no \"session last_used_at\" lines appear under page-load fanout on prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session validation to handle concurrent requests more gracefully, reducing excessive log messages related to temporary database access issues during high-traffic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->