### PR TITLE
docs: correct stale references after v1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Configure per scan path in Config.
 
 ### Using Custom Binary Versions
 
-The Docker image includes ffmpeg, MediaInfo, and HandBrake from Alpine packages. If you need newer versions (e.g., for specific codec support), you have two options:
+The Docker image includes jellyfin-ffmpeg 8, MediaInfo, and HandBrake CLI from Debian packages (the image base switched from Alpine to Debian-slim in v1.3.5 so the NVIDIA Container Toolkit's library injection works out of the box). If you need newer versions or a different build, you have two options:
 
 #### Option 1: Tools Directory (Recommended)
 
@@ -482,7 +482,7 @@ services:
       - /path/to/media:/media:ro
 ```
 
-AV1 NVDEC for Intel iGPUs requires 12th-gen Core (Arc) or later. Older iGPUs handle HEVC / H.264 / VP9 fine via QSV.
+AV1 hardware decode on Intel iGPUs requires 12th-gen Core (Alder Lake) or later, or Intel Arc. Older iGPUs handle HEVC / H.264 / VP9 fine via QSV.
 
 ### Intel iGPU and AMD GPU (VAAPI)
 

--- a/agents/DATABASE.md
+++ b/agents/DATABASE.md
@@ -30,6 +30,12 @@ Migrations are stored in `internal/db/migrations/` and applied in order:
 | `002_add_status_constraints.sql` | Status constraints for corruptions/scans |
 | `003_add_file_path_index.sql` | Performance index for file_path lookups |
 | `004_corruption_summary.sql` | Materialized corruption status table with trigger-based maintenance |
+| `005_sessions.sql` | Per-user session tokens for browser auth |
+| `006_webhook_secret.sql` | Per-instance webhook secret column on `arr_instances` |
+| `007_filter_stray_corruption_summary.sql` | Cleanup + view-level guard against mis-tagged notification events leaking into the corruption summary |
+| `008_scan_path_overrides.sql` | Per-scan-path overrides for thorough decode duration / timeout / hwaccel |
+| `009_scan_presets.sql` | Reusable scan-settings presets (Zero-byte only, Quick, Fast triage, Deep scan, Paranoid, plus user-defined) |
+| `010_scan_files_unique_index.sql` | `UNIQUE(scan_id, file_path)` index so the post-#290 scanner can replay the watermark window without producing duplicate rows |
 
 **Note:** The base schema (001) was consolidated for cleaner deployments. All features (resumable scans, accessibility errors, pending rescans, per-path dry-run) are included. Migration 004 adds a materialized `corruption_summary` table that replaces the slow `corruption_status` VIEW for dramatically improved query performance.
 

--- a/agents/FRONTEND.md
+++ b/agents/FRONTEND.md
@@ -5,7 +5,7 @@
 The frontend is a **React 19** single-page application built with:
 
 - **TypeScript** for type safety
-- **Vite 7** for fast development and building
+- **Vite 8** for fast development and building
 - **Tailwind CSS v4** for styling
 - **TanStack Query** for server state management
 - **Framer Motion** for animations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
       # Media libraries - must match your *arr paths
       # Mount as read-only (:ro) - Healarr only needs to scan files
-      - /path/to/media:/mnt/media:ro
+      - /path/to/media:/media:ro
     
     # Optional: connect to same network as your *arr containers
     # networks:


### PR DESCRIPTION
Five inaccuracies found in a post-v1.3.6 docs audit and fixed in this PR.

| File | Was | Now |
|---|---|---|
| README.md | "Alpine packages" for bundled ffmpeg/MediaInfo/HandBrake | Debian-slim + jellyfin-ffmpeg 8 (the image base switched in v1.3.5) |
| README.md | "AV1 NVDEC for Intel iGPUs requires 12th-gen Core" | "AV1 hardware decode on Intel iGPUs requires 12th-gen Core (Alder Lake) or Intel Arc" — NVDEC is the NVIDIA decoder; Intel's path is QSV |
| docker-compose.yml | mount to `/mnt/media` | mount to `/media` — README uses `/media` everywhere |
| agents/FRONTEND.md | "Vite 7" | "Vite 8" (#296) |
| agents/DATABASE.md | Migration table stopped at 004 | 005-010 added with one-line purpose each |

No code changes; pure documentation alignment.

## Test plan
- [x] `git grep` confirms no remaining stale references to 'Alpine packages', '/mnt/media' (in our docs), 'Vite 7', or 'AV1 NVDEC for Intel'
- [x] DATABASE.md table now lists every file present in `internal/db/migrations/`