### PR TITLE
fix(scanner): make enumeration visible, bounded, and cancellable

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ All configuration options can be set via environment variables or command-line f
 | `--arr-rate-burst` | `HEALARR_ARR_RATE_LIMIT_BURST` | `10` | Burst size for rate limiting |
 | - | `HEALARR_SCANNER_WORKERS` | auto | Files scanned in parallel per scan. Default is tuned to available memory; set explicitly to override (1-32). env only |
 | - | `HEALARR_SCANNER_SHUTDOWN_TIMEOUT` | `30s` | Grace period for in-flight scans to finish on shutdown (env only) |
+| - | `HEALARR_SCANNER_ENUMERATION_TIMEOUT` | `30m` | Max time for the directory-walk phase before a scan aborts. Bounds a hang on a slow/unresponsive network mount; raise it for very large libraries on slow-but-working storage (env only) |
 | `--version` / `-v` | - | - | Print version and exit |
 
 **Examples:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       # - HEALARR_TRUSTED_PROXIES=172.18.0.0/16  # Your reverse proxy subnet
       # - HEALARR_SCANNER_WORKERS=4          # Files scanned in parallel; default auto-tunes to memory (1-32)
       # - HEALARR_SCANNER_SHUTDOWN_TIMEOUT=30s  # Grace period for in-flight scans on shutdown
+      # - HEALARR_SCANNER_ENUMERATION_TIMEOUT=30m  # Max directory-walk time before a scan aborts (guards a hung network mount)
 
       # Custom binary paths (optional - for newer ffmpeg/mediainfo/handbrake):
       # - HEALARR_FFPROBE_PATH=/config/tools/ffprobe

--- a/internal/db/migrations/011_scan_status_enumerating.sql
+++ b/internal/db/migrations/011_scan_status_enumerating.sql
@@ -1,0 +1,55 @@
+-- 011_scan_status_enumerating.sql
+--
+-- Promotes two scanner status values that were, until now, in-memory only.
+-- internal/services/scanner.go already defines ScanStatusEnumerating
+-- ("enumerating") and ScanStatusScanning ("scanning"), and the reconcile
+-- query in internal/repository/scan.go selects WHERE status IN
+-- ('running', 'enumerating', 'scanning'). But the scans.status CHECK
+-- constraint set in 002_add_status_constraints.sql only allowed
+-- ('pending', 'running', 'paused', 'completed', 'cancelled', 'error',
+-- 'interrupted', 'aborted'), so any attempt to persist 'enumerating' or
+-- 'scanning' would fail the constraint -- those states could never reach
+-- the database and existed solely in the running scanner's memory.
+--
+-- We are about to start persisting status='enumerating' on a scan row that
+-- is created BEFORE file enumeration finishes, so the scan is visible in
+-- /scans during a slow directory walk, then transitioning the row to
+-- 'scanning' once the walk completes and per-file work begins. This
+-- migration makes both values legal in the CHECK constraint.
+--
+-- SQLite cannot ALTER a CHECK constraint in place, so we follow the exact
+-- table-recreate pattern from 002: build scans_new with the full current
+-- column set plus the expanded CHECK, copy the data, drop the old table,
+-- rename, and recreate the scans indexes. Forward-only; no DOWN section.
+
+-- 1. Create new scans table with the expanded status CHECK constraint
+CREATE TABLE scans_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL,
+    path_id INTEGER REFERENCES scan_paths(id),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'enumerating', 'scanning', 'paused', 'completed', 'cancelled', 'error', 'interrupted', 'aborted')),
+    files_scanned INTEGER DEFAULT 0,
+    corruptions_found INTEGER DEFAULT 0,
+    total_files INTEGER DEFAULT 0,
+    current_file_index INTEGER DEFAULT 0,
+    file_list TEXT,
+    detection_config TEXT,
+    auto_remediate INTEGER DEFAULT 0,
+    dry_run BOOLEAN DEFAULT 0,
+    error_message TEXT,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP
+);
+
+-- 2. Copy data from old table
+INSERT INTO scans_new SELECT * FROM scans;
+
+-- 3. Drop old table
+DROP TABLE scans;
+
+-- 4. Rename new table
+ALTER TABLE scans_new RENAME TO scans;
+
+-- 5. Recreate indexes for scans (dropped with the old table)
+CREATE INDEX idx_scans_status ON scans(status);
+CREATE INDEX idx_scans_path_id_status ON scans(path_id, status);

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -229,6 +229,42 @@ func (r *ScanRepository) Create(ctx context.Context, p CreateScanParams) (int64,
 	return id, nil
 }
 
+// CreateEnumerating inserts a scan row in the 'enumerating' state, before the
+// directory walk has produced a file list. This makes the scan visible in
+// /scans and the dashboard the moment it starts, instead of appearing only
+// after enumeration completes (which, on a slow/degraded network mount, can
+// be minutes). total_files is 0 and file_list is empty until
+// FinishEnumeration runs; current_file_index stays 0 so that a hard restart
+// mid-enumeration is reconciled to 'cancelled' (nothing to resume) rather
+// than 'interrupted'.
+func (r *ScanRepository) CreateEnumerating(ctx context.Context, p CreateScanParams) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO scans (path, path_id, status, files_scanned, corruptions_found, total_files, current_file_index, file_list, detection_config, auto_remediate, dry_run, started_at)
+		VALUES (?, ?, 'enumerating', 0, 0, 0, 0, '[]', ?, ?, ?, datetime('now'))
+	`, p.Path, p.PathID, p.DetectionConfigJSON, p.AutoRemediate, p.DryRun)
+	if err != nil {
+		return 0, fmt.Errorf("insert enumerating scan: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("last insert id: %w", err)
+	}
+	return id, nil
+}
+
+// FinishEnumeration transitions an 'enumerating' scan to 'scanning' once the
+// directory walk is done: it stores the discovered file_list and total_files
+// so the per-file scan loop (and resume-after-interruption) has the work set.
+func (r *ScanRepository) FinishEnumeration(ctx context.Context, scanID int64, totalFiles int, fileListJSON string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scans SET status = 'scanning', total_files = ?, file_list = ? WHERE id = ?
+	`, totalFiles, fileListJSON, scanID)
+	if err != nil {
+		return fmt.Errorf("finish enumeration: %w", err)
+	}
+	return nil
+}
+
 // SetStatus updates only the status column.
 func (r *ScanRepository) SetStatus(ctx context.Context, scanID int64, status string) error {
 	if _, err := r.db.ExecContext(ctx, `UPDATE scans SET status = ? WHERE id = ?`, status, scanID); err != nil {

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -639,3 +639,111 @@ func TestScanRepository_MarkOrphansCancelled_CatchesZombieRows(t *testing.T) {
 	check(12, "paused")      // spared
 	check(13, "interrupted") // spared
 }
+
+// CreateEnumerating must insert a row in the 'enumerating' state with no file
+// list and zero totals, so the scan is visible the moment it starts but is
+// reconciled as cancelled (not resumed) if the process dies mid-walk.
+func TestScanRepository_CreateEnumerating(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	id, err := repo.CreateEnumerating(ctx, CreateScanParams{
+		Path: "/media/tv", PathID: 1,
+		DetectionConfigJSON: `{"method":"ffprobe"}`,
+		AutoRemediate:       true,
+	})
+	if err != nil {
+		t.Fatalf("CreateEnumerating: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected a positive id, got %d", id)
+	}
+
+	var status, fileList string
+	var total, idx int
+	if err := db.QueryRow(
+		`SELECT status, total_files, current_file_index, file_list FROM scans WHERE id=?`, id,
+	).Scan(&status, &total, &idx, &fileList); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "enumerating" {
+		t.Errorf("status = %q, want enumerating", status)
+	}
+	if total != 0 || idx != 0 {
+		t.Errorf("total=%d idx=%d, want 0/0 (nothing enumerated yet)", total, idx)
+	}
+	if fileList != "[]" {
+		t.Errorf("file_list = %q, want []", fileList)
+	}
+}
+
+// FinishEnumeration must flip an 'enumerating' row to 'scanning' and persist
+// the discovered file list + total so the per-file loop and resume logic have
+// the work set.
+func TestScanRepository_FinishEnumeration(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	id, err := repo.CreateEnumerating(ctx, CreateScanParams{Path: "/media/tv", PathID: 1})
+	if err != nil {
+		t.Fatalf("CreateEnumerating: %v", err)
+	}
+
+	fileList := `["/media/tv/a.mkv","/media/tv/b.mkv","/media/tv/c.mkv"]`
+	if err := repo.FinishEnumeration(ctx, id, 3, fileList); err != nil {
+		t.Fatalf("FinishEnumeration: %v", err)
+	}
+
+	var status, gotList string
+	var total int
+	if err := db.QueryRow(
+		`SELECT status, total_files, file_list FROM scans WHERE id=?`, id,
+	).Scan(&status, &total, &gotList); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != "scanning" {
+		t.Errorf("status = %q, want scanning", status)
+	}
+	if total != 3 {
+		t.Errorf("total_files = %d, want 3", total)
+	}
+	if gotList != fileList {
+		t.Errorf("file_list = %q, want %q", gotList, fileList)
+	}
+}
+
+// An 'enumerating' orphan (process died mid-walk: status='enumerating',
+// current_file_index=0, file_list='[]') must reconcile to 'cancelled', never
+// 'interrupted' — there is no resumable work set.
+func TestScanRepository_ReconcileOrphans_EnumeratingGoesCancelled(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	id, err := repo.CreateEnumerating(ctx, CreateScanParams{Path: "/media/tv", PathID: 1})
+	if err != nil {
+		t.Fatalf("CreateEnumerating: %v", err)
+	}
+
+	out, err := repo.ReconcileOrphans(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+	if out.Interrupted != 0 {
+		t.Errorf("Interrupted = %d, want 0 (enumeration is not resumable)", out.Interrupted)
+	}
+	if out.Cancelled != 1 {
+		t.Errorf("Cancelled = %d, want 1", out.Cancelled)
+	}
+
+	var status string
+	_ = db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&status)
+	if status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", status)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -118,6 +119,35 @@ func scannerShutdownTimeout() time.Duration {
 	}
 	return defaultShutdownTimeout
 }
+
+// defaultEnumerationTimeout bounds the directory-walk phase of a scan. A
+// media library on a healthy local disk enumerates tens of thousands of
+// files in well under a second, but a degraded network mount (mergerfs over
+// CIFS/NFS, a stalled rclone FUSE backend, etc.) can make each stat block for
+// seconds, turning enumeration into an effectively-infinite hang. Without a
+// bound the scan would sit forever with no file list and no way to recover
+// short of restarting the container. 30 minutes is generous enough for very
+// large libraries on slow-but-working storage while still capping a genuine
+// hang.
+const defaultEnumerationTimeout = 30 * time.Minute
+
+// scannerEnumerationTimeout returns the operator-configured enumeration
+// timeout from HEALARR_SCANNER_ENUMERATION_TIMEOUT (time.ParseDuration), or
+// defaultEnumerationTimeout if unset/invalid.
+func scannerEnumerationTimeout() time.Duration {
+	if v := os.Getenv("HEALARR_SCANNER_ENUMERATION_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+		logger.Warnf("Invalid HEALARR_SCANNER_ENUMERATION_TIMEOUT %q; using default %s", v, defaultEnumerationTimeout)
+	}
+	return defaultEnumerationTimeout
+}
+
+// enumerationProgressInterval throttles the "enumerated N files so far" log
+// line emitted during the directory walk so a slow mount produces visible
+// heartbeat output without flooding the log on a fast one.
+const enumerationProgressInterval = 5 * time.Second
 
 // Default media file extensions to scan
 var defaultMediaExtensions = map[string]bool{
@@ -945,15 +975,27 @@ func classifyEntry(filePath string, d fs.DirEntry) (isMedia, isSkipped, isSymlin
 	return false, true, false
 }
 
-// enumerateMediaFiles walks the directory and returns a list of media files.
-// Uses filepath.WalkDir to correctly detect symlinks.
-func (s *ScannerService) enumerateMediaFiles(localPath string) ([]string, error) {
+// enumerateMediaFiles walks localPath and returns the media files found. It
+// honors ctx so a cancelled scan or a blown enumeration timeout aborts the
+// walk promptly (each directory entry checks ctx.Err()), and it emits a
+// throttled "enumerated N files" heartbeat so a slow mount is visibly making
+// progress in the logs instead of looking like a hang. Returns ctx.Err()
+// (context.Canceled / context.DeadlineExceeded) if the walk was aborted.
+func (s *ScannerService) enumerateMediaFiles(ctx context.Context, localPath string) ([]string, error) {
 	stats := walkStats{}
+	lastHeartbeat := time.Now()
+	entriesSeen := 0
 
 	err := filepath.WalkDir(localPath, func(filePath string, d fs.DirEntry, err error) error {
+		// Abort promptly on cancel / enumeration timeout. Returning the
+		// context error stops WalkDir and propagates out.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		if err != nil {
 			return s.handleWalkError(filePath, err)
 		}
+		entriesSeen++
 		isMedia, isSkipped, isSymlink := classifyEntry(filePath, d)
 		switch {
 		case isSymlink:
@@ -963,14 +1005,23 @@ func (s *ScannerService) enumerateMediaFiles(localPath string) ([]string, error)
 		case isMedia:
 			stats.files = append(stats.files, filePath)
 		}
+		// Heartbeat: a degraded mount makes each stat block for seconds, so
+		// without this the only log line is "Starting scan" until the walk
+		// finishes (or never does). Throttled to avoid flooding fast walks.
+		if time.Since(lastHeartbeat) >= enumerationProgressInterval {
+			logger.Infof("Enumerating %s: %d media files found so far (%d entries scanned)", localPath, len(stats.files), entriesSeen)
+			lastHeartbeat = time.Now()
+		}
 		return nil
 	})
 
-	if err == nil && (stats.skippedCount > 0 || stats.symlinkCount > 0) {
+	if err != nil {
+		return stats.files, err
+	}
+	if stats.skippedCount > 0 || stats.symlinkCount > 0 {
 		logger.Debugf("Skipped %d non-media/hidden files and %d symlinks in %s", stats.skippedCount, stats.symlinkCount, localPath)
 	}
-
-	return stats.files, err
+	return stats.files, nil
 }
 
 // handleWalkError handles errors during file system traversal
@@ -1119,21 +1170,36 @@ func (s *ScannerService) ScanPath(pathID int64, localPath string) error {
 		return s.handlePathInaccessible(scanID, localPath, err)
 	}
 
-	// Enumerate files
-	files, err := s.enumerateMediaFiles(localPath)
+	// Create the scan row up front in the 'enumerating' state so the scan is
+	// visible in /scans and the dashboard during the directory walk, instead
+	// of materializing only after enumeration finishes (which on a slow or
+	// degraded mount can take minutes and looks indistinguishable from a hang).
+	scanDBID := s.recordEnumerationStart(localPath, pathID, cfg)
+	progress.ScanDBID = scanDBID
+	s.emitProgress(progress)
+
+	// Enumerate files under a bounded, cancellable context: a user cancel
+	// (which cancels the parent ctx) or a blown enumeration timeout aborts the
+	// walk promptly instead of hanging the scan forever on stalled I/O.
+	enumCtx, enumCancel := context.WithTimeout(ctx, scannerEnumerationTimeout())
+	files, err := s.enumerateMediaFiles(enumCtx, localPath)
+	enumCancel()
 	if err != nil {
-		s.mu.Lock()
-		delete(s.activeScans, scanID)
-		s.mu.Unlock()
-		return err
+		return s.handleEnumerationFailure(scanID, scanDBID, localPath, ctx, err)
 	}
 
 	progress.TotalFiles = len(files)
 	progress.Status = ScanStatusScanning
 
-	// Record scan start
-	scanDBID := s.recordScanStart(localPath, pathID, files, cfg)
-	progress.ScanDBID = scanDBID
+	// Persist the discovered file list + total and transition to 'scanning'.
+	// If the up-front insert failed (scanDBID == 0), fall back to the legacy
+	// create-after-enumeration path so the scan is still recorded.
+	if scanDBID > 0 {
+		s.finishEnumerationRecord(scanDBID, files)
+	} else {
+		scanDBID = s.recordScanStart(localPath, pathID, files, cfg)
+		progress.ScanDBID = scanDBID
+	}
 	s.emitProgress(progress)
 
 	defer s.finalizeScan(scanID, progress, scanDBID)
@@ -1148,6 +1214,89 @@ func (s *ScannerService) ScanPath(pathID int64, localPath string) error {
 		ScanDBID:        scanDBID,
 	})
 	return nil
+}
+
+// recordEnumerationStart inserts the scan row in the 'enumerating' state
+// before the directory walk, returning the scan id (0 on failure, which the
+// caller treats as "fall back to recording after enumeration").
+func (s *ScannerService) recordEnumerationStart(localPath string, pathID int64, cfg scanPathSettings) int64 {
+	detectionConfigJSON, err := json.Marshal(cfg.DetectionConfig)
+	if err != nil {
+		logger.Errorf("Failed to serialize detection config: %v", err)
+		detectionConfigJSON = []byte("{}")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
+	defer cancel()
+	scanDBID, err := s.scanRepo().CreateEnumerating(ctx, repository.CreateScanParams{
+		Path:                localPath,
+		PathID:              pathID,
+		DetectionConfigJSON: string(detectionConfigJSON),
+		AutoRemediate:       cfg.AutoRemediate,
+		DryRun:              cfg.DryRun,
+	})
+	if err != nil {
+		logger.Errorf("Failed to record enumeration start: %v", err)
+		return 0
+	}
+	return scanDBID
+}
+
+// finishEnumerationRecord stores the enumerated file list + total on the scan
+// row and flips it from 'enumerating' to 'scanning'.
+func (s *ScannerService) finishEnumerationRecord(scanDBID int64, files []string) {
+	fileListJSON, err := json.Marshal(files)
+	if err != nil {
+		logger.Errorf("Failed to serialize file list: %v", err)
+		fileListJSON = []byte("[]")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
+	defer cancel()
+	if err := s.scanRepo().FinishEnumeration(ctx, scanDBID, len(files), string(fileListJSON)); err != nil {
+		logger.Errorf("Failed to persist enumerated file list for scan %d: %v", scanDBID, err)
+	}
+}
+
+// handleEnumerationFailure maps a failed/aborted directory walk to a terminal
+// scan state, removes the scan from the in-memory active set, and returns the
+// appropriate error. It is called instead of (not in addition to)
+// finalizeScan, because the deferred finalizeScan is only registered after a
+// successful enumeration.
+func (s *ScannerService) handleEnumerationFailure(scanID string, scanDBID int64, localPath string, ctx context.Context, err error) error {
+	s.mu.Lock()
+	delete(s.activeScans, scanID)
+	s.mu.Unlock()
+
+	qctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
+	defer cancel()
+
+	switch {
+	case errors.Is(err, context.Canceled) || ctx.Err() != nil:
+		// User cancel or scanner shutdown during the walk.
+		logger.Infof("Enumeration cancelled for %s", localPath)
+		if scanDBID > 0 {
+			if _, mErr := s.scanRepo().MarkCancelled(qctx, scanDBID, "cancelled during enumeration"); mErr != nil {
+				logger.Errorf("Failed to mark scan %d cancelled: %v", scanDBID, mErr)
+			}
+		}
+		return nil
+	case errors.Is(err, context.DeadlineExceeded):
+		msg := fmt.Sprintf("enumeration timed out after %s; path %s may be on a slow or unresponsive mount", scannerEnumerationTimeout(), localPath)
+		logger.Errorf("%s", msg)
+		if scanDBID > 0 {
+			if mErr := s.scanRepo().MarkAborted(qctx, scanDBID, msg); mErr != nil {
+				logger.Errorf("Failed to mark scan %d aborted: %v", scanDBID, mErr)
+			}
+		}
+		return fmt.Errorf("%s", msg)
+	default:
+		logger.Errorf("Enumeration failed for %s: %v", localPath, err)
+		if scanDBID > 0 {
+			if mErr := s.scanRepo().MarkAborted(qctx, scanDBID, err.Error()); mErr != nil {
+				logger.Errorf("Failed to mark scan %d aborted: %v", scanDBID, mErr)
+			}
+		}
+		return err
+	}
 }
 
 // =============================================================================

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
+	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/testutil"
 )
 
@@ -4787,4 +4790,147 @@ func TestScannerService_Record_IdempotentOnDoubleRecord(t *testing.T) {
 	if second != len(files) {
 		t.Errorf("second (replay) pass rows = %d, want %d (ON CONFLICT must dedupe)", second, len(files))
 	}
+}
+
+// =============================================================================
+// Enumeration visibility / timeout / cancellation (#298 follow-up)
+// =============================================================================
+
+// scannerEnumerationTimeout reads HEALARR_SCANNER_ENUMERATION_TIMEOUT with a
+// sane default and ignores garbage.
+func TestScannerEnumerationTimeout_EnvParsing(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("HEALARR_SCANNER_ENUMERATION_TIMEOUT", "")
+		if got := scannerEnumerationTimeout(); got != defaultEnumerationTimeout {
+			t.Errorf("got %s, want default %s", got, defaultEnumerationTimeout)
+		}
+	})
+	t.Run("honors valid duration", func(t *testing.T) {
+		t.Setenv("HEALARR_SCANNER_ENUMERATION_TIMEOUT", "90s")
+		if got := scannerEnumerationTimeout(); got != 90*time.Second {
+			t.Errorf("got %s, want 90s", got)
+		}
+	})
+	t.Run("falls back on garbage", func(t *testing.T) {
+		t.Setenv("HEALARR_SCANNER_ENUMERATION_TIMEOUT", "not-a-duration")
+		if got := scannerEnumerationTimeout(); got != defaultEnumerationTimeout {
+			t.Errorf("got %s, want default %s on invalid input", got, defaultEnumerationTimeout)
+		}
+	})
+}
+
+// enumerateMediaFiles must abort promptly when its context is already
+// cancelled instead of walking the whole tree — this is what makes a user
+// cancel (or a blown enumeration timeout) actually stop a slow walk.
+func TestScannerService_EnumerateMediaFiles_HonorsCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	for i := 0; i < 20; i++ {
+		f := filepath.Join(tmpDir, fmt.Sprintf("f%02d.mkv", i))
+		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	s := &ScannerService{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the walk starts
+
+	files, err := s.enumerateMediaFiles(ctx, tmpDir)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("got %d files, want 0 (walk should abort immediately)", len(files))
+	}
+}
+
+// handleEnumerationFailure must map each failure cause to the correct terminal
+// DB state and drop the scan from the active set.
+func TestScannerService_HandleEnumerationFailure(t *testing.T) {
+	newSvc := func(t *testing.T) (*ScannerService, *sql.DB) {
+		t.Helper()
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatalf("NewTestDB: %v", err)
+		}
+		t.Cleanup(func() { db.Close() })
+		return &ScannerService{
+			db:          db,
+			activeScans: make(map[string]*ScanProgress),
+		}, db
+	}
+
+	seedEnumerating := func(t *testing.T, s *ScannerService) (string, int64) {
+		t.Helper()
+		scanID := "enum-" + t.Name()
+		s.mu.Lock()
+		s.activeScans[scanID] = &ScanProgress{ID: scanID}
+		s.mu.Unlock()
+		id, err := s.scanRepo().CreateEnumerating(context.Background(), repository.CreateScanParams{Path: "/media/tv", PathID: 1})
+		if err != nil {
+			t.Fatalf("CreateEnumerating: %v", err)
+		}
+		return scanID, id
+	}
+
+	statusOf := func(t *testing.T, db *sql.DB, id int64) string {
+		t.Helper()
+		var status string
+		if err := db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&status); err != nil {
+			t.Fatalf("read status: %v", err)
+		}
+		return status
+	}
+
+	t.Run("user cancel -> cancelled, no error returned", func(t *testing.T) {
+		s, db := newSvc(t)
+		scanID, id := seedEnumerating(t, s)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := s.handleEnumerationFailure(scanID, id, "/media/tv", ctx, context.Canceled)
+		if err != nil {
+			t.Errorf("err = %v, want nil for user cancel", err)
+		}
+		if got := statusOf(t, db, id); got != "cancelled" {
+			t.Errorf("status = %q, want cancelled", got)
+		}
+		s.mu.Lock()
+		_, stillActive := s.activeScans[scanID]
+		s.mu.Unlock()
+		if stillActive {
+			t.Error("scan still in activeScans after failure handling")
+		}
+	})
+
+	t.Run("timeout -> aborted with message", func(t *testing.T) {
+		s, db := newSvc(t)
+		scanID, id := seedEnumerating(t, s)
+
+		err := s.handleEnumerationFailure(scanID, id, "/media/tv", context.Background(), context.DeadlineExceeded)
+		if err == nil {
+			t.Error("want an error for enumeration timeout")
+		}
+		if got := statusOf(t, db, id); got != "aborted" {
+			t.Errorf("status = %q, want aborted", got)
+		}
+		var msg sql.NullString
+		_ = db.QueryRow(`SELECT error_message FROM scans WHERE id=?`, id).Scan(&msg)
+		if !msg.Valid || msg.String == "" {
+			t.Error("expected a non-empty error_message on timeout abort")
+		}
+	})
+
+	t.Run("generic walk error -> aborted", func(t *testing.T) {
+		s, db := newSvc(t)
+		scanID, id := seedEnumerating(t, s)
+
+		err := s.handleEnumerationFailure(scanID, id, "/media/tv", context.Background(), errors.New("readdir: input/output error"))
+		if err == nil {
+			t.Error("want the original error propagated")
+		}
+		if got := statusOf(t, db, id); got != "aborted" {
+			t.Errorf("status = %q, want aborted", got)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

Diagnosed live on production: a scan stuck in the directory-walk (enumeration) phase was indistinguishable from a hang.

- Only one log line ever appeared: `Starting scan for path ID N`, then silence.
- No `scans` DB row existed yet (it was created *after* enumeration), so `/scans` and the dashboard showed nothing — the System Overview said "no scan" while the user knew one was running.
- The walk ignored cancellation: pressing **Cancel** in the UI did nothing until enumeration finished (which, on a degraded mount, is "never").
- No timeout: a hung mount hung the scan forever, recoverable only by restarting the container.

Root cause of the live incident was host-side (a mergerfs-over-CIFS mount where degraded network storage made each `stat` block for seconds), but Healarr's enumeration had no defenses against it.

## Changes

1. **Visibility** — the scan row is created up front in a new `'enumerating'` state. Migration 011 extends the `scans.status` CHECK to allow `'enumerating'` and `'scanning'` — values the code *already referenced* (`ScanStatusEnumerating`, the reconcile query) but the constraint silently forbade, so they could never be persisted. The row flips to `'scanning'` once the walk completes (`FinishEnumeration` stores the file list + total).
2. **Progress** — `enumerateMediaFiles` emits a throttled heartbeat every 5s: `Enumerating PATH: N media files found so far (M entries scanned)`.
3. **Cancellation** — `enumerateMediaFiles` now takes a `context.Context` and checks `ctx.Err()` on every entry, so a user cancel aborts the walk promptly; the row is marked `'cancelled'`.
4. **Timeout** — the walk runs under `HEALARR_SCANNER_ENUMERATION_TIMEOUT` (default **30m**). On timeout the scan is marked `'aborted'` with an explanatory `error_message`.

### Reconcile interplay
An orphaned `'enumerating'` row (process died mid-walk) has `current_file_index=0` and `file_list='[]'`, so `ReconcileOrphans` marks it `'cancelled'` (not resumable) — correct, there's nothing to resume.

## Test plan
- [x] `go build ./...`, `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./internal/services/` — full suite green (50s)
- [x] `go test ./internal/repository/ ./internal/db/ ./internal/api/` — green
- [x] New repo tests: `CreateEnumerating`, `FinishEnumeration`, `ReconcileOrphans_EnumeratingGoesCancelled`
- [x] New scanner tests: enumeration-timeout env parsing, `EnumerateMediaFiles_HonorsCancellation`, `HandleEnumerationFailure` (cancel→cancelled, timeout→aborted, error→aborted)
- [x] Migration 011 applies cleanly against a fresh DB (db test suite)

## Docs
README env table + docker-compose.yml document `HEALARR_SCANNER_ENUMERATION_TIMEOUT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `HEALARR_SCANNER_ENUMERATION_TIMEOUT` configuration option (30-minute default) to prevent scans from hanging on problematic network mounts.
  * Scans now display enumeration progress during the directory-walk phase.

* **Documentation**
  * Updated configuration documentation to include the new enumeration timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->