### PR TITLE
fix(integration): match Windows UNC paths when finding the *arr instance (#322)

### DIFF
--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -318,17 +318,26 @@ type HistoryResponse struct {
 // isValidPathMatch checks if filePath starts with rootPath followed by "/" or end of string.
 // This prevents "/data/movies" from matching "/data/movies-archive".
 func isValidPathMatch(rootPath, filePath string) bool {
-	rootPath = strings.TrimRight(rootPath, "/")
+	// Accept both / and \ as separators so a Windows *arr's UNC path
+	// (\\server\share\Movies\film.mkv) matches its configured root the same
+	// way a Linux path does. Without this, remediation on a Windows host
+	// fails to find the owning instance ("no instance found for path") even
+	// though detection worked. Same separator class of bug as #305, here in
+	// the instance-ownership matcher. trimTrailingSep / hasSepPrefix are the
+	// shared helpers from path_mapper.go.
+	rootPath = trimTrailingSep(rootPath)
 	if !strings.HasPrefix(filePath, rootPath) {
 		return false
 	}
 	remainder := filePath[len(rootPath):]
-	return remainder == "" || strings.HasPrefix(remainder, "/")
+	return remainder == "" || hasSepPrefix(remainder)
 }
 
-// normalizedPathLength returns the length of rootPath after trimming trailing slashes.
+// normalizedPathLength returns the length of rootPath after trimming trailing
+// separators (both / and \), so the longest-prefix tie-break is consistent
+// regardless of the path's separator style.
 func normalizedPathLength(rootPath string) int {
-	return len(strings.TrimRight(rootPath, "/"))
+	return len(trimTrailingSep(rootPath))
 }
 
 func (c *HTTPArrClient) getInstanceForPath(arrPath string) (*ArrInstance, error) {

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -5502,6 +5502,13 @@ func TestIsValidPathMatch(t *testing.T) {
 		{"no match prefix only", "/data/movie", "/data/movies/movie.mkv", false},
 		{"root path match", "/", "/anything/here", true},
 		{"empty file path", "/data/movies", "", false},
+		// Windows UNC paths (regression for #322): a Windows *arr reports
+		// backslash-separated UNC paths; the matcher must accept them.
+		{"UNC exact match", `\\srv\media\TV Shows`, `\\srv\media\TV Shows`, true},
+		{"UNC subpath match", `\\srv\media\TV Shows`, `\\srv\media\TV Shows\Show\S02E08.mkv`, true},
+		{"UNC trailing backslash root", `\\srv\media\TV Shows\`, `\\srv\media\TV Shows\Show\ep.mkv`, true},
+		{"UNC no match partial name", `\\srv\media\Movies`, `\\srv\media\MoviesArchive\film.mkv`, false},
+		{"UNC no match different share", `\\srv\media\Movies`, `\\srv\media\TV\show.mkv`, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #322.

## Problem

Auto-remediation on a Windows host failed:
```
Corruption detected in file: /media/TV Shows/Accused (US)/Season 2/Accused (US) - S02E08.mkv (Type: CorruptHeader)
Auto-remediation enabled ... proceeding immediately
Failed to find media for path \\alexpr4100\media\TV Shows\...: no instance found for path: \\alexpr4100\media\TV Shows\...
```

Detection worked (clean `/media/...` local path), and `ToArrPath` correctly produced the Windows UNC arr-path. But `getInstanceForPath` → `isValidPathMatch` only trimmed trailing `/` and only accepted `/` as a directory boundary, so the backslash UNC path never matched the instance's configured root folder → remediation gave up.

This is the **same separator bug as #305**, in a different matcher (instance ownership rather than path translation), and it broke auto-remediation entirely for Windows users.

## Fix

`isValidPathMatch` and `normalizedPathLength` now use the shared `trimTrailingSep` / `hasSepPrefix` helpers (from `path_mapper.go`, same package), so `/` and `\` are both treated as separators. `\\srv\media\Movies` still doesn't false-match `\\srv\media\MoviesArchive`.

## Test plan
- [x] `go build`, `golangci-lint run ./internal/integration/` — 0 issues
- [x] `TestIsValidPathMatch` extended with 5 UNC cases (exact, subpath = the #322 scenario, trailing-backslash root, partial-name boundary, different-share); all existing forward-slash cases still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path-ownership matching to correctly handle paths using either forward slashes or backward slashes, ensuring consistent and reliable matching behavior across different path separator styles and platforms.
  * Improved Windows path validation with enhanced support for UNC paths and corrected handling of trailing separators for more accurate path comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->