### PR TITLE
fix(db): actually enable incremental auto_vacuum so the DB reclaims space

### DIFF
--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -134,13 +134,42 @@ const pragmaDSNSuffix = "?_pragma=busy_timeout(30000)" +
 // DSN. Connection-level pragmas (busy_timeout, journal_mode, foreign_keys,
 // synchronous, temp_store, cache_size) are applied to every pooled connection
 // via pragmaDSNSuffix instead — see #321.
+//
+// Its one job is converting the database to INCREMENTAL auto_vacuum.
+// auto_vacuum is a database-level property that only takes effect on an empty
+// database or after a VACUUM. It was historically set with a plain db.Exec
+// after the schema already existed, so it silently stayed at NONE (0) — and
+// the daily `PRAGMA incremental_vacuum` maintenance was a no-op, meaning the
+// file never reclaimed pages freed by retention pruning and only ever grew.
+//
+// We convert once: set the mode and VACUUM to apply it. The check makes it
+// idempotent (a no-op once the DB is already incremental). On a fresh DB the
+// VACUUM is trivial and the mode persists as the schema is migrated in
+// afterward; on an existing DB it is a one-time rewrite that also reclaims
+// the accumulated free space. Both pragma and VACUUM run on one dedicated
+// connection so the mode-change definitely applies to the VACUUM.
 func configureSQLite(db *sql.DB) error {
-	// auto_vacuum is a database-level property (persisted in the file header);
-	// setting it once is sufficient. INCREMENTAL reclaims freed pages on
-	// demand without the full-rewrite cost of auto_vacuum=FULL.
-	if _, err := db.Exec("PRAGMA auto_vacuum=INCREMENTAL"); err != nil {
-		// Non-fatal: only affects space reclamation, not correctness.
-		logger.Debugf("Failed to set auto_vacuum pragma: %v", err)
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection for auto_vacuum config: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	var mode int
+	if err := conn.QueryRowContext(ctx, "PRAGMA auto_vacuum").Scan(&mode); err != nil {
+		return fmt.Errorf("read auto_vacuum: %w", err)
+	}
+	if mode == 2 { // 2 == INCREMENTAL: already converted
+		return nil
+	}
+
+	logger.Infof("Converting database to incremental auto-vacuum (one-time; reclaims freed space going forward)...")
+	if _, err := conn.ExecContext(ctx, "PRAGMA auto_vacuum=INCREMENTAL"); err != nil {
+		return fmt.Errorf("set auto_vacuum=INCREMENTAL: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "VACUUM"); err != nil {
+		return fmt.Errorf("vacuum to apply auto_vacuum: %w", err)
 	}
 	return nil
 }

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -1999,6 +1999,13 @@ func TestConfigureSQLite_AllPragmas(t *testing.T) {
 	if tempStore != 2 { // 2 == MEMORY
 		t.Errorf("temp_store = %d, want 2 (MEMORY)", tempStore)
 	}
+
+	// configureSQLite converts the DB to INCREMENTAL auto_vacuum.
+	var autoVacuum int
+	db.QueryRow("PRAGMA auto_vacuum").Scan(&autoVacuum)
+	if autoVacuum != 2 {
+		t.Errorf("auto_vacuum = %d, want 2 (INCREMENTAL)", autoVacuum)
+	}
 }
 
 // =============================================================================
@@ -2910,13 +2917,11 @@ func TestConfigureSQLite_AfterClose(t *testing.T) {
 	// Close the database first
 	db.Close()
 
-	// configureSQLite now only sets the database-level auto_vacuum, which is
-	// best-effort (failures are logged, not returned) since it affects space
-	// reclamation, not correctness. The connection-level pragmas that used to
-	// be "critical" here moved to the DSN (#321). So even on a closed DB this
-	// returns nil rather than erroring — and must not panic.
-	if err := configureSQLite(db); err != nil {
-		t.Errorf("configureSQLite on closed DB = %v, want nil (best-effort)", err)
+	// configureSQLite acquires a connection (to run the auto_vacuum conversion
+	// on a single connection); on a closed pool that fails, so it returns an
+	// error rather than panicking.
+	if err := configureSQLite(db); err == nil {
+		t.Error("configureSQLite on closed DB should return an error")
 	}
 }
 
@@ -4453,5 +4458,70 @@ func TestRepository_StartPeriodicPoolStats_Stop(t *testing.T) {
 	if got := mock.poolStatsCallCount(); got > initialCalls+1 {
 		t.Errorf("Pool stats calls should stop after stop(), got %d calls after %d initial",
 			got, initialCalls)
+	}
+}
+
+// TestNewRepositoryEnablesIncrementalVacuum verifies the auto_vacuum fix: a DB
+// opened via NewRepository must be in INCREMENTAL mode so the daily
+// incremental_vacuum maintenance actually reclaims freed pages. Historically
+// auto_vacuum was set too late (after the schema existed) and silently stayed
+// at NONE, making incremental_vacuum a no-op and letting the file grow forever.
+func TestNewRepositoryEnablesIncrementalVacuum(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "healarr.db")
+	repo, err := NewRepository(dbPath)
+	if err != nil {
+		t.Fatalf("NewRepository: %v", err)
+	}
+	defer repo.DB.Close()
+
+	var mode int
+	if err := repo.DB.QueryRow("PRAGMA auto_vacuum").Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != 2 {
+		t.Fatalf("auto_vacuum=%d, want 2 (INCREMENTAL)", mode)
+	}
+
+	// Prove incremental_vacuum now reclaims: bloat, delete, then vacuum.
+	if _, err := repo.DB.Exec(`CREATE TABLE bloat (id INTEGER PRIMARY KEY, blob TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2000; i++ {
+		_, _ = repo.DB.Exec(`INSERT INTO bloat (blob) VALUES (printf('%01000d', ?))`, i)
+	}
+	_, _ = repo.DB.Exec(`DELETE FROM bloat`)
+
+	var freeBefore int
+	_ = repo.DB.QueryRow("PRAGMA freelist_count").Scan(&freeBefore)
+	if freeBefore == 0 {
+		t.Skip("no free pages accumulated; the auto_vacuum=2 assertion above is the core check")
+	}
+	_, _ = repo.DB.Exec("PRAGMA incremental_vacuum")
+	var freeAfter int
+	_ = repo.DB.QueryRow("PRAGMA freelist_count").Scan(&freeAfter)
+	if freeAfter >= freeBefore {
+		t.Errorf("incremental_vacuum did not reclaim: freelist %d -> %d", freeBefore, freeAfter)
+	}
+}
+
+// TestConfigureSQLite_Idempotent verifies the second call is a no-op (the DB is
+// already INCREMENTAL) and does not error.
+func TestConfigureSQLite_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "t.db")
+	db, err := sql.Open("sqlite", dbPath+pragmaDSNSuffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := configureSQLite(db); err != nil {
+		t.Fatalf("first configureSQLite: %v", err)
+	}
+	if err := configureSQLite(db); err != nil {
+		t.Fatalf("second configureSQLite (should be no-op): %v", err)
+	}
+	var mode int
+	_ = db.QueryRow("PRAGMA auto_vacuum").Scan(&mode)
+	if mode != 2 {
+		t.Errorf("auto_vacuum=%d, want 2", mode)
 	}
 }


### PR DESCRIPTION
Found while verifying #321.

## Problem

`auto_vacuum` only takes effect on an empty DB or after a `VACUUM`. It was set with a plain `db.Exec` *after* the schema already existed, so it silently stayed at `NONE` (0) on every database. Consequence: the daily `PRAGMA incremental_vacuum` maintenance is a **no-op**, and since no full `VACUUM` runs in normal operation (only `VACUUM INTO` for backups, which compacts the *backup*), the live DB never reclaims pages freed by retention pruning — the file only grows.

Confirmed on prod: `PRAGMA auto_vacuum` → `0`.

## Fix

`configureSQLite` now converts the DB to `INCREMENTAL` once: on a single dedicated connection it reads the mode, and if not already incremental, sets the pragma and runs `VACUUM` to apply it. The mode check makes it idempotent — it runs once and is skipped on every subsequent startup. On a fresh DB the VACUUM is trivial and the mode persists as migrations add the schema; on an existing DB it's a one-time rewrite that also reclaims the accumulated free space. A one-line notice is logged when it converts.

## Test plan
- [x] `go build`, `golangci-lint run ./internal/db/` — 0 issues
- [x] New `TestNewRepositoryEnablesIncrementalVacuum`: full flow yields `auto_vacuum=2`, and a subsequent `incremental_vacuum` reclaims freelist pages (500 → 0)
- [x] New `TestConfigureSQLite_Idempotent`: second call is a no-op, stays mode 2
- [x] `TestConfigureSQLite_AllPragmas` updated to assert `auto_vacuum=2`
- [x] `go test ./internal/db/ ./internal/repository/ ./internal/api/` — green

## Upgrade note
On first start after upgrading, an existing DB runs a one-time `VACUUM` (logged). Fast for typical DBs; proportional to file size for very large ones, then never again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database storage efficiency by properly configuring automatic space reclamation when records are deleted
  * Enhanced database initialization to reliably apply configuration and reclaim unused disk space
  * Made database setup more robust with error handling and verification checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->