### PR TITLE
fix(integration): normalize path separators in mapper (#305)

### DIFF
--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -2070,3 +2070,96 @@ func TestResolveHwAccelVendor_AutoMatchesHostState(t *testing.T) {
 		t.Errorf("auto on non-NVIDIA host: got %q, want vaapi or empty", got)
 	}
 }
+
+// =============================================================================
+// DetectionMethod / DetectionMode parsing + sql driver round-trip
+// =============================================================================
+
+func TestParseDetectionMethod(t *testing.T) {
+	valid := []string{"zero_byte", "ffprobe", "mediainfo", "handbrake"}
+	for _, s := range valid {
+		got, err := ParseDetectionMethod(s)
+		if err != nil {
+			t.Errorf("ParseDetectionMethod(%q) unexpected error: %v", s, err)
+		}
+		if string(got) != s {
+			t.Errorf("ParseDetectionMethod(%q) = %q", s, got)
+		}
+	}
+	for _, s := range []string{"", "FFPROBE", "ffmpeg", "bogus"} {
+		if _, err := ParseDetectionMethod(s); err == nil {
+			t.Errorf("ParseDetectionMethod(%q) expected error, got nil", s)
+		}
+	}
+}
+
+func TestParseDetectionMode(t *testing.T) {
+	for _, s := range []string{"quick", "thorough"} {
+		got, err := ParseDetectionMode(s)
+		if err != nil {
+			t.Errorf("ParseDetectionMode(%q) unexpected error: %v", s, err)
+		}
+		if string(got) != s {
+			t.Errorf("ParseDetectionMode(%q) = %q", s, got)
+		}
+	}
+	for _, s := range []string{"", "Quick", "deep", "fast"} {
+		if _, err := ParseDetectionMode(s); err == nil {
+			t.Errorf("ParseDetectionMode(%q) expected error, got nil", s)
+		}
+	}
+}
+
+func TestDetectionMethod_ScanValue(t *testing.T) {
+	// Value round-trips the underlying string.
+	v, err := DetectionFFprobe.Value()
+	if err != nil || v != "ffprobe" {
+		t.Errorf("Value() = (%v, %v), want (ffprobe, nil)", v, err)
+	}
+
+	var m DetectionMethod
+	// string source
+	if err := m.Scan("mediainfo"); err != nil || m != DetectionMediaInfo {
+		t.Errorf("Scan(string) = (%q, %v), want (mediainfo, nil)", m, err)
+	}
+	// []byte source
+	if err := m.Scan([]byte("handbrake")); err != nil || m != DetectionHandBrake {
+		t.Errorf("Scan([]byte) = (%q, %v), want (handbrake, nil)", m, err)
+	}
+	// NULL
+	if err := m.Scan(nil); err == nil {
+		t.Error("Scan(nil) expected error, got nil")
+	}
+	// wrong type
+	if err := m.Scan(42); err == nil {
+		t.Error("Scan(int) expected error, got nil")
+	}
+	// invalid string value
+	if err := m.Scan("nope"); err == nil {
+		t.Error("Scan(invalid) expected error, got nil")
+	}
+}
+
+func TestDetectionMode_ScanValue(t *testing.T) {
+	v, err := DetectionMode(ModeThorough).Value()
+	if err != nil || v != "thorough" {
+		t.Errorf("Value() = (%v, %v), want (thorough, nil)", v, err)
+	}
+
+	var mode DetectionMode
+	if err := mode.Scan("quick"); err != nil || string(mode) != "quick" {
+		t.Errorf("Scan(string) = (%q, %v), want (quick, nil)", mode, err)
+	}
+	if err := mode.Scan([]byte("thorough")); err != nil || string(mode) != "thorough" {
+		t.Errorf("Scan([]byte) = (%q, %v), want (thorough, nil)", mode, err)
+	}
+	if err := mode.Scan(nil); err == nil {
+		t.Error("Scan(nil) expected error, got nil")
+	}
+	if err := mode.Scan(3.14); err == nil {
+		t.Error("Scan(float) expected error, got nil")
+	}
+	if err := mode.Scan("ultra"); err == nil {
+		t.Error("Scan(invalid) expected error, got nil")
+	}
+}

--- a/internal/integration/path_mapper.go
+++ b/internal/integration/path_mapper.go
@@ -63,6 +63,31 @@ func hasSepPrefix(s string) bool {
 	return strings.ContainsRune(pathSeparators, rune(s[0]))
 }
 
+// dominantSeparator returns the path separator that p is written in: backslash
+// if p uses backslashes and no forward slashes (a native Windows path like
+// D:\Media\Movies), forward slash otherwise. The forward-slash default covers
+// Linux/macOS (where Healarr containers run) and any mixed/ambiguous input.
+func dominantSeparator(p string) byte {
+	if strings.Contains(p, "\\") && !strings.Contains(p, "/") {
+		return '\\'
+	}
+	return '/'
+}
+
+// normalizeRemainder rewrites the separators in an *arr-supplied path
+// remainder to match the target path's separator convention. Sonarr/Radarr
+// running on Windows report paths with backslashes; when the mapped local
+// path is a Linux path (the container default), those backslashes must become
+// forward slashes or downstream filesystem ops (stat/open) and the scan-path
+// matcher treat the whole tail as one nonsensical filename
+// (e.g. stat "/media/Movies\Show\file.mkv": invalid argument). Closes #305.
+func normalizeRemainder(remainder string, target string) string {
+	if dominantSeparator(target) == '\\' {
+		return strings.ReplaceAll(remainder, "/", "\\")
+	}
+	return strings.ReplaceAll(remainder, "\\", "/")
+}
+
 func (pm *SQLPathMapper) Reload() error {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -109,7 +134,7 @@ func (pm *SQLPathMapper) ToArrPath(localPath string) (string, error) {
 	}
 
 	relPath := strings.TrimPrefix(localPath, bestMatch.LocalPath)
-	return bestMatch.ArrPath + relPath, nil
+	return bestMatch.ArrPath + normalizeRemainder(relPath, bestMatch.ArrPath), nil
 }
 
 func (pm *SQLPathMapper) ToLocalPath(arrPath string) (string, error) {
@@ -137,5 +162,5 @@ func (pm *SQLPathMapper) ToLocalPath(arrPath string) (string, error) {
 	}
 
 	relPath := strings.TrimPrefix(arrPath, bestMatch.ArrPath)
-	return bestMatch.LocalPath + relPath, nil
+	return bestMatch.LocalPath + normalizeRemainder(relPath, bestMatch.LocalPath), nil
 }

--- a/internal/integration/path_mapper_test.go
+++ b/internal/integration/path_mapper_test.go
@@ -696,3 +696,145 @@ func TestPathMapper_ToArrPath_WindowsUNC(t *testing.T) {
 		t.Errorf("ToArrPath(%q) = %q, want %q", in, got, in)
 	}
 }
+
+// =============================================================================
+// Mixed-separator normalization (regression for #305)
+// =============================================================================
+//
+// A Windows Sonarr/Radarr reports a file path that mixes the *arr-path prefix
+// (configured in Healarr with forward slashes, e.g. /media/Movies) with a
+// backslash remainder from the Windows host:
+//
+//   /media/Movies\Angels And Demons (2009)\Angels & Demons (2009).mkv
+//
+// #299 made the prefix MATCH across separators, but the backslashes survived
+// into the mapped local path, so the scan-path-config lookup (which only
+// accepts '/' boundaries) missed and the filesystem stat failed with
+// "invalid argument". ToLocalPath must now normalize the remainder to the
+// local path's separator.
+
+func TestPathMapper_ToLocalPath_NormalizesWindowsRemainder(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	// Linux-style local path, *arr path also forward-slash (Radarr remote path
+	// mapping presents /media/Movies) — but the Windows host appends a
+	// backslash remainder.
+	seedScanPath(db, 1, "/media/Movies", "/media/Movies", false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		arrPath string
+		want    string
+	}{
+		{
+			"exact #305 case",
+			`/media/Movies\Angels And Demons (2009)\Angels & Demons (2009) {edition-Extended Cut}.mkv`,
+			"/media/Movies/Angels And Demons (2009)/Angels & Demons (2009) {edition-Extended Cut}.mkv",
+		},
+		{
+			"all backslashes after prefix",
+			`/media/Movies\A\B\C.mkv`,
+			"/media/Movies/A/B/C.mkv",
+		},
+		{
+			"already-forward-slash is unchanged",
+			"/media/Movies/Clean/file.mkv",
+			"/media/Movies/Clean/file.mkv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pm.ToLocalPath(tt.arrPath)
+			if err != nil {
+				t.Errorf("ToLocalPath(%q) error = %v", tt.arrPath, err)
+			}
+			if got != tt.want {
+				t.Errorf("ToLocalPath(%q)\n  = %q\n  want %q", tt.arrPath, got, tt.want)
+			}
+		})
+	}
+}
+
+// When the LOCAL side is a native Windows path (a Windows Healarr install),
+// a forward-slash remainder from a Linux-y *arr path must be normalized to
+// backslashes so the Windows filesystem can open it.
+func TestPathMapper_ToLocalPath_NormalizesToWindowsLocal(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	// Local path is Windows-native; arr path is forward-slash.
+	seedScanPath(db, 1, `D:\Media\Movies`, "/data/movies", false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	got, err := pm.ToLocalPath("/data/movies/Show/file.mkv")
+	if err != nil {
+		t.Fatalf("ToLocalPath error = %v", err)
+	}
+	want := `D:\Media\Movies\Show\file.mkv`
+	if got != want {
+		t.Errorf("ToLocalPath = %q, want %q", got, want)
+	}
+}
+
+// ToArrPath is the reverse: a Linux local path mapping to a Windows *arr must
+// present the remainder with backslashes so the Windows *arr recognizes it.
+func TestPathMapper_ToArrPath_NormalizesToWindowsArr(t *testing.T) {
+	db, err := newTestDBForPathMapper()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	seedScanPath(db, 1, "/media/Movies", `\\nas\Movies`, false, false)
+
+	pm, err := NewPathMapper(db)
+	if err != nil {
+		t.Fatalf("NewPathMapper() error = %v", err)
+	}
+
+	got, err := pm.ToArrPath("/media/Movies/Show/file.mkv")
+	if err != nil {
+		t.Fatalf("ToArrPath error = %v", err)
+	}
+	want := `\\nas\Movies\Show\file.mkv`
+	if got != want {
+		t.Errorf("ToArrPath = %q, want %q", got, want)
+	}
+}
+
+// Unit coverage for the separator helpers.
+func TestDominantSeparator(t *testing.T) {
+	cases := []struct {
+		in   string
+		want byte
+	}{
+		{"/media/Movies", '/'},
+		{`D:\Media\Movies`, '\\'},
+		{`\\nas\share`, '\\'},
+		{"", '/'},              // default
+		{`/media/My\Odd`, '/'}, // has '/', so forward slash wins
+		{"relativepath", '/'},  // no separator -> default
+	}
+	for _, c := range cases {
+		if got := dominantSeparator(c.in); got != c.want {
+			t.Errorf("dominantSeparator(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #305.

## Problem

The same Windows user from #298 reported that after the UNC path-matching fix (#299), webhook scans still failed:

```
Could not determine scan path config for /media/Movies\Angels And Demons (2009)\...: no matching scan path found
Recoverable error ... stat /media/Movies\Angels And Demons (2009)\...: invalid argument
```

#299 made the matcher *accept* a backslash boundary, but the backslashes **survived into the mapped local path**. On a Linux container that breaks two things:
1. The scan-path-config lookup (`scanner.go:2410`) only accepts `/` boundaries → "no matching scan path found".
2. The filesystem `stat` treats `\` as a literal filename char → `invalid argument`.

Full scans worked because they enumerate the Linux FS directly (clean forward slashes); only the webhook path, sourced from the Windows *arr, carried backslashes.

## Fix

Normalize the mapped remainder to the **target path's** separator convention in both `ToLocalPath` and `ToArrPath`:
- target is a Linux path (container default) → backslashes become forward slashes
- target is a native Windows path → forward slashes become backslashes

`dominantSeparator(p)` picks the convention from the target path (backslash only if it uses `\` and no `/`), defaulting to `/`.

## Coverage

Also adds tests for `ParseDetectionMethod`/`ParseDetectionMode` and their `sql.Scanner`/`driver.Valuer` impls (previously 0%, in the new-code window) to restore the SonarCloud new-code coverage gate (was 79.6%, threshold 80%).

## Test plan
- [x] `go build ./...`, `golangci-lint run ./internal/... ./cmd/...` — 0 issues
- [x] New tests: exact #305 case, all-backslash remainder, already-clean path, Windows-local target, Windows-arr target (`ToArrPath`), `dominantSeparator` unit table
- [x] Existing UNC tests (#299) still pass
- [x] DetectionMethod/Mode parser + Scan/Value tests (flip ~50 lines 0%→100%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization to properly handle mixed forward and backslash separators when mapping paths across Windows and Linux platforms.

* **Tests**
  * Added comprehensive test coverage for detection parsing and path-separator normalization across different platform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->