### PR TITLE
fix(api): unify scan counters by deriving from scan_files

### DIFF
--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -266,23 +266,32 @@ func (s *RESTServer) getScanDetails(c *gin.Context) {
 	scan.ID = int(row.ID)
 	scan.Path = row.Path
 	scan.Status = row.Status
-	scan.FilesScanned = row.FilesScanned
-	scan.CorruptionsFound = row.CorruptionsFound
 	scan.StartedAt = row.StartedAt
 	scan.CompletedAt = row.CompletedAt.String
 	if row.PathID.Valid {
 		scan.PathID = int(row.PathID.Int64)
 	}
 
-	// Get file counts from scan_files table using single GROUP BY query (performance optimization)
+	// Derive aggregate counters from scan_files in a single GROUP BY so that
+	// files_scanned, corruptions_found, and the per-status breakdown all come
+	// from the same source. The scans.files_scanned / corruptions_found
+	// columns are lagging caches (files_scanned is only persisted every 10
+	// files during a running scan) — reading them alongside a live
+	// scan_files COUNT made the UI show three different numbers for the
+	// same quantity (e.g. files_scanned=1791 but healthy_files=1792 with
+	// a header progress of 1855).
 	counts, err := s.scanFiles.CountByStatus(c.Request.Context(), scanIDInt)
 	if err != nil {
-		logger.Debugf("Failed to query file counts: %v", err)
+		logger.Debugf("Failed to query file counts, falling back to cached aggregates: %v", err)
+		scan.FilesScanned = row.FilesScanned
+		scan.CorruptionsFound = row.CorruptionsFound
 	} else {
 		scan.HealthyFiles = counts["healthy"]
 		scan.CorruptFiles = counts["corrupt"]
 		scan.SkippedFiles = counts["skipped"]
 		scan.InaccessibleFiles = counts["inaccessible"]
+		scan.FilesScanned = scan.HealthyFiles + scan.CorruptFiles + scan.SkippedFiles + scan.InaccessibleFiles
+		scan.CorruptionsFound = scan.CorruptFiles
 	}
 
 	c.JSON(http.StatusOK, scan)

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -814,6 +814,90 @@ func TestGetScanDetails_Success(t *testing.T) {
 	}
 }
 
+// TestGetScanDetails_CountersDerivedFromScanFiles asserts that
+// files_scanned and corruptions_found in the response are derived from the
+// scan_files table — not read from the lagging scans.files_scanned /
+// scans.corruptions_found cache columns. This guards against the
+// "three different numbers for the same quantity" UI regression where a
+// running scan showed e.g. files_scanned=1791, healthy_files=1792.
+func TestGetScanDetails_CountersDerivedFromScanFiles(t *testing.T) {
+	db, cleanup := setupScansTestDB(t)
+	defer cleanup()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	now := time.Now()
+
+	// Insert a scan row with stale cached aggregates: simulates a running
+	// scan that has only checkpointed the every-10-files counter to 100
+	// while the per-file scan_files rows have advanced further.
+	_, err := db.Exec(`
+		INSERT INTO scans (path, status, started_at, files_scanned, corruptions_found)
+		VALUES (?, 'running', ?, 100, 5)
+	`, "/test/path", now.Format("2006-01-02 15:04:05"))
+	if err != nil {
+		t.Fatalf("Failed to insert scan: %v", err)
+	}
+
+	// 3 healthy + 2 corrupt + 1 skipped + 1 inaccessible = 7 actually-scanned
+	statuses := []struct {
+		path   string
+		status string
+	}{
+		{"/test/h1.mkv", "healthy"}, {"/test/h2.mkv", "healthy"}, {"/test/h3.mkv", "healthy"},
+		{"/test/c1.mkv", "corrupt"}, {"/test/c2.mkv", "corrupt"},
+		{"/test/s1.mkv", "skipped"},
+		{"/test/i1.mkv", "inaccessible"},
+	}
+	for _, s := range statuses {
+		if _, err := db.Exec(
+			`INSERT INTO scan_files (scan_id, file_path, status) VALUES (1, ?, ?)`,
+			s.path, s.status,
+		); err != nil {
+			t.Fatalf("Failed to insert scan_file: %v", err)
+		}
+	}
+
+	server := createScansTestServer(t, db, eb)
+	defer server.scanner.Shutdown()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/scans/:scan_id", server.getScanDetails)
+
+	req, _ := http.NewRequest("GET", "/scans/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var scan map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &scan); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	// files_scanned must come from scan_files (7), not from the cached
+	// scans.files_scanned column (100).
+	if got := scan["files_scanned"].(float64); got != 7 {
+		t.Errorf("files_scanned: expected 7 (derived from scan_files), got %v (cached column?)", got)
+	}
+	// corruptions_found must equal corrupt_files (2), not the cached
+	// scans.corruptions_found column (5).
+	if got := scan["corruptions_found"].(float64); got != 2 {
+		t.Errorf("corruptions_found: expected 2 (= corrupt_files), got %v (cached column?)", got)
+	}
+	// Identity: files_scanned == healthy + corrupt + skipped + inaccessible.
+	sum := scan["healthy_files"].(float64) + scan["corrupt_files"].(float64) +
+		scan["skipped_files"].(float64) + scan["inaccessible_files"].(float64)
+	if scan["files_scanned"].(float64) != sum {
+		t.Errorf("files_scanned (%v) must equal sum of per-status counts (%v)",
+			scan["files_scanned"], sum)
+	}
+}
+
 func TestGetScanFiles_NotFound(t *testing.T) {
 	db, cleanup := setupScansTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

The scan-detail screen showed **three different numbers** for the same quantity during a running scan:

| Counter | Source | Cadence |
|---|---|---|
| Header *Running (**1855**/31107)* | in-memory \`FilesDone\` over WebSocket | per-file |
| Stat card *Files scanned: **1791*** | \`scans.files_scanned\` column | **every 10 files** |
| Stat card *Healthy files: **1792*** | \`COUNT(scan_files WHERE healthy)\` | per-file |

\`scans.files_scanned\` is a lagging cache — \`markFileProcessed\` at \`scanner.go:1855\` only persists it on file-index multiples of 10. Reading it alongside live \`scan_files\` COUNTs surfaces the gap directly in the UI.

## Fix

\`getScanDetails\` now derives \`files_scanned\` and \`corruptions_found\` from the **same** \`CountByStatus\` query that produces the per-status breakdown. By construction:

    files_scanned == healthy + corrupt + skipped + inaccessible
    corruptions_found == corrupt

Falls back to the cached aggregate columns if the count query errors (matches the existing \`FileCountQueryError\` test contract).

## Not addressed in this PR

The chunk-by-chunk \`scanned_at\` timestamps (many files share the same second) come from the scanner's deliberate batched fan-out/fan-in at \`scanner.go:1538-1573\`. The barrier exists to keep the resume checkpoint monotonic — removing it is an architectural change for a follow-up.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`/usr/bin/golangci-lint run ./internal/api/...\` — 0 issues
- [x] \`go test ./internal/api/ -run 'TestGetScanDetails'\` — 5/5 pass, including new \`TestGetScanDetails_CountersDerivedFromScanFiles\` that asserts:
  - \`files_scanned\` ignores the stale cached column (returns 7, not 100)
  - \`corruptions_found\` == \`corrupt_files\` (returns 2, not 5)
  - sum identity holds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of file statistics in scan detail reports by deriving file counts from individual file records rather than cached values. Files are now properly categorized by status (healthy, corrupt, skipped, inaccessible).

* **Tests**
  * Added test coverage for scan details counter computation from file records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->