### PR TITLE
fix(db): apply SQLite pragmas to all pool connections; quiet watermark BUSY (#321)

### DIFF
--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -51,7 +51,17 @@ func NewRepository(dbPath string) (*Repository, error) {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
+	// Apply connection-level pragmas through the DSN so EVERY pooled
+	// connection gets them. Setting them later with db.Exec only configures
+	// the single connection that happens to serve that call; the other pool
+	// connections kept busy_timeout=0 (immediate SQLITE_BUSY instead of
+	// waiting), foreign_keys=OFF and synchronous=FULL. The busy_timeout gap
+	// is what surfaced as "database is locked" on the parallel scan's
+	// watermark writer (#321): whichever of the 4 connections it landed on
+	// usually wasn't the one configured. modernc.org/sqlite runs each
+	// _pragma on connection open. journal_mode is database-level (persists in
+	// the file) but harmless to assert here too.
+	db, err := sql.Open("sqlite", dbPath+pragmaDSNSuffix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
@@ -99,47 +109,39 @@ func NewRepository(dbPath string) (*Repository, error) {
 	return repo, nil
 }
 
-// configureSQLite sets optimal SQLite pragmas for reliability and performance
+// pragmaDSNSuffix carries the connection-level pragmas appended to the DSN so
+// modernc.org/sqlite applies them on EVERY pooled connection, not just the one
+// a later db.Exec("PRAGMA ...") happens to land on. Each pragma:
+//   - busy_timeout(30000): wait up to 30s for a lock instead of returning
+//     SQLITE_BUSY immediately. This is the #321 fix — without it on every
+//     connection, the parallel scan's watermark writer saw "database is
+//     locked".
+//   - journal_mode(WAL): concurrent readers + one writer. Database-level and
+//     persistent, but asserted here so a fresh file gets it on first open.
+//   - foreign_keys(1): enforce FK constraints (off by default per connection).
+//   - synchronous(NORMAL): WAL-safe, avoids the per-commit fsync FULL pays on
+//     the write-heavy scan path; only risks the last txn on OS crash/power
+//     loss, recoverable since scans re-run and the event store replays.
+//   - temp_store(MEMORY) / cache_size(-8000): per-connection performance knobs.
+const pragmaDSNSuffix = "?_pragma=busy_timeout(30000)" +
+	"&_pragma=journal_mode(WAL)" +
+	"&_pragma=foreign_keys(1)" +
+	"&_pragma=synchronous(NORMAL)" +
+	"&_pragma=temp_store(MEMORY)" +
+	"&_pragma=cache_size(-8000)"
+
+// configureSQLite sets the database-level pragmas that aren't carried in the
+// DSN. Connection-level pragmas (busy_timeout, journal_mode, foreign_keys,
+// synchronous, temp_store, cache_size) are applied to every pooled connection
+// via pragmaDSNSuffix instead — see #321.
 func configureSQLite(db *sql.DB) error {
-	// Critical pragmas that must succeed for proper database operation
-	criticalPragmas := []string{
-		// WAL mode for better concurrency and crash recovery
-		"PRAGMA journal_mode=WAL",
-		// Enable foreign key constraints
-		"PRAGMA foreign_keys=ON",
-		// Busy timeout of 30 seconds to handle concurrent access during heavy scans
-		"PRAGMA busy_timeout=30000",
+	// auto_vacuum is a database-level property (persisted in the file header);
+	// setting it once is sufficient. INCREMENTAL reclaims freed pages on
+	// demand without the full-rewrite cost of auto_vacuum=FULL.
+	if _, err := db.Exec("PRAGMA auto_vacuum=INCREMENTAL"); err != nil {
+		// Non-fatal: only affects space reclamation, not correctness.
+		logger.Debugf("Failed to set auto_vacuum pragma: %v", err)
 	}
-
-	for _, pragma := range criticalPragmas {
-		if _, err := db.Exec(pragma); err != nil {
-			return fmt.Errorf("failed to set critical pragma %s: %w", pragma, err)
-		}
-	}
-
-	// Non-critical pragmas - log failures but continue
-	optionalPragmas := []string{
-		// synchronous=NORMAL is the recommended setting with WAL: it is fully
-		// corruption-safe (WAL guarantees database integrity at NORMAL), and only
-		// risks losing the last committed transaction(s) on an OS crash / power
-		// loss — recoverable here since scans re-run and the event store replays.
-		// It avoids the per-commit fsync that FULL pays on the write-heavy scan path.
-		"PRAGMA synchronous=NORMAL",
-		// Auto-vacuum in incremental mode - reclaims space automatically
-		"PRAGMA auto_vacuum=INCREMENTAL",
-		// Store temp tables in memory for performance
-		"PRAGMA temp_store=MEMORY",
-		// Increase cache size (negative = KB, so -8000 = 8MB)
-		"PRAGMA cache_size=-8000",
-	}
-
-	for _, pragma := range optionalPragmas {
-		if _, err := db.Exec(pragma); err != nil {
-			// Log but don't fail - some pragmas may not be supported
-			logger.Debugf("Failed to set optional pragma %s: %v", pragma, err)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -1955,30 +1955,49 @@ func TestConfigureSQLite_AllPragmas(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	dbPath := filepath.Join(tmpDir, "test.db")
-	db, err := sql.Open("sqlite", dbPath)
+	// Open exactly as NewRepository does: connection-level pragmas ride on the
+	// DSN so every pooled connection gets them (#321). configureSQLite then
+	// applies the database-level auto_vacuum.
+	db, err := sql.Open("sqlite", dbPath+pragmaDSNSuffix)
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)
 	}
 	defer db.Close()
+	db.SetMaxOpenConns(4)
 
-	// Configure SQLite
-	err = configureSQLite(db)
-	if err != nil {
+	if err := configureSQLite(db); err != nil {
 		t.Errorf("configureSQLite failed: %v", err)
 	}
 
-	// Verify key pragmas
-	var busyTimeout int
-	db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout)
-	if busyTimeout != 30000 {
-		t.Errorf("Expected busy_timeout=30000, got %d", busyTimeout)
+	// busy_timeout must be set on every pooled connection, not just one — the
+	// crux of #321. Sample several to defeat the pool handing back the same
+	// connection each time.
+	for i := 0; i < 6; i++ {
+		var busyTimeout int
+		if err := db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+			t.Fatalf("query busy_timeout: %v", err)
+		}
+		if busyTimeout != 30000 {
+			t.Errorf("iter %d: busy_timeout=%d, want 30000 (pragma not applied to all pool connections)", i, busyTimeout)
+		}
 	}
 
 	var syncMode string
 	db.QueryRow("PRAGMA synchronous").Scan(&syncMode)
-	// SQLite returns numeric mode (1=NORMAL)
 	if syncMode != "1" && syncMode != "NORMAL" && syncMode != "normal" {
-		t.Logf("synchronous mode: %s (expected 1 or NORMAL)", syncMode)
+		t.Errorf("synchronous = %s, want 1/NORMAL", syncMode)
+	}
+
+	var fk int
+	db.QueryRow("PRAGMA foreign_keys").Scan(&fk)
+	if fk != 1 {
+		t.Errorf("foreign_keys = %d, want 1", fk)
+	}
+
+	var tempStore int
+	db.QueryRow("PRAGMA temp_store").Scan(&tempStore)
+	if tempStore != 2 { // 2 == MEMORY
+		t.Errorf("temp_store = %d, want 2 (MEMORY)", tempStore)
 	}
 }
 
@@ -2891,10 +2910,13 @@ func TestConfigureSQLite_AfterClose(t *testing.T) {
 	// Close the database first
 	db.Close()
 
-	// configureSQLite should return an error for critical pragma failures on a closed database
-	err = configureSQLite(db)
-	if err == nil {
-		t.Error("configureSQLite should return error for closed database")
+	// configureSQLite now only sets the database-level auto_vacuum, which is
+	// best-effort (failures are logged, not returned) since it affects space
+	// reclamation, not correctness. The connection-level pragmas that used to
+	// be "critical" here moved to the DSN (#321). So even on a closed DB this
+	// returns nil rather than erroring — and must not panic.
+	if err := configureSQLite(db); err != nil {
+		t.Errorf("configureSQLite on closed DB = %v, want nil (best-effort)", err)
 	}
 }
 

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -451,11 +451,18 @@ func (r *ScanRepository) ReconcileOrphans(ctx context.Context) (ReconcileOrphans
 
 // UpdateProgress updates the live current_file_index and files_scanned
 // counters during a running scan.
+//
+// Uses db.ExecWithRetry (like Record and IncrementCorruptions) because the
+// parallel scan's watermark goroutine fires this concurrently with the
+// per-file scan_files inserts, so it can hit SQLite BUSY under write
+// contention. Combined with busy_timeout now being applied to every pooled
+// connection (#321), this makes the watermark write reliable instead of
+// failing and logging noise.
 func (r *ScanRepository) UpdateProgress(ctx context.Context, scanID int64, currentFileIndex, filesScanned int) error {
-	_, err := r.db.ExecContext(ctx, `
+	_ = ctx // retry wrapper operates on the pool; ctx reserved for a future ExecContext variant
+	if _, err := db.ExecWithRetry(r.db, `
 		UPDATE scans SET current_file_index = ?, files_scanned = ? WHERE id = ?
-	`, currentFileIndex, filesScanned, scanID)
-	if err != nil {
+	`, currentFileIndex, filesScanned, scanID); err != nil {
 		return fmt.Errorf("update scan progress: %w", err)
 	}
 	return nil

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1748,7 +1748,12 @@ func (s *ScannerService) scanFilesParallel(
 			progress.mu.Unlock()
 			progressCtx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 			if err := s.scanRepo().UpdateProgress(progressCtx, cfg.ScanDBID, watermark, filesDone); err != nil {
-				logger.Warnf("watermark persist for scan %d (idx=%d) failed: %v", cfg.ScanDBID, watermark, err)
+				// Best-effort: the watermark is a resume optimization, not
+				// correctness-critical (the next tick re-attempts, and
+				// scan_files rows are the source of truth). Debug-level so a
+				// transient lock doesn't spam the log viewer as if it were an
+				// error — the symptom reported in #321.
+				logger.Debugf("watermark persist for scan %d (idx=%d) deferred: %v", cfg.ScanDBID, watermark, err)
 			}
 			cancel()
 			lastPersisted = watermark


### PR DESCRIPTION
Closes #321.

## Problem

Manual scans spammed the log:
```
watermark persist for scan 11 (idx=335) failed: update scan progress: database is locked (5) (SQLITE_BUSY)
watermark persist for scan 11 (idx=556) failed: ...
```
(many per scan). The scan still works, but it reads like a failure.

## Root cause #1 — pragmas applied to one connection, not the pool

`busy_timeout=30000` (and `foreign_keys`, `synchronous`, `temp_store`, `cache_size`) were set via `db.Exec("PRAGMA ...")` *after* open. With `SetMaxOpenConns(4)`, `db.Exec` configures only the one connection it lands on; the other 3 keep `busy_timeout=0` → **immediate `SQLITE_BUSY`** instead of waiting. The parallel scan's watermark writer runs concurrently with per-file `scan_files` inserts, so whenever it landed on an unconfigured connection while an insert held the write lock, it failed instantly.

**Fix:** carry the connection-level pragmas on the DSN (`?_pragma=busy_timeout(30000)&...`), which modernc.org/sqlite applies on *every* connection open. Verified across multiple pool connections in `TestConfigureSQLite_AllPragmas`.

## Root cause #2 — watermark write didn't retry, logged at WARN

`UpdateProgress` used plain `ExecContext`, unlike `Record`/`IncrementCorruptions` which use `db.ExecWithRetry`. Switched it to the retry wrapper, and demoted the persist-failure log to **Debug** — the watermark is a resume optimization (next tick re-attempts; `scan_files` rows are the source of truth), so a transient lock shouldn't surface as an error.

`configureSQLite` now only sets database-level `auto_vacuum`.

## Test plan
- [x] `go build`, `golangci-lint` — 0 issues
- [x] `TestConfigureSQLite_AllPragmas` rewritten to open via the production DSN and assert `busy_timeout=30000` on 6 sampled connections + synchronous/foreign_keys/temp_store
- [x] `go test ./internal/db/ ./internal/repository/` green
- [x] `go test -race ./internal/services/ -run 'ScanFilesParallel|Watermark'` green
- [x] Empirically verified the `_pragma` DSN format applies per-connection before wiring it in