### PR TITLE
docs: note Windows UNC path support for *arr scan paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ HEALARR_DATA_DIR=/opt/healarr/config ./healarr
 
 > **💡 Pro tip:** If you mount media with the same path as your *arr apps (e.g., Sonarr sees `/tv` and you mount `-v /host/tv:/tv:ro`), set both Local Path and *arr Path to the same value. This eliminates path translation issues.
 
+> **🪟 Windows hosts:** If your Sonarr/Radarr runs on Windows, it reports paths with backslashes and UNC roots (e.g. `\\server\media\TV Shows`). Set the **\*arr Path** to that UNC form exactly as the *arr reports it, and the **Local Path** to wherever Healarr sees the same files (e.g. `/media/TV Shows` inside a Linux container). Healarr normalizes the separators between the two, so webhook scans, path matching, and auto-remediation all work across the `\` ↔ `/` boundary — no manual conversion needed.
+
 ### Webhook Integration (Recommended)
 
 For instant scanning when downloads complete:

--- a/frontend/src/pages/Help.tsx
+++ b/frontend/src/pages/Help.tsx
@@ -852,6 +852,12 @@ server {
                                     scan path has *arr Path = <span className="font-mono">/tv</span>, Local Path = <span className="font-mono">/media/tv</span>,
                                     Healarr will scan <span className="font-mono">/media/tv/MyShow/S01E01.mkv</span>. Or if you mounted with <span className="font-mono">-v /host/tv:/tv:ro</span>, just use <span className="font-mono">/tv</span> for both paths.
                                 </p>
+                                <p className="text-xs text-slate-500 mt-2">
+                                    <span className="font-semibold">🪟 Windows *arr:</span> If Sonarr/Radarr runs on Windows it reports backslash UNC paths
+                                    like <span className="font-mono">{'\\\\server\\media\\TV Shows'}</span>. Set the *arr Path to that exact UNC form and the
+                                    Local Path to where Healarr sees the files (e.g. <span className="font-mono">/media/TV Shows</span>). Healarr normalizes the
+                                    <span className="font-mono">{' \\ '}</span>↔<span className="font-mono">{' / '}</span> separators automatically, so webhooks, matching, and remediation all work — no manual conversion.
+                                </p>
                             </div>
                         </div>
 


### PR DESCRIPTION
We've now fixed three Windows-host path issues (#298, #305, #322) for the same Windows user, but the docs never mentioned Windows *arr setups with backslash/UNC paths are supported.

Adds a short note in two places:
- README "Setting Up Scan Paths"
- in-app Help "Webhook Path Mapping Errors" troubleshooter

Both explain: set the *arr Path to the UNC form the Windows *arr reports (e.g. `\\server\media\TV Shows`) and the Local Path to where Healarr sees the files; Healarr normalizes the `\` ↔ `/` separators automatically.

## Test plan
- [x] `npm run typecheck` + `npm run build` clean (Help.tsx)
- [x] Docs-only; no code paths touched