### PR TITLE
feat(scanner): log completion of single-file (webhook) scans (#305)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -830,42 +830,47 @@ func (s *ScannerService) ScanFile(localPath string) error {
 	progress.FilesDone = 1
 	s.emitProgress(progress)
 
-	if !healthy {
-		// CRITICAL: Check if this is a recoverable error (mount lost, NAS offline, etc.)
-		if healthErr.IsRecoverable() {
-			logger.Infof("Recoverable error for file %s (Type: %s): %s - will NOT trigger remediation",
-				localPath, healthErr.Type, healthErr.Message)
-			// Don't emit corruption event for recoverable errors
-			return nil
-		}
+	if healthy {
+		// Explicit success line so a single-file (webhook) scan visibly
+		// confirms completion in the log, instead of ending silently after
+		// "Scanning single file". Requested in #305.
+		logger.Infof("Scan completed for file: %s (healthy)", localPath)
+		return nil
+	}
 
-		// This is TRUE corruption - emit event for remediation
-		logger.Infof("Corruption detected in file: %s (Type: %s)", localPath, healthErr.Type)
+	// CRITICAL: Check if this is a recoverable error (mount lost, NAS offline, etc.)
+	if healthErr.IsRecoverable() {
+		logger.Infof("Recoverable error for file %s (Type: %s): %s - will NOT trigger remediation",
+			localPath, healthErr.Type, healthErr.Message)
+		// Don't emit corruption event for recoverable errors
+		return nil
+	}
 
-		// DEDUPLICATION: Check if this file already has an active corruption record
-		if s.hasActiveCorruption(localPath) {
-			logger.Infof("Skipping duplicate corruption for file already being processed: %s", localPath)
-			return nil
-		}
+	// This is TRUE corruption - emit event for remediation
+	logger.Infof("Corruption detected in file: %s (Type: %s)", localPath, healthErr.Type)
 
-		// Emit event - critical entry point for remediation journey, use retry
-		err := s.eventBus.PublishWithRetry(domain.Event{
-			AggregateType: "corruption",
-			AggregateID:   uuid.New().String(),
-			EventType:     domain.CorruptionDetected,
-			EventData: map[string]interface{}{
-				"file_path":       localPath,
-				"file_size":       fileSize,
-				"corruption_type": healthErr.Type,
-				"error_details":   healthErr.Message,
-				"source":          "webhook",
-				"auto_remediate":  autoRemediate,
-				"dry_run":         dryRun,
-			},
-		})
-		if err != nil {
-			return err
-		}
+	// DEDUPLICATION: Check if this file already has an active corruption record
+	if s.hasActiveCorruption(localPath) {
+		logger.Infof("Skipping duplicate corruption for file already being processed: %s", localPath)
+		return nil
+	}
+
+	// Emit event - critical entry point for remediation journey, use retry
+	if err := s.eventBus.PublishWithRetry(domain.Event{
+		AggregateType: "corruption",
+		AggregateID:   uuid.New().String(),
+		EventType:     domain.CorruptionDetected,
+		EventData: map[string]interface{}{
+			"file_path":       localPath,
+			"file_size":       fileSize,
+			"corruption_type": healthErr.Type,
+			"error_details":   healthErr.Message,
+			"source":          "webhook",
+			"auto_remediate":  autoRemediate,
+			"dry_run":         dryRun,
+		},
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4934,3 +4934,54 @@ func TestScannerService_HandleEnumerationFailure(t *testing.T) {
 		}
 	})
 }
+
+// TestScannerService_ScanFile_Healthy covers the healthy early-return branch
+// added in #305: a healthy single-file (webhook) scan returns nil, emits no
+// corruption event, and counts the file as done.
+func TestScannerService_ScanFile_Healthy(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	tmpDir := t.TempDir()
+	if _, err := db.Exec(`
+		INSERT INTO scan_paths (local_path, arr_path, enabled, auto_remediate, dry_run)
+		VALUES (?, ?, 1, 0, 0)
+	`, tmpDir, tmpDir); err != nil {
+		t.Fatalf("Failed to insert scan path: %v", err)
+	}
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			return true, nil // healthy
+		},
+	}
+	scanner := NewScannerService(db, eb, mockHC, nil)
+
+	testFile := filepath.Join(tmpDir, "healthy.mkv")
+	if err := os.WriteFile(testFile, []byte("good content"), 0644); err != nil {
+		t.Fatalf("Failed to create file: %v", err)
+	}
+
+	if err := scanner.ScanFile(testFile); err != nil {
+		t.Errorf("ScanFile(healthy) returned error: %v", err)
+	}
+
+	// No corruption event should be emitted for a healthy file.
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM events
+		WHERE event_type = 'CorruptionDetected'
+		AND json_extract(event_data, '$.file_path') = ?
+	`, testFile).Scan(&count); err != nil {
+		t.Fatalf("Failed to query events: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("healthy file emitted %d corruption events, want 0", count)
+	}
+}


### PR DESCRIPTION
Follow-up to the #305 thread. The path-separator fix (v1.3.9) works, and alex882001 asked for a small UX touch: a log line confirming a single-file/webhook scan **completed**, since today it logs "started" and "scanning" then ends silently on success.

## Change
Adds `Scan completed for file: X (healthy)` on the healthy path of `ScanFile`. Restructured the healthy case as an early return (which also de-nests the corruption branch). No behavior change beyond the new log line.

## Test plan
- [x] `go build`, `golangci-lint run ./internal/services/` — 0 issues
- [x] New `TestScannerService_ScanFile_Healthy` — healthy file returns nil, emits no corruption event
- [x] Existing ScanFile tests (corruption / recoverable / duplicate) still pass