### PR TITLE
fix(dashboard): reflect partial scans in 'last scan'

### DIFF
--- a/internal/api/handlers_stats.go
+++ b/internal/api/handlers_stats.go
@@ -77,7 +77,7 @@ func (s *RESTServer) getDashboardStats(c *gin.Context) {
 	}
 
 	// Query 4: Last completed scan info
-	last, err := s.scans.GetLastCompletedScan(c.Request.Context())
+	last, err := s.scans.GetLastScan(c.Request.Context())
 	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		warnings = append(warnings, "failed to query last scan")
 		logger.Debugf("Failed to query last scan: %v", err)
@@ -197,7 +197,7 @@ func (s *RESTServer) getPathHealth(c *gin.Context) {
 
 // loadPathLastScan queries the last completed scan for a given path, returning nullable ID and time.
 func (s *RESTServer) loadPathLastScan(ctx context.Context, pathID int64) (*int, *string) {
-	last, err := s.scans.GetLastCompletedScanByPathID(ctx, pathID)
+	last, err := s.scans.GetLastScanByPathID(ctx, pathID)
 	if err != nil {
 		return nil, nil
 	}

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -138,36 +138,49 @@ func (r *ScanRepository) GetScanStats(ctx context.Context) (ScanStats, error) {
 	return s, nil
 }
 
-// GetLastCompletedScan returns the most recent completed scan globally.
+// GetLastScan returns the most recent scan that processed at least one file,
+// regardless of whether it ran to completion. The dashboard "Last Scan" card
+// and per-path "last scanned" use this: a scan that checked thousands of
+// files before being cancelled or interrupted is real scan activity and
+// should be reflected, where the old completed-only query left the dashboard
+// saying "Never scanned" while /scans clearly listed the scan. The
+// files_scanned > 0 filter excludes scans cancelled during enumeration (0
+// files), which genuinely scanned nothing. Active scans (running / scanning /
+// enumerating / paused / pending) are excluded too — a scan still in flight
+// belongs in the active-scans indicator, not "last scan". The reported time
+// is completed_at when the scan reached a terminal state, otherwise
+// started_at.
 // Returns ErrNotFound when no completed scan exists.
-func (r *ScanRepository) GetLastCompletedScan(ctx context.Context) (LastScan, error) {
+func (r *ScanRepository) GetLastScan(ctx context.Context) (LastScan, error) {
 	var l LastScan
 	err := r.db.QueryRowContext(ctx, `
-		SELECT id, completed_at, path
+		SELECT id, COALESCE(completed_at, started_at), path
 		FROM scans
-		WHERE status = 'completed' AND completed_at IS NOT NULL
-		ORDER BY completed_at DESC
+		WHERE files_scanned > 0
+		  AND status NOT IN ('pending', 'running', 'scanning', 'enumerating', 'paused')
+		ORDER BY COALESCE(completed_at, started_at) DESC
 		LIMIT 1
 	`).Scan(&l.ID, &l.CompletedAt, &l.Path)
 	if errors.Is(err, sql.ErrNoRows) {
 		return LastScan{}, ErrNotFound
 	}
 	if err != nil {
-		return LastScan{}, fmt.Errorf("query last completed scan: %w", err)
+		return LastScan{}, fmt.Errorf("query last scan: %w", err)
 	}
 	return l, nil
 }
 
-// GetLastCompletedScanByPathID returns the most recent completed scan
-// for a specific scan_path. Path is left zero-valued (the caller usually
-// knows the path already). Returns ErrNotFound when none exists.
-func (r *ScanRepository) GetLastCompletedScanByPathID(ctx context.Context, pathID int64) (LastScan, error) {
+// GetLastScanByPathID returns the most recent scan for a specific scan_path
+// that processed at least one file. Path is left zero-valued (the caller
+// usually knows the path already). Returns ErrNotFound when none exists.
+func (r *ScanRepository) GetLastScanByPathID(ctx context.Context, pathID int64) (LastScan, error) {
 	var l LastScan
 	err := r.db.QueryRowContext(ctx, `
-		SELECT id, completed_at
+		SELECT id, COALESCE(completed_at, started_at)
 		FROM scans
-		WHERE path_id = ? AND status = 'completed' AND completed_at IS NOT NULL
-		ORDER BY completed_at DESC
+		WHERE path_id = ? AND files_scanned > 0
+		  AND status NOT IN ('pending', 'running', 'scanning', 'enumerating', 'paused')
+		ORDER BY COALESCE(completed_at, started_at) DESC
 		LIMIT 1
 	`, pathID).Scan(&l.ID, &l.CompletedAt)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -163,49 +163,76 @@ func TestScanRepository_GetScanStats(t *testing.T) {
 	}
 }
 
-func TestScanRepository_GetLastCompletedScan(t *testing.T) {
+func TestScanRepository_GetLastScan(t *testing.T) {
 	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
-	seedScan(t, db, "/older", "completed", 0, 0, "2026-05-01 00:00:00")
-	seedScan(t, db, "/newer", "completed", 0, 0, "2026-05-10 00:00:00")
-	seedScan(t, db, "/running", "running", 0, 0, "")
+	seedScan(t, db, "/older", "completed", 10, 0, "2026-05-01 00:00:00")
+	seedScan(t, db, "/newer", "completed", 20, 0, "2026-05-10 00:00:00")
+	seedScan(t, db, "/running", "running", 5, 0, "")
 
-	last, err := repo.GetLastCompletedScan(context.Background())
+	last, err := repo.GetLastScan(context.Background())
 	if err != nil {
-		t.Fatalf("GetLastCompletedScan: %v", err)
+		t.Fatalf("GetLastScan: %v", err)
 	}
 	if !last.Path.Valid || last.Path.String != "/newer" {
 		t.Errorf("Path = %+v, want /newer", last.Path)
 	}
 }
 
-func TestScanRepository_GetLastCompletedScan_empty(t *testing.T) {
-	t.Parallel()
-	repo := NewScanRepository(newScanTestDB(t))
-	if _, err := repo.GetLastCompletedScan(context.Background()); !errors.Is(err, ErrNotFound) {
-		t.Errorf("empty DB = %v, want ErrNotFound", err)
-	}
-}
-
-func TestScanRepository_GetLastCompletedScanByPathID(t *testing.T) {
+// The reported bug: a scan that processed thousands of files before being
+// cancelled is real scan activity, but the old completed-only query ignored
+// it, leaving the dashboard saying "Never scanned" while /scans listed it.
+// GetLastScan must return such a scan.
+func TestScanRepository_GetLastScan_CountsCancelledWithFiles(t *testing.T) {
 	t.Parallel()
 	db := newScanTestDB(t)
 	repo := NewScanRepository(db)
-	// Two paths, two completed scans each — the per-path query should pick
-	// the newer one for the queried path, not the global newest.
+	// A cancelled scan that scanned 4031 files (exactly the prod scenario).
+	seedScan(t, db, "/media/TV", "cancelled", 4031, 0, "2026-06-03 16:31:10")
+	// A later cancelled scan that scanned 0 files (cancelled during
+	// enumeration) must NOT win — it scanned nothing.
+	seedScan(t, db, "/media/Movies/HD", "cancelled", 0, 0, "2026-06-05 09:31:42")
+
+	last, err := repo.GetLastScan(context.Background())
+	if err != nil {
+		t.Fatalf("GetLastScan: %v", err)
+	}
+	if !last.Path.Valid || last.Path.String != "/media/TV" {
+		t.Errorf("Path = %+v, want /media/TV (the cancelled scan that scanned 4031 files)", last.Path)
+	}
+}
+
+func TestScanRepository_GetLastScan_empty(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	// A scan that scanned zero files does not count as scan activity.
+	seedScan(t, db, "/zero", "cancelled", 0, 0, "2026-05-01 00:00:00")
+	if _, err := repo.GetLastScan(context.Background()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("no scan with files = %v, want ErrNotFound", err)
+	}
+}
+
+func TestScanRepository_GetLastScanByPathID(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	// Two paths; the per-path query should pick the newer scan-with-files for
+	// the queried path, not the global newest. The middle row is cancelled
+	// but scanned files, so it still counts.
 	if _, err := db.Exec(`
-		INSERT INTO scans (path, path_id, status, completed_at) VALUES
-		('/a', 1, 'completed', '2026-05-01 00:00:00'),
-		('/a', 1, 'completed', '2026-05-05 00:00:00'),
-		('/b', 2, 'completed', '2026-05-10 00:00:00')
+		INSERT INTO scans (path, path_id, status, files_scanned, completed_at) VALUES
+		('/a', 1, 'completed', 100, '2026-05-01 00:00:00'),
+		('/a', 1, 'cancelled', 250, '2026-05-05 00:00:00'),
+		('/b', 2, 'completed', 300, '2026-05-10 00:00:00')
 	`); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
-	last, err := repo.GetLastCompletedScanByPathID(context.Background(), 1)
+	last, err := repo.GetLastScanByPathID(context.Background(), 1)
 	if err != nil {
-		t.Fatalf("GetLastCompletedScanByPathID: %v", err)
+		t.Fatalf("GetLastScanByPathID: %v", err)
 	}
 	// modernc.org/sqlite normalizes timestamps to RFC3339-ish form
 	// (2026-05-05T00:00:00Z); just check the date portion to keep the test


### PR DESCRIPTION
## Problem

The System Overview showed **"Never scanned" / "No scans yet"** even when `/scans` clearly listed scans — a confusing contradiction reported from production. Root cause: `GetLastCompletedScan` (and the per-path variant, both used only by the dashboard) filtered `status = 'completed'`. On the affected instance, all three scans were `cancelled` — but scan 1 had processed **4031 files** of `/media/TV` before cancellation. That's real scan activity the dashboard ignored.

## Fix

Renamed to `GetLastScan` / `GetLastScanByPathID` and broadened the query: return the most recent scan that processed at least one file (`files_scanned > 0`), in any terminal state.

- Scans cancelled **during enumeration** (0 files) are excluded — they scanned nothing.
- **Active** scans (running/scanning/enumerating/paused/pending) are excluded — an in-flight scan belongs in the active-scans indicator, not "last scan".
- Displayed time is `completed_at` for terminal scans, else `started_at`.

No frontend change needed: the "Last Scan" card already renders `last_scan_time`/`path` when present — they were simply absent before.

## Test plan
- [x] `go build`, `golangci-lint` — 0 issues
- [x] Simulated against the exact prod data shape: `/media/TV` cancelled-at-4031-files now surfaces as last scan
- [x] New `TestScanRepository_GetLastScan_CountsCancelledWithFiles` (the bug), `_empty` (0-file scans don't count), `GetLastScanByPathID`, plus the running-scan-excluded case
- [x] Existing dashboard handler tests (`TestGetDashboardStats_LastScan_*`) still pass