### PR TITLE
fix(frontend): use per-instance webhook secret in copy-URL field

### DIFF
--- a/frontend/src/components/config/ArrServersSection.tsx
+++ b/frontend/src/components/config/ArrServersSection.tsx
@@ -439,7 +439,7 @@ const ArrServersSection = () => {
                                                     <input
                                                         type="text"
                                                         readOnly
-                                                        value={`${window.location.origin}/api/webhook/${arr.id}?apikey=${apiKeyData?.api_key || '...'}`}
+                                                        value={`${window.location.origin}/api/webhook/${arr.id}?apikey=${arr.webhook_secret || apiKeyData?.api_key || '...'}`}
                                                         onClick={(e) => e.currentTarget.select()}
                                                         className="w-full max-w-md bg-white dark:bg-slate-900/50 border border-slate-300 dark:border-slate-700 rounded px-2 py-1 text-xs text-slate-600 dark:text-slate-400 font-mono focus:outline-none focus:border-blue-500 focus:text-blue-300 cursor-pointer"
                                                     />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,6 +244,10 @@ export interface ArrInstance {
     url: string;
     api_key: string;
     enabled: boolean;
+    // Per-instance webhook secret. Null on legacy rows created before the
+    // per-instance-secret migration; the master api_key acts as the
+    // fallback credential in that case.
+    webhook_secret?: string | null;
 }
 
 export interface ScanPath {

--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -405,9 +405,9 @@ const SecuritySection = ({ apiKeyData, refetchApiKey }: SecuritySectionProps) =>
             <div className="rounded-xl border border-slate-200 dark:border-slate-800/50 bg-white/80 dark:bg-slate-900/40 backdrop-blur-xl p-6 h-full">
                 <div className="space-y-4">
                     <div>
-                        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Webhook API Key</h3>
+                        <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Master API Key</h3>
                         <p className="text-xs text-slate-500 mb-4">
-                            Use this API key in your Sonarr/Radarr webhook URLs. Add <code className="bg-slate-200 dark:bg-slate-800 px-1 rounded text-purple-600 dark:text-purple-300">?apikey=YOUR_KEY</code> to the webhook URL.
+                            Used by external integrations to call the Healarr API. For Sonarr/Radarr webhooks, copy the per-instance URL from the instance row above. The master key is only a fallback for legacy instances that have no per-instance webhook secret.
                         </p>
                     </div>
 
@@ -441,8 +441,9 @@ const SecuritySection = ({ apiKeyData, refetchApiKey }: SecuritySectionProps) =>
 
                     <div className="bg-amber-100 dark:bg-yellow-500/10 border border-amber-300 dark:border-yellow-500/20 rounded-lg p-3">
                         <p className="text-xs text-amber-800 dark:text-yellow-300">
-                            <strong>Webhook URL Format:</strong><br />
-                            <code className="text-xs">{window.location.origin}/api/webhook/{'{'}instance_id{'}'}</code> + <code>?apikey={apiKeyData?.api_key || 'YOUR_KEY'}</code>
+                            <strong>Legacy webhook URL (fallback only):</strong><br />
+                            <code className="text-xs">{window.location.origin}/api/webhook/{'{'}instance_id{'}'}</code> + <code>?apikey={apiKeyData?.api_key || 'YOUR_KEY'}</code><br />
+                            Prefer the per-instance URL shown in each instance row above.
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
## Problem

The webhook URL shown in each Arr-instance row was hardcoded to the master API key:

    /api/webhook/<id>?apikey={apiKeyData?.api_key}

When the instance has a per-instance \`webhook_secret\` (default for any instance created after the per-instance-secret migration), the backend at \`handlers_webhook.go:86-97\` rejects requests authenticated with the master key:

    401 Unauthorized {"error":"Invalid webhook secret"}

[#286](https://github.com/mescon/Healarr/issues/286) reports exactly this: user copied the URL verbatim from the UI into Sonarr's webhook config, Sonarr's connection test failed with the 401.

## Fix

- \`ArrServersSection.tsx\`: per-row URL uses \`arr.webhook_secret\` if present, falls back to \`apiKeyData?.api_key\` for legacy rows.
- \`ArrInstance\` type gains the optional \`webhook_secret\` field (the API already returns it).
- \`Config.tsx\` master-key card: rename "Webhook API Key" → "Master API Key", revise copy to call itself a fallback for legacy instances. The amber banner is repurposed as the legacy URL format with a "prefer the per-instance URL" hint.

Closes #286.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm run typecheck\` clean
- [x] \`go build ./...\` clean
- [ ] After deploy: verify on production that POSTing to /api/webhook/<id>?apikey=<webhook_secret> returns 2xx, and POSTing with the master key returns 401 (because the instance has a per-instance secret)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-instance webhook secrets as an alternative to the master API key.
  * Webhook URLs now automatically use per-instance secrets when available, with automatic fallback to the master API key.

* **Documentation**
  * Improved clarity in Security settings with updated API key labeling and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->