### PR TITLE
test(api): fix path-health test seed after GetLastScan change

### DIFF
--- a/internal/api/handlers_stats_test.go
+++ b/internal/api/handlers_stats_test.go
@@ -1209,15 +1209,15 @@ func TestGetPathHealth_WithScansAndCorruptions(t *testing.T) {
 	}
 
 	// Insert completed scans for each path
-	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, completed_at) VALUES (1, '/healthy', 'completed', '2026-01-10 10:00:00')`)
+	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, files_scanned, completed_at) VALUES (1, '/healthy', 'completed', 100, '2026-01-10 10:00:00')`)
 	if err != nil {
 		t.Fatalf("Failed to insert scan: %v", err)
 	}
-	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, completed_at) VALUES (2, '/warning', 'completed', '2026-01-10 09:00:00')`)
+	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, files_scanned, completed_at) VALUES (2, '/warning', 'completed', 100, '2026-01-10 09:00:00')`)
 	if err != nil {
 		t.Fatalf("Failed to insert scan: %v", err)
 	}
-	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, completed_at) VALUES (3, '/critical', 'completed', '2026-01-10 08:00:00')`)
+	_, err = db.Exec(`INSERT INTO scans (path_id, path, status, files_scanned, completed_at) VALUES (3, '/critical', 'completed', 100, '2026-01-10 08:00:00')`)
 	if err != nil {
 		t.Fatalf("Failed to insert scan: %v", err)
 	}


### PR DESCRIPTION
CI failed on the v1.3.10 release commit: `TestGetPathHealth_WithScansAndCorruptions` seeds completed scans with no `files_scanned` (defaulting to 0). #317 changed the dashboard "last scan" queries to require `files_scanned > 0` (so a scan that scanned nothing doesn't count as activity), which correctly excluded those 0-file seeds — breaking the test's last_scan + derived-health assertions.

Test-only fix: seed `files_scanned = 100` so the scans represent real activity. **The v1.3.10 binary is unchanged** (the failure was a stale test fixture, not a code bug).

Missed locally because I ran only `-run 'Stats|Dashboard'`; the full `./internal/api/` run catches it.

## Test plan
- [x] `go test ./internal/api/` — full package green
- [x] `go test ./internal/services/ ./internal/repository/` — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for path health statistics validation by expanding test data seeding with additional scan metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->