### PR TITLE
fix(scanner): semaphore pool + completion-bitmap watermark

### DIFF
--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -77,6 +77,9 @@ func setupScansTestDB(t *testing.T) (*sql.DB, func()) {
 			file_size INTEGER,
 			scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
+		-- Mirrors migration 010_scan_files_unique_index.sql.
+		CREATE UNIQUE INDEX idx_scan_files_scan_id_file_path_unique
+		    ON scan_files(scan_id, file_path);
 	`
 	if _, err := db.Exec(schema); err != nil {
 		db.Close()

--- a/internal/db/migrations/010_scan_files_unique_index.sql
+++ b/internal/db/migrations/010_scan_files_unique_index.sql
@@ -1,0 +1,37 @@
+-- 010_scan_files_unique_index.sql
+--
+-- Makes scan_files inserts idempotent on (scan_id, file_path) so the
+-- refactored scanner from #290 can safely replay work on resume.
+--
+-- Background: the scanner is moving from a batched fan-out/fan-in pipeline
+-- to a semaphore-bounded worker pool that persists progress via a
+-- completion bitmap plus a contiguous-completion watermark. When a scan
+-- is interrupted (process crash, host reboot, deliberate cancel) the
+-- watermark lags behind the actual highest-completed index because
+-- workers complete out of order; on the next startup the runner replays
+-- the window between the persisted watermark and the highest-completed
+-- index to guarantee no file is missed. Files in that replay window will
+-- already have a row in scan_files from their first processing pass, so
+-- a naive INSERT would create duplicate (scan_id, file_path) rows --
+-- inflating progress counts, polluting the corruption view, and breaking
+-- per-file lookups.
+--
+-- After this migration the repository switches its INSERT to
+-- ON CONFLICT(scan_id, file_path) DO NOTHING, making replay safe and
+-- letting the scanner treat "did we already record this?" as a database
+-- invariant rather than an application-level check.
+--
+-- Step 1 is defensive: any historical duplicates (none expected, but the
+-- absence of the constraint until now means we cannot prove it) must be
+-- collapsed first, otherwise the UNIQUE INDEX creation in step 2 will
+-- fail and roll the migration back. We keep the lowest id per group so
+-- foreign-key-ish references by id (if any external tooling held them)
+-- stay stable on the oldest row.
+
+DELETE FROM scan_files
+WHERE id NOT IN (
+    SELECT MIN(id) FROM scan_files GROUP BY scan_id, file_path
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scan_files_scan_id_file_path_unique
+    ON scan_files(scan_id, file_path);

--- a/internal/repository/scan_file.go
+++ b/internal/repository/scan_file.go
@@ -44,9 +44,20 @@ func NewScanFileRepository(sqlDB *sql.DB) *ScanFileRepository {
 // Record inserts a per-file scan result for the given scan.
 //
 // Uses db.ExecWithRetry because these inserts fire from parallel per-file
-// scan goroutines and can hit SQLite BUSY under contention; the retry
-// wrapper is the same one the scanner used inline before this migration,
-// so concurrency behavior is unchanged.
+// scan goroutines and can hit SQLite BUSY under contention.
+//
+// Idempotent on (scan_id, file_path) via the UNIQUE index added in migration
+// 010 and the ON CONFLICT DO NOTHING clause below: on resume from
+// interruption, the scanner's watermark may lag behind the actual
+// highest-completed index, so a re-detection of an already-recorded file
+// must not produce a duplicate row. Callers that need to distinguish
+// "fresh insert" from "already existed" can check the returned bool.
+//
+// scanned_at is set explicitly via strftime to millisecond precision
+// instead of the column's CURRENT_TIMESTAMP default (second precision).
+// The old precision clustered batch-completions into a single per-second
+// timestamp; with the new out-of-order worker pool, real wall-clock order
+// is visible in the scan-detail UI.
 func (r *ScanFileRepository) Record(ctx context.Context, scanID int64, rec ScanFileRecord) error {
 	_ = ctx // retry wrapper operates on the pool; ctx reserved for a future ExecContext variant
 	var corruptionType, errorDetails interface{}
@@ -57,8 +68,9 @@ func (r *ScanFileRepository) Record(ctx context.Context, scanID int64, rec ScanF
 		errorDetails = rec.ErrorDetails
 	}
 	_, err := db.ExecWithRetry(r.db, `
-		INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size, scanned_at)
+		VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+		ON CONFLICT(scan_id, file_path) DO NOTHING
 	`, scanID, rec.FilePath, rec.Status, corruptionType, errorDetails, rec.FileSize)
 	if err != nil {
 		return fmt.Errorf("record scan file: %w", err)

--- a/internal/repository/scan_file_test.go
+++ b/internal/repository/scan_file_test.go
@@ -19,6 +19,11 @@ CREATE TABLE scan_files (
 	file_size       INTEGER,
 	scanned_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+-- Mirrors migration 010_scan_files_unique_index.sql so the test DB
+-- exercises the same ON CONFLICT(scan_id, file_path) path the production
+-- repository relies on.
+CREATE UNIQUE INDEX idx_scan_files_scan_id_file_path_unique
+    ON scan_files(scan_id, file_path);
 `
 
 func newScanFileTestDB(t *testing.T) *sql.DB {
@@ -160,5 +165,75 @@ func TestScanFileRepository_ListForScan_pagination(t *testing.T) {
 	page3, err := repo.ListForScan(ctx, 1, "all", 2, 4)
 	if err != nil || len(page3) != 1 {
 		t.Fatalf("page3 = (%d, %v), want (1, nil)", len(page3), err)
+	}
+}
+
+// Record must be idempotent on (scan_id, file_path) so the scanner's
+// post-interruption replay window cannot produce duplicate rows. The
+// underlying INSERT ... ON CONFLICT DO NOTHING (migration 010) is what
+// guarantees this; this test pins the behavior.
+func TestScanFileRepository_Record_IdempotentOnReplay(t *testing.T) {
+	t.Parallel()
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+	ctx := context.Background()
+
+	rec := ScanFileRecord{FilePath: "/a.mkv", Status: "healthy", FileSize: 1024}
+
+	// First insert succeeds.
+	if err := repo.Record(ctx, 7, rec); err != nil {
+		t.Fatalf("first Record: %v", err)
+	}
+	// Second insert with the same (scan_id, file_path) must NOT error.
+	if err := repo.Record(ctx, 7, rec); err != nil {
+		t.Fatalf("second Record (replay) should be a no-op, got error: %v", err)
+	}
+
+	// The table must still contain exactly one row for the pair.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE scan_id=7 AND file_path='/a.mkv'`).Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("duplicate inserts produced %d rows, want 1", count)
+	}
+
+	// A different scan_id with the same file_path is a different row — the
+	// uniqueness is scoped to (scan_id, file_path), not file_path alone.
+	if err := repo.Record(ctx, 8, rec); err != nil {
+		t.Fatalf("Record for different scan: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE file_path='/a.mkv'`).Scan(&count); err != nil {
+		t.Fatalf("count query 2: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("got %d rows for /a.mkv across scans, want 2 (one per scan)", count)
+	}
+}
+
+// Record must persist scanned_at at millisecond precision rather than the
+// column's CURRENT_TIMESTAMP default (second precision). The chunked-burst
+// timestamp clustering visible in the scan-detail UI before #290 came from
+// many parallel workers committing within the same second; the new write
+// path stamps each row with strftime('%f') so per-file order survives.
+func TestScanFileRepository_Record_StoresMillisecondTimestamp(t *testing.T) {
+	t.Parallel()
+	db := newScanFileTestDB(t)
+	repo := NewScanFileRepository(db)
+	ctx := context.Background()
+
+	if err := repo.Record(ctx, 1, ScanFileRecord{FilePath: "/a.mkv", Status: "healthy"}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var ts string
+	if err := db.QueryRow(`SELECT scanned_at FROM scan_files WHERE scan_id=1 AND file_path='/a.mkv'`).Scan(&ts); err != nil {
+		t.Fatalf("read scanned_at: %v", err)
+	}
+	// strftime('%Y-%m-%d %H:%M:%f', 'now') produces e.g. "2026-06-04 15:23:42.789".
+	// CURRENT_TIMESTAMP produces "2026-06-04 15:23:42" (no fractional part).
+	// We expect the dot-and-fractional-seconds tail.
+	if len(ts) < 20 || ts[19] != '.' {
+		t.Errorf("scanned_at=%q is missing fractional-seconds tail; expected millisecond-precision format", ts)
 	}
 }

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -1526,15 +1527,23 @@ type detectJob struct {
 	state  detectJobState
 }
 
-// scanFilesParallel processes files in ordered batches of scanWorkers. Within a
-// batch, the read-only detection (detectFile: stat checks + ffprobe) runs
-// concurrently across workers (fan-out); results are then applied strictly in
-// index order by this single goroutine (fan-in: recording, corruption routing,
-// progress). Because the fan-in is sequential and in order, the periodic
-// progress checkpoint stays monotonic and resume-after-interruption keeps its
-// "everything before the saved index is done" guarantee. Cancellation and pause
-// are handled at batch boundaries (and workers bail before an expensive
-// detection if the scan is already stopping).
+// watermarkPersistInterval is how often the watermark goroutine flushes the
+// contiguous-completion watermark to scans.current_file_index. Bounded so
+// per-file write amplification stays low and resume granularity stays tight.
+const watermarkPersistInterval = 2 * time.Second
+
+// scanFilesParallel processes files with a semaphore-bounded worker pool. The
+// previous design used ordered fan-out/fan-in batches of scanWorkers files
+// with a wg.Wait barrier between batches: one slow file held back every
+// other worker in the batch, and all completions clustered into the same
+// CURRENT_TIMESTAMP second. The new design dispatches one worker per file up
+// to scanWorkers in flight, lets each commit its scan_files row as it
+// finishes, and tracks completion in a per-index bitmap so the persisted
+// current_file_index can still advance monotonically as a contiguous-done
+// watermark. Idempotency on (scan_id, file_path) (migration 010) covers the
+// resume replay window where the watermark may lag behind the actual
+// highest-completed index. Cancellation and pause are checked at every
+// dispatch iteration instead of only at batch boundaries.
 func (s *ScannerService) scanFilesParallel(
 	ctx context.Context,
 	progress *ScanProgress,
@@ -1544,63 +1553,166 @@ func (s *ScannerService) scanFilesParallel(
 	files := cfg.Files
 	pathID := progress.PathID
 
-	for start := cfg.StartIndex; start < len(files); {
-		if s.checkScanCancellation(ctx, progress, progress.Path, start, len(files)) == scanReturn {
-			return
+	// done[i] flips to true once index i has been fully processed (recorded,
+	// counter bumped, or deliberately skipped). The watermark advances over
+	// the contiguous prefix of trues.
+	done := make([]atomic.Bool, len(files))
+
+	// stopped flips when a worker or the dispatch loop decides the scan must
+	// stop (cancel, pause, fatal detection error). Workers that haven't
+	// started yet bail without consuming a semaphore slot; the dispatch loop
+	// breaks on the next iteration.
+	var stopped atomic.Bool
+
+	sem := make(chan struct{}, s.scanWorkers)
+	var wg sync.WaitGroup
+
+	// Watermark persister: walks `done` from cfg.StartIndex forward over
+	// consecutive trues, advances an in-memory watermark, and flushes it to
+	// scans.current_file_index every ~watermarkPersistInterval. Owning the
+	// DB write here means workers can finish out of order without
+	// corrupting the resume floor.
+	watermarkDone := make(chan struct{})
+	safego.Run("scan-watermark", func() {
+		defer close(watermarkDone)
+		watermark := cfg.StartIndex
+		lastPersisted := -1
+		ticker := time.NewTicker(watermarkPersistInterval)
+		defer ticker.Stop()
+
+		advance := func() {
+			for watermark < len(files) && done[watermark].Load() {
+				watermark++
+			}
 		}
-		if s.handleScanPause(ctx, progress, progress.Path, start, cfg.ScanDBID) == scanReturn {
-			return
+		persistIfAdvanced := func() {
+			if cfg.ScanDBID <= 0 || watermark == lastPersisted {
+				return
+			}
+			progress.mu.Lock()
+			filesDone := progress.FilesDone
+			progress.mu.Unlock()
+			progressCtx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
+			if err := s.scanRepo().UpdateProgress(progressCtx, cfg.ScanDBID, watermark, filesDone); err != nil {
+				logger.Warnf("watermark persist for scan %d (idx=%d) failed: %v", cfg.ScanDBID, watermark, err)
+			}
+			cancel()
+			lastPersisted = watermark
 		}
 
-		end := start + s.scanWorkers
-		if end > len(files) {
-			end = len(files)
+		for {
+			advance()
+			if watermark >= len(files) {
+				persistIfAdvanced()
+				return
+			}
+			select {
+			case <-ticker.C:
+				persistIfAdvanced()
+			case <-ctx.Done():
+				persistIfAdvanced()
+				return
+			}
+		}
+	})
+
+	// Dispatch loop: spawn one worker per file, capped at scanWorkers
+	// in-flight via the semaphore. Cancellation and pause are checked per
+	// iteration; if either fires we set `stopped` so already-dispatched
+	// workers can bail and we break out of the loop.
+	for i := cfg.StartIndex; i < len(files); i++ {
+		if s.checkScanCancellation(ctx, progress, progress.Path, i, len(files)) == scanReturn {
+			stopped.Store(true)
+			break
+		}
+		if s.handleScanPause(ctx, progress, progress.Path, i, cfg.ScanDBID) == scanReturn {
+			stopped.Store(true)
+			break
+		}
+		if stopped.Load() {
+			break
 		}
 
-		// Fan-out: detect each file in the batch concurrently. detectFile is
-		// read-only; the only shared state a worker mutates is filesInProgress
-		// (mutex-guarded), and each worker writes only its own jobs[k] element.
-		jobs := make([]detectJob, end-start)
-		var wg sync.WaitGroup
-		for k := range jobs {
-			idx := start + k
-			wg.Add(1)
-			safego.Run("scan-detect-worker", func() {
-				defer wg.Done()
-				s.detectInWorker(ctx, &jobs[k], files[idx], pathID, cfg, activeCorruptions)
-			})
+		// Acquire a slot (blocks if scanWorkers are already in flight). Use
+		// a select so we honor cancellation while waiting for a slot.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			stopped.Store(true)
 		}
-		wg.Wait()
+		if stopped.Load() {
+			break
+		}
 
-		// Fan-in: apply outcomes in index order, single-threaded.
-		for k := range jobs {
-			idx := start + k
-			switch jobs[k].state {
+		idx := i
+		wg.Add(1)
+		safego.Run("scan-detect-worker", func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			// Late-bail: another worker may have flipped `stopped` between
+			// our dispatch and our start. Don't mark done — resume must
+			// re-attempt this file.
+			if stopped.Load() {
+				return
+			}
+
+			var job detectJob
+			s.detectInWorker(ctx, &job, files[idx], pathID, cfg, activeCorruptions)
+
+			switch job.state {
 			case jobDedupSkipped:
 				logger.Debugf("Skipping file already being scanned: %s", files[idx])
-				s.markFileProcessed(progress, idx, cfg.ScanDBID)
+				s.markFileProcessedNoSync(progress)
+				done[idx].Store(true)
 			case jobStopped:
-				// Scan is canceling/shutting down: record the terminal status and stop.
-				s.checkScanCancellation(ctx, progress, progress.Path, idx, len(files))
+				// Worker observed ctx.Done() mid-detection. Signal so the
+				// dispatch loop stops, but leave done[idx]=false so resume
+				// retries this file.
+				stopped.Store(true)
 				return
 			case jobDone:
 				progress.mu.Lock()
 				progress.CurrentFile = files[idx]
 				progress.mu.Unlock()
 				s.emitProgress(progress)
-				if s.handleDetection(ctx, progress, cfg, idx, jobs[k].sfc, jobs[k].result) == scanReturn {
+				if s.handleDetection(ctx, progress, cfg, idx, job.sfc, job.result) == scanReturn {
+					// handleDetection already persisted the terminal scan
+					// state for this file via its own write paths. Signal
+					// shutdown but mark done so the watermark can pass this
+					// index (we don't want a stuck-forever watermark on a
+					// file the scanner has decided to terminate from).
+					stopped.Store(true)
+					done[idx].Store(true)
 					return
 				}
-			default: // jobPending — worker panicked mid-file; count it and move on.
+				done[idx].Store(true)
+			default: // jobPending — worker panicked mid-file.
 				logger.Warnf("Scan worker did not complete for %s; skipping", files[idx])
-				s.markFileProcessed(progress, idx, cfg.ScanDBID)
+				s.markFileProcessedNoSync(progress)
+				done[idx].Store(true)
 			}
-		}
-
-		start = end
+		})
 	}
 
-	progress.Status = "completed"
+	wg.Wait()
+	<-watermarkDone
+
+	if !stopped.Load() {
+		progress.Status = "completed"
+	}
+}
+
+// markFileProcessedNoSync bumps the in-memory FilesDone counter without
+// writing to the database. The parallel path uses this because the
+// watermark goroutine owns DB progress writes; the original
+// markFileProcessed (with its every-10-files persist of the worker's
+// fileIndex) is unsafe under out-of-order completion since it can write a
+// non-monotonic current_file_index.
+func (s *ScannerService) markFileProcessedNoSync(progress *ScanProgress) {
+	progress.mu.Lock()
+	progress.FilesDone++
+	progress.mu.Unlock()
 }
 
 // detectInWorker runs the read-only detection for a single file inside a worker

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4619,3 +4619,172 @@ func TestScannerWorkers_EnvOverride(t *testing.T) {
 		t.Errorf("unset should yield a sane memory-aware default, got %d", got)
 	}
 }
+
+// =============================================================================
+// Watermark + bitmap correctness (#290)
+// =============================================================================
+
+// TestScannerService_ScanFilesParallel_WatermarkIsContiguous asserts that the
+// persisted current_file_index after a successful run equals total_files: the
+// watermark must have walked the full contiguous done prefix even though
+// workers committed their scan_files rows out of order. This is the load-
+// bearing invariant for resume safety after the #290 refactor.
+func TestScannerService_ScanFilesParallel_WatermarkIsContiguous(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckWithConfigFunc: func(string, integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+			return true, nil
+		},
+	}
+
+	scanner := &ScannerService{
+		db:              db,
+		eventBus:        eb,
+		detector:        mockHC,
+		activeScans:     make(map[string]*ScanProgress),
+		filesInProgress: make(map[string]bool),
+		shutdownCh:      make(chan struct{}),
+		scanWorkers:     8,
+	}
+
+	tmpDir := t.TempDir()
+	const n = 40
+	files := make([]string, n)
+	oldTime := time.Now().Add(-10 * time.Minute)
+	for i := 0; i < n; i++ {
+		f := filepath.Join(tmpDir, fmt.Sprintf("w%02d.mkv", i))
+		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		_ = os.Chtimes(f, oldTime, oldTime)
+		files[i] = f
+	}
+
+	res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files, files_scanned) VALUES (?, 1, 'running', ?, 0)`, tmpDir, n)
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	scanDBID, _ := res.LastInsertId()
+
+	progress := &ScanProgress{
+		ID: "wm-scan", Type: "path", Path: tmpDir, PathID: 1,
+		TotalFiles: n, ScanDBID: scanDBID, resumeChan: make(chan struct{}),
+	}
+
+	scanner.scanFiles(context.Background(), progress, scanFilesConfig{
+		Files:           files,
+		StartIndex:      0,
+		DetectionConfig: integration.DetectionConfig{Method: "ffprobe", Mode: "quick"},
+		ScanDBID:        scanDBID,
+	})
+
+	// Persisted current_file_index must equal n (the full contiguous prefix).
+	var persistedIdx int
+	if err := db.QueryRow(`SELECT current_file_index FROM scans WHERE id = ?`, scanDBID).Scan(&persistedIdx); err != nil {
+		t.Fatalf("read current_file_index: %v", err)
+	}
+	if persistedIdx != n {
+		t.Errorf("current_file_index = %d, want %d (watermark must reach the end on full completion)", persistedIdx, n)
+	}
+}
+
+// TestScannerService_Record_IdempotentOnDoubleRecord covers the on-conflict
+// path that pairs with the watermark replay window: when a resumed scan
+// reprocesses files that have already been recorded, the second Record call
+// must be a no-op rather than producing a duplicate row or erroring.
+func TestScannerService_Record_IdempotentOnDoubleRecord(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckWithConfigFunc: func(string, integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+			return true, nil
+		},
+	}
+
+	scanner := &ScannerService{
+		db:              db,
+		eventBus:        eb,
+		detector:        mockHC,
+		activeScans:     make(map[string]*ScanProgress),
+		filesInProgress: make(map[string]bool),
+		shutdownCh:      make(chan struct{}),
+		scanWorkers:     2,
+	}
+
+	tmpDir := t.TempDir()
+	files := []string{
+		filepath.Join(tmpDir, "a.mkv"),
+		filepath.Join(tmpDir, "b.mkv"),
+		filepath.Join(tmpDir, "c.mkv"),
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+		_ = os.Chtimes(f, oldTime, oldTime)
+	}
+
+	res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files, files_scanned) VALUES (?, 1, 'running', ?, 0)`, tmpDir, len(files))
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	scanDBID, _ := res.LastInsertId()
+
+	progress := &ScanProgress{
+		ID: "replay-scan", Type: "path", Path: tmpDir, PathID: 1,
+		TotalFiles: len(files), ScanDBID: scanDBID, resumeChan: make(chan struct{}),
+	}
+
+	// First pass: full scan.
+	scanner.scanFiles(context.Background(), progress, scanFilesConfig{
+		Files: files, StartIndex: 0,
+		DetectionConfig: integration.DetectionConfig{Method: "ffprobe", Mode: "quick"},
+		ScanDBID:        scanDBID,
+	})
+
+	var first int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE scan_id = ?`, scanDBID).Scan(&first); err != nil {
+		t.Fatalf("count first pass: %v", err)
+	}
+	if first != len(files) {
+		t.Fatalf("first pass rows = %d, want %d", first, len(files))
+	}
+
+	// Second pass: simulate the replay window by re-running from index 0.
+	// The ON CONFLICT(scan_id, file_path) DO NOTHING in Record must prevent
+	// duplicate rows. progress.FilesDone is bumped again, but the table
+	// row count must stay exactly len(files).
+	progress2 := &ScanProgress{
+		ID: "replay-scan-2", Type: "path", Path: tmpDir, PathID: 1,
+		TotalFiles: len(files), ScanDBID: scanDBID, resumeChan: make(chan struct{}),
+	}
+	scanner.scanFiles(context.Background(), progress2, scanFilesConfig{
+		Files: files, StartIndex: 0,
+		DetectionConfig: integration.DetectionConfig{Method: "ffprobe", Mode: "quick"},
+		ScanDBID:        scanDBID,
+	})
+
+	var second int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE scan_id = ?`, scanDBID).Scan(&second); err != nil {
+		t.Fatalf("count second pass: %v", err)
+	}
+	if second != len(files) {
+		t.Errorf("second (replay) pass rows = %d, want %d (ON CONFLICT must dedupe)", second, len(files))
+	}
+}

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -19,6 +19,16 @@ func NewTestDB() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open in-memory database: %w", err)
 	}
+	// `:memory:` is per-connection in modernc.org/sqlite: every new pool
+	// connection opens its own fresh empty database, which means the
+	// schema initialized on one connection is invisible to the next. The
+	// previous behavior happened to work because tests barely exercised
+	// concurrent DB access; the parallel scanner refactor (#290) added a
+	// watermark goroutine that writes alongside per-file workers, so the
+	// pool now hands out multiple connections and the latent issue
+	// surfaces as "no such table". Pin the pool to a single connection so
+	// the schema is the same one everyone sees.
+	db.SetMaxOpenConns(1)
 
 	if err := initializeSchema(db); err != nil {
 		_ = db.Close() // Ignore close error since we're already returning an error
@@ -98,7 +108,9 @@ func initializeSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create scans table: %w", err)
 	}
 
-	// Create scan_files table
+	// Create scan_files table. The UNIQUE index mirrors migration 010 so
+	// the ON CONFLICT(scan_id, file_path) DO NOTHING path used by the
+	// production repository works in tests too.
 	_, err = db.Exec(`
 		CREATE TABLE scan_files (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -109,7 +121,9 @@ func initializeSchema(db *sql.DB) error {
 			error_details TEXT,
 			file_size INTEGER,
 			scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		)
+		);
+		CREATE UNIQUE INDEX idx_scan_files_scan_id_file_path_unique
+		    ON scan_files(scan_id, file_path);
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to create scan_files table: %w", err)


### PR DESCRIPTION
Closes #290.

## What changes

The scanner replaces its batched fan-out/fan-in with a semaphore-bounded worker pool and a completion-bitmap watermark.

| Before | After |
|---|---|
| Ordered batches of `scanWorkers` files; `wg.Wait()` between batches | One worker per file, up to `scanWorkers` in flight via a buffered-channel semaphore |
| Slow file in a batch holds back the other N-1 | Workers commit independently |
| All N completions cluster on the same CURRENT_TIMESTAMP second | Per-file `strftime('%Y-%m-%d %H:%M:%f', 'now')` ms-precision |
| `markFileProcessed` writes worker's `fileIndex` every 10 files (non-monotonic under out-of-order completion) | New `markFileProcessedNoSync` for parallel path; a watermark goroutine owns the DB progress write |

## Why a watermark + bitmap

Resume safety requires the persisted `current_file_index` to be monotonic so that on the next startup, "replay from index N" is guaranteed to cover every file that hadn't completed. With out-of-order worker completion, the worker's own `fileIndex` is no longer suitable for this. The bitmap (`done []atomic.Bool` indexed by file position) lets a separate goroutine walk forward over the contiguous prefix of trues; that walk position is the watermark.

The watermark may lag behind the actual highest-completed index — that's the **replay window**. Migration 010 adds `UNIQUE INDEX (scan_id, file_path)` and `Record` now uses `ON CONFLICT(scan_id, file_path) DO NOTHING`, so re-processing a file during the replay window is a no-op rather than producing a duplicate row.

## Cancellation & pause

Both checks fire on every dispatch-loop iteration (previously only between batches). In-flight workers honor `ctx.Done()` at the same point they always have. The `stopped` atomic flag prevents already-dispatched workers from starting expensive work, and lets the dispatch loop break out cleanly.

## Test changes

- New `TestScannerService_ScanFilesParallel_WatermarkIsContiguous`: after a clean run, persisted `current_file_index == total_files` (the watermark walked the whole way).
- New `TestScannerService_Record_IdempotentOnDoubleRecord`: a simulated replay (running the same file list twice) must not produce duplicate `scan_files` rows.
- New `TestScanFileRepository_Record_IdempotentOnReplay` and `TestScanFileRepository_Record_StoresMillisecondTimestamp` in the repo tests.
- Inline schemas in two test files updated to mirror migration 010's UNIQUE index.
- `NewTestDB` pins `MaxOpenConns=1`. The parallel refactor exposed a latent issue where modernc.org/sqlite's `:memory:` is per-connection — multi-connection writes from worker+watermark in tests started seeing 'no such table' on fresh connections. Real production DBs use a file path so this only affected tests.

## Test plan
- [x] `go build ./...` clean
- [x] `/usr/bin/golangci-lint run ./...` — 0 issues
- [x] `go test ./internal/repository/ ./internal/api/ ./internal/integration/ ./internal/db/` — all green
- [x] `go test -race ./internal/services/` — full services suite green under the race detector (44s)
- [x] New tests: `WatermarkIsContiguous`, `IdempotentOnDoubleRecord`, `Record_IdempotentOnReplay`, `Record_StoresMillisecondTimestamp` all pass