### PR TITLE
chore(release): v1.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.11] - 2026-06-09
+
+Two fixes from a Windows user's testing, a database-bloat fix found along the way, and a docs note.
+
+### Fixed
+- **Auto-remediation now finds the *arr instance for Windows UNC paths** ([#323](https://github.com/mescon/Healarr/pull/323)). On a Windows host, remediation failed with `no instance found for path: \\server\share\TV Shows\...` even though the file's corruption was detected correctly. The instance-ownership matcher (`isValidPathMatch`) only trimmed trailing `/` and only treated `/` as a directory boundary, so a Windows *arr's backslash-separated UNC path never matched its configured root folder and remediation gave up. Same separator class of bug as the v1.3.9 webhook fix, in a different matcher; it now accepts `/` or `\` (and `\\srv\media\Movies` still doesn't false-match `\\srv\media\MoviesArchive`). Reported by alex882001 in [#322](https://github.com/mescon/Healarr/issues/322).
+- **Manual scans no longer spam "database is locked (SQLITE_BUSY)" warnings** ([#324](https://github.com/mescon/Healarr/pull/324)). Connection-level SQLite pragmas — most importantly `busy_timeout=30000` — were applied with a post-open `db.Exec`, which configures only one connection in the pool; the other three kept `busy_timeout=0` and returned `SQLITE_BUSY` immediately instead of waiting for the lock. The parallel scanner's watermark writer (running alongside the per-file `scan_files` inserts) hit those unconfigured connections and failed noisily. The pragmas now ride on the connection string so every pooled connection gets them, the watermark write uses the same retry wrapper as the other writers, and its best-effort failures log at debug level instead of warn (the watermark is a resume optimization; `scan_files` rows are the source of truth). Reported by alex882001 in [#321](https://github.com/mescon/Healarr/issues/321).
+- **The database now reclaims freed space instead of only growing** ([#326](https://github.com/mescon/Healarr/pull/326)). `auto_vacuum` only takes effect on an empty database or after a `VACUUM`, but it was set with a plain `db.Exec` after the schema already existed, so it silently stayed at `NONE`. That made the daily `PRAGMA incremental_vacuum` maintenance a no-op — and since no full `VACUUM` runs in normal operation (only `VACUUM INTO` for backups, which compacts the backup copy), pages freed by retention pruning were never reclaimed and the file only grew. The database is now converted to `INCREMENTAL` auto-vacuum once on startup (a one-time `VACUUM` that also reclaims accumulated free space; skipped on every start thereafter), so incremental vacuum actually works. Found while investigating [#321](https://github.com/mescon/Healarr/issues/321).
+
+### Documentation
+- **Windows UNC path note** ([#327](https://github.com/mescon/Healarr/pull/327)). After fixing three Windows-host path issues ([#298](https://github.com/mescon/Healarr/issues/298), [#305](https://github.com/mescon/Healarr/issues/305), [#322](https://github.com/mescon/Healarr/issues/322)), the README "Setting Up Scan Paths" section and the in-app Help "Webhook Path Mapping Errors" troubleshooter now explain Windows *arr setups: set the *arr Path to the UNC form the Windows *arr reports (e.g. `\\server\media\TV Shows`) and the Local Path to where Healarr sees the files; Healarr normalizes the separators automatically.
+
 ## [1.3.10] - 2026-06-08
 
 Dashboard accuracy and a webhook log-line nicety, plus a batch of dependency bumps.


### PR DESCRIPTION
## v1.3.11 release notes

Two Windows-user fixes, a DB-bloat fix found along the way, and a docs note.

### Fixed
- #323 (#322): auto-remediation finds the *arr instance for Windows UNC paths
- #324 (#321): SQLite pragmas apply to all pool connections; manual scans stop logging spurious "database is locked"
- #326: incremental auto_vacuum actually enabled, so the DB reclaims freed space instead of only growing

### Documentation
- #327: Windows UNC path note in README + in-app Help

## Test plan
- [x] go build, golangci-lint clean
- [x] db/repository/api/integration suites green; -race on parallel scan path
- [ ] After merge: SonarCloud gate green, tag build, deploy to Sokaris (one-time VACUUM on first start)