### PR TITLE
fix(integration): match Windows UNC paths in webhook path mapper

### DIFF
--- a/internal/integration/path_mapper.go
+++ b/internal/integration/path_mapper.go
@@ -36,6 +36,33 @@ func NewPathMapper(db *sql.DB) (*SQLPathMapper, error) {
 	return pm, nil
 }
 
+// pathSeparators are the path separators we recognize when matching a stored
+// scan-path against a path reported by an *arr instance. Forward slash covers
+// Linux/macOS and *arr's normalized form on most setups; backslash covers
+// Windows UNC paths (e.g. \\server\share\folder) that Sonarr/Radarr report
+// verbatim when running on Windows.
+const pathSeparators = "/\\"
+
+// trimTrailingSep removes any trailing path separators (both / and \) so the
+// stored mapping form is canonical. TrimRight is safe for UNC paths because
+// it only strips trailing characters, not the leading \\ that anchors the
+// UNC root.
+func trimTrailingSep(p string) string {
+	return strings.TrimRight(p, pathSeparators)
+}
+
+// hasSepPrefix reports whether s begins with a recognized path separator
+// (forward slash or backslash). Used after a HasPrefix match to confirm that
+// the matched stem ends on a directory boundary, so /mnt/media/TV doesn't
+// false-match against /mnt/media/TV2, and \\srv\share\Movies doesn't
+// false-match \\srv\share\MoviesArchive.
+func hasSepPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	return strings.ContainsRune(pathSeparators, rune(s[0]))
+}
+
 func (pm *SQLPathMapper) Reload() error {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -47,11 +74,9 @@ func (pm *SQLPathMapper) Reload() error {
 
 	mappings := make([]PathMapping, 0, len(rows))
 	for _, row := range rows {
-		// Ensure paths don't have trailing slashes for consistent matching,
-		// unless it's root (which shouldn't happen for media folders)
 		mappings = append(mappings, PathMapping{
-			LocalPath: strings.TrimRight(row.LocalPath, "/"),
-			ArrPath:   strings.TrimRight(row.ArrPath, "/"),
+			LocalPath: trimTrailingSep(row.LocalPath),
+			ArrPath:   trimTrailingSep(row.ArrPath),
 		})
 	}
 
@@ -68,12 +93,9 @@ func (pm *SQLPathMapper) ToArrPath(localPath string) (string, error) {
 
 	for i := range pm.mappings {
 		m := &pm.mappings[i]
-		// Check if localPath starts with m.LocalPath AND is followed by / or end of string
-		// This prevents /mnt/media/TV from matching /mnt/media/TV2
 		if strings.HasPrefix(localPath, m.LocalPath) {
 			remainder := localPath[len(m.LocalPath):]
-			// Valid match only if remainder is empty or starts with /
-			if remainder == "" || strings.HasPrefix(remainder, "/") {
+			if remainder == "" || hasSepPrefix(remainder) {
 				if len(m.LocalPath) > longestPrefixLen {
 					longestPrefixLen = len(m.LocalPath)
 					bestMatch = m
@@ -99,12 +121,9 @@ func (pm *SQLPathMapper) ToLocalPath(arrPath string) (string, error) {
 
 	for i := range pm.mappings {
 		m := &pm.mappings[i]
-		// Check if arrPath starts with m.ArrPath AND is followed by / or end of string
-		// This prevents /data/movies from matching /data/movies-archive
 		if strings.HasPrefix(arrPath, m.ArrPath) {
 			remainder := arrPath[len(m.ArrPath):]
-			// Valid match only if remainder is empty or starts with /
-			if remainder == "" || strings.HasPrefix(remainder, "/") {
+			if remainder == "" || hasSepPrefix(remainder) {
 				if len(m.ArrPath) > longestPrefixLen {
 					longestPrefixLen = len(m.ArrPath)
 					bestMatch = m

--- a/internal/integration/path_mapper_test.go
+++ b/internal/integration/path_mapper_test.go
@@ -557,3 +557,142 @@ func TestPathMapper_EmptyMappings(t *testing.T) {
 		t.Error("ToLocalPath should error with no mappings")
 	}
 }
+
+// =============================================================================
+// Windows UNC path tests (regression for #298)
+// =============================================================================
+//
+// When *arr is running on Windows it reports paths using backslash separators
+// and UNC roots, e.g. \\alexpr4100\media\Movies\High Strung (2016)\film.mkv.
+// The path-matching logic used to require the post-prefix remainder to start
+// with '/' which never matched on Windows, leaving every webhook stranded
+// with 'no matching scan path found'.
+
+func TestPathMapper_ToLocalPath_WindowsUNC(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	// Same UNC for both local + arr is the typical Docker-Desktop-on-Windows
+	// setup: the host mount IS the *arr path, no remapping needed.
+	seedScanPath(db, 1, `\\alexpr4100\media\Movies`, `\\alexpr4100\media\Movies`, false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		arrPath string
+		want    string
+	}{
+		{
+			"exact UNC match",
+			`\\alexpr4100\media\Movies`,
+			`\\alexpr4100\media\Movies`,
+		},
+		{
+			"UNC with file",
+			`\\alexpr4100\media\Movies\High Strung (2016)\High Strung (2016).mkv`,
+			`\\alexpr4100\media\Movies\High Strung (2016)\High Strung (2016).mkv`,
+		},
+		{
+			"UNC with nested folders",
+			`\\alexpr4100\media\Movies\A\B\C\D.mkv`,
+			`\\alexpr4100\media\Movies\A\B\C\D.mkv`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pm.ToLocalPath(tt.arrPath)
+			if err != nil {
+				t.Errorf("ToLocalPath(%q) error = %v", tt.arrPath, err)
+			}
+			if got != tt.want {
+				t.Errorf("ToLocalPath(%q) = %q, want %q", tt.arrPath, got, tt.want)
+			}
+		})
+	}
+}
+
+// Even on Windows the boundary check must hold: a prefix that is only a
+// substring of the configured path must not match.
+func TestPathMapper_ToLocalPath_WindowsUNC_PrefixBoundary(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	seedScanPath(db, 1, `\\srv\share\Movies`, `\\srv\share\Movies`, false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	// MoviesArchive is a sibling of Movies; must not match the Movies mapping.
+	if _, err := pm.ToLocalPath(`\\srv\share\MoviesArchive\film.mkv`); err == nil {
+		t.Error("ToLocalPath should not match MoviesArchive against Movies mapping")
+	}
+}
+
+// Cross-separator: Linux mapping must not pick up a Windows-style remainder
+// (or vice versa) just because the stored prefix is a substring of the
+// reported path.
+func TestPathMapper_ToLocalPath_TrimsTrailingBackslash(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	// Trailing backslash in the configured path must be stripped at load
+	// so it matches the same way as the no-slash form.
+	seedScanPath(db, 1, `\\srv\share\Movies\`, `\\srv\share\Movies\`, false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	want := `\\srv\share\Movies\film.mkv`
+	got, err := pm.ToLocalPath(want)
+	if err != nil {
+		t.Errorf("ToLocalPath(%q) error = %v", want, err)
+	}
+	if got != want {
+		t.Errorf("ToLocalPath(%q) = %q, want %q", want, got, want)
+	}
+}
+
+// ToArrPath direction must also handle UNC paths (covers any local->arr
+// callers, e.g. the on-demand-scan trigger that maps a filesystem path
+// back to the *arr canonical form before talking to the *arr API).
+func TestPathMapper_ToArrPath_WindowsUNC(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	seedScanPath(db, 1, `\\alexpr4100\media\Movies`, `\\alexpr4100\media\Movies`, false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	in := `\\alexpr4100\media\Movies\High Strung (2016)\film.mkv`
+	got, err := pm.ToArrPath(in)
+	if err != nil {
+		t.Errorf("ToArrPath(%q) error = %v", in, err)
+	}
+	if got != in {
+		t.Errorf("ToArrPath(%q) = %q, want %q", in, got, in)
+	}
+}


### PR DESCRIPTION
Closes #298.

## Problem

The path matcher (\`internal/integration/path_mapper.go\`) required the post-prefix remainder to start with a forward slash, so Windows UNC paths reported by *arr never matched. Every Healarr-on-Docker-Desktop-Windows setup hit:

    Webhook path mapping failed: *arr reported path
    '\\\\alexpr4100\\media\\Movies\\High Strung (2016)\\film.mkv'
    but no matching scan path found

even with a correctly configured scan path \`\\\\alexpr4100\\media\\Movies\`. Reported by @alex882001 in #298 after the v1.3.6 webhook-auth fix (#293) let his request reach the mapper layer in the first place.

## Fix

Accept either \`/\` or \`\\\\\` as the directory-boundary separator in:
- The post-HasPrefix remainder check (so \`\\\\srv\\share\\Movies\` matches \`\\\\srv\\share\\Movies\\film.mkv\` but not \`\\\\srv\\share\\MoviesArchive\\film.mkv\`)
- The trailing-separator trim at load time

Helpers factored out (\`pathSeparators\`, \`hasSepPrefix\`, \`trimTrailingSep\`) so the rule is named once.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`/usr/bin/golangci-lint run ./internal/integration/\` — 0 issues
- [x] \`go test ./internal/integration/ -run 'PathMapper'\` — all existing 17 tests pass, plus 4 new UNC-specific tests:
  - \`TestPathMapper_ToLocalPath_WindowsUNC\` — exact, with file, deep-nested
  - \`TestPathMapper_ToLocalPath_WindowsUNC_PrefixBoundary\` — \`MoviesArchive\` must not false-match \`Movies\`
  - \`TestPathMapper_ToLocalPath_TrimsTrailingBackslash\` — trailing \`\\\` is stripped at load
  - \`TestPathMapper_ToArrPath_WindowsUNC\` — reverse direction also covered

## Caveats

This fix gets the **path matching** working. If the user is running Healarr in a Linux container (Docker Desktop default) and their UNC share isn't mounted into the container, scanning will still fail at file-access time — that's a deployment issue, not a code one. The error message in that case will be from the scanner ("file not accessible"), which is at least a useful signal pointing at the real problem rather than the misleading "no matching scan path".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows UNC path handling to properly recognize and map network share paths with correct boundary detection.
  * Improved path separator handling to consistently process both forward slashes and backslashes, with proper normalization of trailing separators.

* **Tests**
  * Added comprehensive Windows UNC path regression test coverage including prefix boundary validation and path mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->