### PR TITLE
fix(frontend): use absolute base path so nested SPA routes load assets

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,8 +4,14 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // Use relative paths so the app works at any base path (e.g., /healarr/)
-  base: './',
+  // Absolute base: nested SPA routes (e.g. /scans/123) load assets from
+  // /assets/* regardless of current path. Relative './' breaks on any
+  // deep-link because the browser resolves it against the current URL,
+  // producing /scans/assets/foo.js, which the SPA fallback returns as
+  // HTML and the browser then refuses on MIME-type grounds. A
+  // sub-path mount (e.g. /healarr/) would need a build-time env var
+  // + server-side index.html base-href rewrite, not a static './'.
+  base: '/',
   build: {
     outDir: '../web',
     emptyOutDir: true,


### PR DESCRIPTION
## Problem

Visiting any nested route (\`/scans/1\`, \`/corruptions\`, etc.) produces a blank page with this console error:

    Refused to apply style from 'https://healarr.yi.se/scans/assets/index-...css'
    because its MIME type ('text/html') is not a supported stylesheet MIME type
    Failed to load module script: Expected JavaScript ... server responded with text/html

## Root cause

\`vite.config.ts\` set \`base: './'\` (relative paths). When the browser is at \`/scans/1\` it resolves \`./assets/foo.js\` as \`/scans/assets/foo.js\`. The Go SPA fallback returns \`index.html\` for any unknown path, so the asset request gets HTML back, the browser rejects the import on MIME type, and React never boots.

The comment claimed this was for \`/healarr/\` sub-path support, but that scenario was already broken — sub-path mount needs a build-time env var and server-side base-href rewrite, not a static \`./\`.

## Fix

Switch to \`base: '/'\`. Built \`index.html\` now references \`/assets/*\` absolutely; nested routes load identically to the root route.

If sub-path mount is ever wanted, it's a separate feature (vite \`base: process.env.BASE_PATH\` + a server-side template rewrite), and the comment now says so explicitly.

## Test plan

- [x] \`npm run build\` clean
- [x] Built \`web/index.html\` uses \`<script src=\"/assets/...\">\` (absolute)
- [ ] After deploy: \`/scans/<id>\` renders, no MIME errors in console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing configuration to properly support deep links and nested application routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->