### PR TITLE
fix(scanner): resume orphan scans with progress instead of cancelling

### DIFF
--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -313,23 +313,76 @@ func (r *ScanRepository) MarkCancelled(ctx context.Context, scanID int64, reason
 	return n > 0, nil
 }
 
+// ReconcileOrphansResult reports the outcome of the startup reconcile.
+type ReconcileOrphansResult struct {
+	// Interrupted is the count of rows that had real persisted progress
+	// (current_file_index > 0 and a saved file_list) and were demoted to
+	// 'interrupted' so ResumeInterruptedScans picks them up.
+	Interrupted int64
+	// Cancelled is the count of rows that had no resumable state
+	// (enumerating, or zero progress) and were marked terminal.
+	Cancelled int64
+}
+
 // MarkOrphansCancelled is the startup reconciliation: any row left in an
 // active state ("running"/"enumerating"/"scanning") that does not belong to
 // this process's in-memory activeScans is the residue of a hard restart
-// (SIGKILL/OOM/crash) that prevented MarkInterrupted from running. Mark them
-// cancelled so they disappear from /scans and Dashboard instead of looking
-// like live work forever. "paused" and "interrupted" are deliberately spared:
-// those are legitimate resumable states the user (or graceful shutdown) put
-// the scan into. Returns the number of rows updated.
+// (SIGKILL/OOM/crash) that prevented MarkInterrupted from running.
+//
+// Rows with real persisted progress (current_file_index > 0 AND
+// total_files > 0 AND a saved file_list) are demoted to 'interrupted'
+// so the next ResumeInterruptedScans sweep picks them up. Rows with no
+// resumable state (enumerating mid-walk, or zero progress) are marked
+// 'cancelled' so they leave the active UI.
+//
+// "paused" and "interrupted" are spared throughout: they are the
+// legitimate resumable states that the user or graceful shutdown put
+// the scan into.
+//
+// The legacy single-counter return is preserved for callers/tests: it
+// is the sum of interrupted+cancelled. The structured outcome is also
+// exposed via ReconcileOrphans for richer logging.
 func (r *ScanRepository) MarkOrphansCancelled(ctx context.Context) (int64, error) {
-	// The status filter (no "completed_at IS NULL") is intentional: an
-	// inconsistent row with status='running' but completed_at already set
-	// (the #274 zombie pattern) IS exactly what this query is supposed to
-	// reap. The old completed_at-based guard meant such rows survived
-	// every restart. The status filter alone is sufficient because
-	// activeScans is empty at startup, so any row in an active status is
-	// by definition an orphan.
-	res, err := r.db.ExecContext(ctx, `
+	res, err := r.ReconcileOrphans(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return res.Interrupted + res.Cancelled, nil
+}
+
+// ReconcileOrphans runs the two-step reconcile in a single transaction:
+//  1. Resumable orphans -> 'interrupted'
+//  2. Everything else still in an active status -> 'cancelled'
+//
+// The status filter (no "completed_at IS NULL") is intentional: an
+// inconsistent row with an active status but completed_at already set
+// (the #274 zombie pattern) IS exactly what this query is supposed to
+// reap. activeScans is empty at startup, so any row in an active status
+// is by definition an orphan.
+func (r *ScanRepository) ReconcileOrphans(ctx context.Context) (ReconcileOrphansResult, error) {
+	var out ReconcileOrphansResult
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return out, fmt.Errorf("reconcile orphans begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	resInt, err := tx.ExecContext(ctx, `
+		UPDATE scans
+		SET status = 'interrupted',
+		    error_message = 'auto-marked interrupted on Healarr restart'
+		WHERE status IN ('running', 'scanning')
+		  AND current_file_index > 0
+		  AND total_files > 0
+		  AND file_list IS NOT NULL
+	`)
+	if err != nil {
+		return out, fmt.Errorf("mark resumable orphans interrupted: %w", err)
+	}
+	out.Interrupted, _ = resInt.RowsAffected()
+
+	resCan, err := tx.ExecContext(ctx, `
 		UPDATE scans
 		SET status = 'cancelled',
 		    completed_at = datetime('now'),
@@ -337,9 +390,14 @@ func (r *ScanRepository) MarkOrphansCancelled(ctx context.Context) (int64, error
 		WHERE status IN ('running', 'enumerating', 'scanning')
 	`)
 	if err != nil {
-		return 0, fmt.Errorf("mark orphan scans cancelled: %w", err)
+		return out, fmt.Errorf("mark orphan scans cancelled: %w", err)
 	}
-	return res.RowsAffected()
+	out.Cancelled, _ = resCan.RowsAffected()
+
+	if err := tx.Commit(); err != nil {
+		return out, fmt.Errorf("reconcile orphans commit: %w", err)
+	}
+	return out, nil
 }
 
 // UpdateProgress updates the live current_file_index and files_scanned

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -447,6 +447,83 @@ func TestScanRepository_MarkOrphansCancelled(t *testing.T) {
 	}
 }
 
+// ReconcileOrphans must demote rows with real persisted progress to
+// 'interrupted' (resumable) rather than 'cancelled' (terminal). This is the
+// case where a long-running scan was killed by an abrupt container restart
+// before its SIGTERM handler could MarkInterrupted — historically the row
+// was left dead, so a multi-hour run had to be restarted from zero.
+func TestScanRepository_ReconcileOrphans_ResumesProgress(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	// Resumable orphan: real progress + file_list saved.
+	resumable, _ := repo.Create(ctx, CreateScanParams{Path: "/resumable", PathID: 1, TotalFiles: 100, FileListJSON: `["a","b","c"]`})
+	mustExecScan(t, db, `UPDATE scans SET status='running', current_file_index=42 WHERE id=?`, resumable)
+
+	// Zero-progress orphan: running but never got past file 0 (e.g. crashed in setup).
+	zero, _ := repo.Create(ctx, CreateScanParams{Path: "/zero", PathID: 1, TotalFiles: 100, FileListJSON: `["a","b","c"]`})
+	mustExecScan(t, db, `UPDATE scans SET status='running', current_file_index=0 WHERE id=?`, zero)
+
+	// Enumerating: file list not built yet — never resumable.
+	enumerating, _ := repo.Create(ctx, CreateScanParams{Path: "/enum", PathID: 1, TotalFiles: 0, FileListJSON: ""})
+	mustExecScan(t, db, `UPDATE scans SET status='enumerating', current_file_index=0, file_list=NULL WHERE id=?`, enumerating)
+
+	// Spared statuses (must not be touched at all).
+	paused, _ := repo.Create(ctx, CreateScanParams{Path: "/pause", PathID: 1, TotalFiles: 10, FileListJSON: `["x"]`})
+	if err := repo.MarkPaused(ctx, paused, 5); err != nil {
+		t.Fatalf("MarkPaused setup: %v", err)
+	}
+	completed, _ := repo.Create(ctx, CreateScanParams{Path: "/done", PathID: 1, TotalFiles: 10, FileListJSON: `["x"]`})
+	if err := repo.Finalize(ctx, completed, "completed", 10); err != nil {
+		t.Fatalf("Finalize setup: %v", err)
+	}
+
+	out, err := repo.ReconcileOrphans(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+	if out.Interrupted != 1 {
+		t.Errorf("Interrupted count: got %d, want 1 (only the row with progress)", out.Interrupted)
+	}
+	if out.Cancelled != 2 {
+		t.Errorf("Cancelled count: got %d, want 2 (zero-progress running + enumerating)", out.Cancelled)
+	}
+
+	check := func(id int64, want string) {
+		var got string
+		_ = db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&got)
+		if got != want {
+			t.Errorf("scan %d: status = %q, want %q", id, got, want)
+		}
+	}
+	check(resumable, "interrupted") // demoted, resume will pick up
+	check(zero, "cancelled")        // no progress to resume
+	check(enumerating, "cancelled") // file list not built
+	check(paused, "paused")         // spared
+	check(completed, "completed")   // untouched
+
+	// Resumable row's progress fields must survive so resume can use them.
+	var currentFileIndex int
+	var fileList sql.NullString
+	if err := db.QueryRow(`SELECT current_file_index, file_list FROM scans WHERE id=?`, resumable).Scan(&currentFileIndex, &fileList); err != nil {
+		t.Fatalf("read resumable row: %v", err)
+	}
+	if currentFileIndex != 42 {
+		t.Errorf("current_file_index reset: got %d, want 42", currentFileIndex)
+	}
+	if !fileList.Valid || fileList.String == "" {
+		t.Errorf("file_list cleared on reconcile (must be preserved for resume)")
+	}
+
+	// Idempotent: second call is a no-op.
+	out2, err := repo.ReconcileOrphans(ctx)
+	if err != nil || out2.Interrupted != 0 || out2.Cancelled != 0 {
+		t.Errorf("second ReconcileOrphans: got (%d intr, %d can, %v), want (0,0,nil)", out2.Interrupted, out2.Cancelled, err)
+	}
+}
+
 // =============================================================================
 // Regression tests for #274: zombie cancelled-then-interrupted scans
 // =============================================================================

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1921,23 +1921,32 @@ func (s *ScannerService) IsPathBeingScanned(path string) bool {
 // status ("running"/"enumerating"/"scanning") at this point cannot belong to
 // this process (activeScans is empty until the first scan starts), so it must
 // be the residue of a previous hard restart that prevented MarkInterrupted
-// from running. Mark those rows cancelled so they disappear from /scans and
-// Dashboard instead of looking like live work forever. "paused" and
-// "interrupted" are deliberately spared (legitimate resumable states).
-// Idempotent: a fresh DB or a previously-reconciled DB results in 0 updates.
+// from running.
+//
+// Rows with real persisted progress (file_list saved, current_file_index > 0)
+// are demoted to 'interrupted' so the subsequent ResumeInterruptedScans pass
+// picks them up and continues from the saved checkpoint. Rows without
+// resumable state (mid-enumerate, or zero progress) are marked 'cancelled'.
+//
+// "paused" and "interrupted" are deliberately spared (legitimate resumable
+// states). Idempotent: a fresh DB or a previously-reconciled DB results in
+// 0 updates.
 func (s *ScannerService) ReconcileOrphanScans() {
 	if s.scanRepo() == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	n, err := s.scanRepo().MarkOrphansCancelled(ctx)
+	res, err := s.scanRepo().ReconcileOrphans(ctx)
 	if err != nil {
 		logger.Warnf("ReconcileOrphanScans: failed to clean orphan rows: %v", err)
 		return
 	}
-	if n > 0 {
-		logger.Infof("ReconcileOrphanScans: marked %d orphan scan row(s) cancelled (residue of a previous hard restart)", n)
+	if res.Interrupted > 0 {
+		logger.Infof("ReconcileOrphanScans: demoted %d orphan scan row(s) to 'interrupted' for auto-resume (residue of a previous hard restart)", res.Interrupted)
+	}
+	if res.Cancelled > 0 {
+		logger.Infof("ReconcileOrphanScans: marked %d orphan scan row(s) cancelled (no resumable progress)", res.Cancelled)
 	}
 }
 


### PR DESCRIPTION
## Problem

When the container restarts **abruptly** (SIGKILL/OOM/host crash) the graceful-shutdown handler that calls \`MarkInterrupted\` never runs, so active scan rows stay as \`status='running'\` in the DB. \`ReconcileOrphanScans\` catches these on the next startup — but historically marked them all \`'cancelled'\` (terminal). The downstream \`ResumeInterruptedScans\` only handles \`'interrupted'\`, so a 3-hour scan with 4,000 files done was abandoned and had to be restarted from zero on the next boot.

Observed today in production: scan #1 ran for ~3h (4,031 / 31,107 files), the container was killed abruptly at 16:31 UTC (no \`'Scanner: initiating graceful shutdown'\` log line). On the next startup the reconcile correctly noticed the orphan row but cancelled it — no auto-resume.

## Fix

Split the reconcile by progress, in a single transaction:

- \`status IN ('running','scanning')\` AND \`current_file_index > 0\` AND \`total_files > 0\` AND \`file_list IS NOT NULL\`
  → \`'interrupted'\` (the next \`ResumeInterruptedScans\` picks it up)
- everything else still in an active status
  → \`'cancelled'\` (zero progress / no file_list to replay from)

\`MarkOrphansCancelled\` is preserved as a thin shim over the new \`ReconcileOrphans\` so the existing test contract (combined count, idempotency) holds, and the behavior change is additive: rows that previously got cancelled with zero progress still get cancelled.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`/usr/bin/golangci-lint run ./internal/repository/ ./internal/services/\` — 0 issues
- [x] \`go test ./internal/repository/ -run 'Reconcile|MarkOrphan'\` — 3/3 pass:
  - Existing \`TestScanRepository_MarkOrphansCancelled\` unchanged (zero-progress \`running\` still gets cancelled)
  - Existing zombie-row regression test unchanged
  - New \`TestScanRepository_ReconcileOrphans_ResumesProgress\` asserts the split: progress >0 ⇒ interrupted; progress=0 ⇒ cancelled; enumerating ⇒ cancelled; \`paused\`/\`completed\` untouched; resumable row's \`current_file_index\` and \`file_list\` preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after unexpected restarts: scans with persisted progress are now preserved and can resume, while incomplete scans are properly cancelled to prevent stalled jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->