### PR TITLE
fix(remediator): never invent consent (audit findings 1+4, CRITICAL)

### DIFF
--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,60 @@
+// Package pathutil holds the shared path-matching semantics used everywhere
+// Healarr compares a file path against a configured root: the path mapper,
+// the *arr instance-ownership matcher, the scanner's per-file config lookup,
+// and the remediator's consent resolution.
+//
+// The rules exist as ONE package because the same separator bug was fixed
+// three times in three sibling matchers (#298, #305, #322): each had its own
+// slightly different prefix/boundary logic, and each missed Windows
+// backslash paths in its own way. Any new code that needs "is this file
+// under this root?" must use IsWithinRoot rather than rolling its own
+// strings.HasPrefix.
+package pathutil
+
+import "strings"
+
+// Separators are the path separators we recognize. Forward slash covers
+// Linux/macOS and *arr's normalized form on most setups; backslash covers
+// Windows-native paths and UNC roots (\\server\share\folder) that
+// Sonarr/Radarr report verbatim when running on Windows.
+const Separators = "/\\"
+
+// TrimTrailingSep removes trailing path separators (both / and \) so a
+// configured root compares the same whether the operator typed a trailing
+// slash or not. Safe for UNC paths: it only strips trailing characters,
+// never the leading \\ anchor.
+func TrimTrailingSep(p string) string {
+	return strings.TrimRight(p, Separators)
+}
+
+// HasSepPrefix reports whether s begins with a recognized path separator.
+// Used after a prefix match to confirm the match ends on a directory
+// boundary, so /media/TV does not match /media/TV2 and \\srv\Movies does
+// not match \\srv\MoviesArchive.
+func HasSepPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	return strings.ContainsRune(Separators, rune(s[0]))
+}
+
+// IsWithinRoot reports whether path is the configured root itself or a file
+// or directory inside it, with separator-agnostic boundary semantics. The
+// root is trailing-separator-trimmed before comparison so stored configs
+// like "/media/tv/" match the same as "/media/tv".
+func IsWithinRoot(root, path string) bool {
+	root = TrimTrailingSep(root)
+	if root == "" || !strings.HasPrefix(path, root) {
+		return false
+	}
+	remainder := path[len(root):]
+	return remainder == "" || HasSepPrefix(remainder)
+}
+
+// MatchedRootLen returns the comparable length of a root for
+// longest-prefix-wins selection among multiple matching roots, using the
+// same trailing-separator trim as IsWithinRoot so a root with a trailing
+// slash does not outrank the same root without one.
+func MatchedRootLen(root string) int {
+	return len(TrimTrailingSep(root))
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,50 @@
+package pathutil
+
+import "testing"
+
+func TestIsWithinRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+		path string
+		want bool
+	}{
+		// Linux semantics
+		{"exact match", "/media/tv", "/media/tv", true},
+		{"file inside", "/media/tv", "/media/tv/show/ep.mkv", true},
+		{"trailing slash root", "/media/tv/", "/media/tv/show/ep.mkv", true},
+		{"trailing slash root exact", "/media/tv/", "/media/tv", true},
+		{"sibling prefix", "/media/tv", "/media/tv2/ep.mkv", false},
+		{"different tree", "/media/tv", "/data/tv/ep.mkv", false},
+		{"empty path", "/media/tv", "", false},
+		{"empty root", "", "/media/tv", false},
+
+		// Windows / UNC semantics (the #298/#305/#322 class)
+		{"UNC exact", `\\srv\media\TV Shows`, `\\srv\media\TV Shows`, true},
+		{"UNC file inside", `\\srv\media\TV Shows`, `\\srv\media\TV Shows\Show\S01E01.mkv`, true},
+		{"UNC trailing backslash root", `\\srv\media\TV Shows\`, `\\srv\media\TV Shows\Show\ep.mkv`, true},
+		{"UNC sibling prefix", `\\srv\media\Movies`, `\\srv\media\MoviesArchive\f.mkv`, false},
+		{"drive letter inside", `D:\Media\TV`, `D:\Media\TV\Show\ep.mkv`, true},
+		{"drive letter sibling", `D:\Media\TV`, `D:\Media\TV2\ep.mkv`, false},
+
+		// Mixed separators after the root (a Windows *arr remainder on a
+		// forward-slash root) still counts as a boundary.
+		{"mixed separator boundary", "/media/Movies", `/media/Movies\Film (2024)\f.mkv`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsWithinRoot(tt.root, tt.path); got != tt.want {
+				t.Errorf("IsWithinRoot(%q, %q) = %v, want %v", tt.root, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchedRootLen(t *testing.T) {
+	if MatchedRootLen("/media/tv/") != MatchedRootLen("/media/tv") {
+		t.Error("trailing slash must not change comparable root length")
+	}
+	if MatchedRootLen(`\\srv\share\`) != MatchedRootLen(`\\srv\share`) {
+		t.Error("trailing backslash must not change comparable root length")
+	}
+}

--- a/internal/services/health_monitor.go
+++ b/internal/services/health_monitor.go
@@ -119,8 +119,17 @@ func (h *HealthMonitorService) checkStuckRemediations() {
 
 	// Find corruptions where:
 	// 1. CorruptionDetected exists
-	// 2. No VerificationSuccess or MaxRetriesReached
+	// 2. No terminal or deliberate-parking event exists (see below)
 	// 3. Last event was more than stuckThreshold ago
+	//
+	// The exclusion list is load-bearing for the user's veto: an aggregate
+	// with CorruptionIgnored is the operator explicitly saying "leave this
+	// file alone" (the designed escape hatch for false positives), and the
+	// other parking states (RemediationPaused, SearchExhausted,
+	// DownloadIgnored, ManuallyRemoved) are deliberate stops. Before these
+	// were excluded, the sweep flagged ignored items as "stuck" after
+	// stuckThreshold and the monitor's retry deleted files the user had
+	// vetoed.
 	query := `
 		SELECT
 			e1.aggregate_id,
@@ -133,7 +142,11 @@ func (h *HealthMonitorService) checkStuckRemediations() {
 		AND NOT EXISTS (
 			SELECT 1 FROM events e3
 			WHERE e3.aggregate_id = e1.aggregate_id
-			AND e3.event_type IN ('VerificationSuccess', 'MaxRetriesReached')
+			AND e3.event_type IN (
+				'VerificationSuccess', 'MaxRetriesReached',
+				'CorruptionIgnored', 'RemediationPaused',
+				'SearchExhausted', 'DownloadIgnored', 'ManuallyRemoved'
+			)
 		)
 		GROUP BY e1.aggregate_id
 		HAVING MAX(e2.created_at) < datetime('now', '-' || ? || ' hours')

--- a/internal/services/health_monitor_test.go
+++ b/internal/services/health_monitor_test.go
@@ -1900,3 +1900,59 @@ func TestHealthMonitorService_checkInstanceHealth_MultipleInstanceRecovery(t *te
 		t.Error("Expected Radarr to recover")
 	}
 }
+
+// The stuck sweep must NOT flag aggregates the user has ignored (or that sit
+// in another deliberate parking state): before the exclusion, an ignored
+// false positive on an auto-remediate path was resurrected after
+// stuckThreshold and the monitor's consented retry deleted the file the user
+// explicitly vetoed.
+func TestHealthMonitorService_checkStuckRemediations_SkipsIgnoredAndParked(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	h := NewHealthMonitorService(db, eb, nil, 24*time.Hour)
+	h.stuckThreshold = 1 * time.Millisecond
+
+	eventCh := make(chan domain.Event, 10)
+	eb.Subscribe(domain.StuckRemediation, func(e domain.Event) {
+		eventCh <- e
+	})
+
+	seed := func(aggID, parkEvent string) {
+		t.Helper()
+		if _, err := db.Exec(`
+			INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at)
+			VALUES ('corruption', ?, 'CorruptionDetected', '{"file_path":"/test/x.mkv"}', datetime('now', '-48 hours'))
+		`, aggID); err != nil {
+			t.Fatalf("seed detected: %v", err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at)
+			VALUES ('corruption', ?, ?, '{}', datetime('now', '-47 hours'))
+		`, aggID, parkEvent); err != nil {
+			t.Fatalf("seed park event: %v", err)
+		}
+	}
+
+	// Every deliberate stop must be excluded from the sweep.
+	seed("ignored-1", "CorruptionIgnored")
+	seed("paused-1", "RemediationPaused")
+	seed("exhausted-1", "SearchExhausted")
+	seed("dl-ignored-1", "DownloadIgnored")
+	seed("removed-1", "ManuallyRemoved")
+
+	h.checkStuckRemediations()
+
+	select {
+	case ev := <-eventCh:
+		t.Errorf("Sweep flagged a parked/ignored aggregate as stuck: %s", ev.AggregateID)
+	case <-time.After(150 * time.Millisecond):
+		// Correct: nothing flagged.
+	}
+}

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -206,6 +206,16 @@ func (m *MonitorService) scheduleRetry(corruptionID, filePath string, pathID int
 func (m *MonitorService) handleStuckRemediation(event domain.Event) {
 	corruptionID := event.AggregateID
 
+	// Belt-and-braces against resurrecting a user veto: the stuck sweep
+	// excludes ignored aggregates at the query level, but this handler is the
+	// last automated gate before a consented retry, so it independently
+	// refuses if the user ever ignored this corruption. (A manual UI retry
+	// does not pass through here, so the user can still un-park explicitly.)
+	if m.hasUserVeto(corruptionID) {
+		logger.Infof("Stuck remediation %s was ignored by the user; not scheduling automated retry", corruptionID)
+		return
+	}
+
 	// Check if we've already hit max retries
 	retryCount, maxRetries, err := m.getRetryCount(corruptionID)
 	if err != nil {
@@ -341,6 +351,24 @@ func (m *MonitorService) getRetryCount(corruptionID string) (int, int, error) {
 	// If user sets 0, they want 0 retries.
 
 	return count, limit, nil
+}
+
+// hasUserVeto reports whether the user has ever ignored this corruption.
+// CorruptionIgnored is the operator's explicit "leave this file alone" (the
+// designed escape hatch for false positives), so no automated path may
+// schedule a retry past it. Errors fail open to "vetoed" — refusing an
+// automated destructive retry on a query failure is the safe direction.
+func (m *MonitorService) hasUserVeto(corruptionID string) bool {
+	var n int
+	err := m.db.QueryRow(`
+		SELECT COUNT(*) FROM events
+		WHERE aggregate_id = ? AND event_type = 'CorruptionIgnored'
+	`, corruptionID).Scan(&n)
+	if err != nil {
+		logger.Warnf("Cannot check ignore-veto for %s; refusing automated retry: %v", corruptionID, err)
+		return true
+	}
+	return n > 0
 }
 
 // handleNeedsAttention handles events that require manual intervention.

--- a/internal/services/monitor_test.go
+++ b/internal/services/monitor_test.go
@@ -2567,3 +2567,47 @@ func TestGetCorruptionContextWithRetry_ErrNoRowsExitsEarly(t *testing.T) {
 		t.Errorf("Expected early exit on ErrNoRows, but took %v (retries may have occurred)", elapsed)
 	}
 }
+
+// handleStuckRemediation must refuse to schedule an automated retry for an
+// aggregate the user has ignored: CorruptionIgnored is the operator's veto,
+// and the stuck path was historically able to override it and delete the
+// vetoed file.
+func TestMonitorService_HandleStuckRemediation_RespectsIgnoreVeto(t *testing.T) {
+	config.SetForTesting(config.NewTestConfig())
+
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	m := NewMonitorService(eb, db)
+
+	retryCh := make(chan domain.Event, 4)
+	eb.Subscribe(domain.RetryScheduled, func(e domain.Event) { retryCh <- e })
+
+	// Aggregate with a detection and a user veto.
+	if _, err := db.Exec(`
+		INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at) VALUES
+		('corruption', 'veto-1', 'CorruptionDetected', '{"file_path":"/media/tv/x.mkv","path_id":1}', datetime('now', '-48 hours')),
+		('corruption', 'veto-1', 'CorruptionIgnored', '{}', datetime('now', '-47 hours'))
+	`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m.handleStuckRemediation(domain.Event{
+		AggregateID:   "veto-1",
+		AggregateType: "corruption",
+		EventType:     domain.StuckRemediation,
+	})
+
+	select {
+	case ev := <-retryCh:
+		t.Errorf("automated retry scheduled despite user veto: %+v", ev.EventData)
+	case <-time.After(150 * time.Millisecond):
+		// Correct: veto respected.
+	}
+}

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/pathutil"
 	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
@@ -78,20 +79,65 @@ const (
 // and an operator may have flipped a path to manual or dry-run since the scan was
 // queued. On any doubt (no path id, path deleted, lookup error) it refuses to
 // auto-remediate, so we never delete a file without a clear, current opt-in.
-func (r *RemediatorService) resolveRemediationPolicy(pathID int64, evtAuto, evtDry bool) (autoRemediate, dryRun bool) {
-	if pathID <= 0 || r.scanPaths == nil {
-		// Legacy/edge events without a path id: honor only what the event itself
-		// claimed (never invent consent), and keep dry-run if it asked for it.
+func (r *RemediatorService) resolveRemediationPolicy(pathID int64, evtAuto, evtDry bool, filePath string) (autoRemediate, dryRun bool) {
+	if r.scanPaths == nil {
+		// Test fixtures without a repository: honor the event values.
 		return evtAuto, evtDry
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
 	defer cancel()
+
+	if pathID <= 0 {
+		// No path id on the event (legacy events, or producers that predate the
+		// path_id-on-ScanFile fix). The event's own auto_remediate is NOT
+		// trustworthy here: the recovery sweep, the stuck-remediation monitor,
+		// and the manual-retry endpoint all hardcode auto_remediate=true and
+		// drop dry_run, so honoring the event would invent consent the operator
+		// never gave (and historically deleted files on dry-run paths). Resolve
+		// the owning scan path from the file path instead; if no path matches,
+		// refuse to auto-remediate.
+		if sp, ok := r.findScanPathForFile(ctx, filePath); ok {
+			return sp.AutoRemediate, sp.DryRun
+		}
+		logger.Warnf("Remediation: no path_id on event and no scan path matches %s; refusing to auto-remediate (safe default)", filePath)
+		return false, evtDry
+	}
+
 	sp, err := r.scanPaths.GetByID(ctx, pathID)
 	if err != nil {
 		logger.Warnf("Remediation: cannot load scan path %d; refusing to auto-remediate (safe default): %v", pathID, err)
 		return false, evtDry
 	}
 	return sp.AutoRemediate, sp.DryRun
+}
+
+// findScanPathForFile resolves the enabled scan path that owns filePath using
+// the shared longest-prefix, separator-agnostic matching from pathutil. Used
+// as the consent fallback when an event carries no path_id.
+func (r *RemediatorService) findScanPathForFile(ctx context.Context, filePath string) (repository.ScanPath, bool) {
+	if filePath == "" {
+		return repository.ScanPath{}, false
+	}
+	rows, err := r.scanPaths.ListEnabled(ctx)
+	if err != nil {
+		logger.Warnf("Remediation: cannot list scan paths to resolve consent for %s: %v", filePath, err)
+		return repository.ScanPath{}, false
+	}
+	best := -1
+	bestLen := -1
+	for i := range rows {
+		if !pathutil.IsWithinRoot(rows[i].LocalPath, filePath) {
+			continue
+		}
+		if l := pathutil.MatchedRootLen(rows[i].LocalPath); l > bestLen {
+			bestLen = l
+			best = i
+		}
+	}
+	if best < 0 {
+		return repository.ScanPath{}, false
+	}
+	return rows[best], true
 }
 
 // Start subscribes to corruption and retry events to begin remediation handling.
@@ -241,7 +287,7 @@ func (r *RemediatorService) retrySearchOnly(event domain.Event, mediaID int64, m
 		// imported), remove and blocklist it so the re-search grabs a different
 		// release rather than waiting on the same dead one.
 		if !blocklisted {
-			blocklisted = r.handleStalledDownloadBeforeSearch(corruptionID, pathID, mediaID, arrPath)
+			blocklisted = r.handleStalledDownloadBeforeSearch(corruptionID, pathID, mediaID, arrPath, filePath)
 		}
 
 		// Extract episode IDs from metadata first - validates data before announcing search
@@ -353,7 +399,9 @@ func (r *RemediatorService) handleCorruptReplacementBeforeSearch(corruptionID st
 	}
 
 	// Re-read the authoritative auto-remediate / dry-run policy for this path.
-	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, true, false)
+	// The replacement's own local path doubles as the consent-resolution
+	// fallback when the event chain carried no path_id.
+	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, false, false, paths[0])
 	if !autoRemediate {
 		logger.Infof("Corrupt replacement present for %s but path is not auto-remediate; leaving for manual handling", corruptionID)
 		return false
@@ -455,7 +503,7 @@ func (r *RemediatorService) lastFailureWasDownloadTimeout(corruptionID string) b
 // the caller must NOT issue a duplicate search. On any inability to proceed
 // (not a timeout retry, nothing queued, non-auto path, dry-run, API error) it
 // returns false so the caller performs a normal search.
-func (r *RemediatorService) handleStalledDownloadBeforeSearch(corruptionID string, pathID, mediaID int64, arrPath string) bool {
+func (r *RemediatorService) handleStalledDownloadBeforeSearch(corruptionID string, pathID, mediaID int64, arrPath, localPath string) bool {
 	if !r.lastFailureWasDownloadTimeout(corruptionID) {
 		return false
 	}
@@ -465,7 +513,9 @@ func (r *RemediatorService) handleStalledDownloadBeforeSearch(corruptionID strin
 		return false
 	}
 
-	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, true, false)
+	// localPath is the consent-resolution fallback when the event chain
+	// carried no path_id.
+	autoRemediate, dryRun := r.resolveRemediationPolicy(pathID, false, false, localPath)
 	if !autoRemediate {
 		logger.Infof("Stalled download for %s but path is not auto-remediate; leaving for manual handling", corruptionID)
 		return false
@@ -633,8 +683,9 @@ func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {
 	// event payload is not authoritative (recovery/monitor retries hardcode
 	// auto_remediate=true and drop dry_run, and the operator may have changed the
 	// setting), so deciding deletion from it could delete files on a manual-mode
-	// or dry-run path. This is the single enforcement point for both.
-	autoRemediate, dryRun := r.resolveRemediationPolicy(data.PathID, data.AutoRemediate, data.DryRun)
+	// or dry-run path. This is the single enforcement point for both. When the
+	// event has no path_id, the file path resolves the owning scan path instead.
+	autoRemediate, dryRun := r.resolveRemediationPolicy(data.PathID, data.AutoRemediate, data.DryRun, data.FilePath)
 
 	// Check for auto-remediation
 	if !autoRemediate {

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -21,6 +21,21 @@ import (
 // errPathNotConfigured is a test error for path mapping failures.
 var errPathNotConfigured = errors.New("path not configured")
 
+// seedRemediationPath inserts an enabled scan path so the remediator's
+// consent re-read (resolveRemediationPolicy) finds a configured opt-in.
+// Tests that expect remediation to PROCEED must seed the owning path: the
+// remediator never trusts the event's own auto_remediate claim, so an
+// unseeded DB means "no consent" and the flow stops before any delete.
+func seedRemediationPath(t *testing.T, db *sql.DB, localPath string, autoRemediate, dryRun bool) {
+	t.Helper()
+	if _, err := db.Exec(`
+		INSERT INTO scan_paths (local_path, arr_path, enabled, auto_remediate, dry_run)
+		VALUES (?, ?, 1, ?, ?)
+	`, localPath, localPath, autoRemediate, dryRun); err != nil {
+		t.Fatalf("seed scan path %s: %v", localPath, err)
+	}
+}
+
 // TestMain sets up test configuration before running tests.
 func TestMain(m *testing.M) {
 	// Initialize config for tests that require it
@@ -49,6 +64,9 @@ func TestRemediatorService_SafetyCheck(t *testing.T) {
 				t.Fatalf("Failed to create test DB: %v", err)
 			}
 			defer db.Close()
+			// Seed an auto-remediate path: the category gate, not missing
+			// consent, must be what blocks these recoverable errors.
+			seedRemediationPath(t, db, "/media/movies", true, false)
 
 			mockEventBus := testutil.NewMockEventBus()
 			mockArrClient := &testutil.MockArrClient{}
@@ -123,6 +141,16 @@ func TestRemediatorService_HandleCorruptionDetected(t *testing.T) {
 		}
 
 		remediator := NewRemediatorService(mockEventBus, mockArrClient, mockPathMapper, db)
+
+		// Seed the owning scan path with auto_remediate enabled: the remediator
+		// re-reads consent from the path config (resolved by file path when the
+		// event has no path_id) and never trusts the event's own claim.
+		if _, err := db.Exec(`
+			INSERT INTO scan_paths (local_path, arr_path, enabled, auto_remediate, dry_run)
+			VALUES ('/media/movies', '/media/movies', 1, 1, 0)
+		`); err != nil {
+			t.Fatalf("seed scan path: %v", err)
+		}
 
 		// Create corruption event with TRUE corruption type
 		event := testutil.NewCorruptionEventWithType(
@@ -210,6 +238,7 @@ func TestRemediatorService_HandleCorruptionDetected(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		seedRemediationPath(t, db, "/media/movies", true, false)
 
 		mockEventBus := testutil.NewMockEventBus()
 		mockArrClient := &testutil.MockArrClient{}
@@ -285,6 +314,8 @@ func TestRemediatorService_DryRunMode(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		// Path config carries the dry-run; the event payload is not trusted.
+		seedRemediationPath(t, db, "/media/movies", true, true)
 
 		mockEventBus := testutil.NewMockEventBus()
 		mockArrClient := &testutil.MockArrClient{
@@ -383,6 +414,7 @@ func TestRemediatorService_RetryLogic(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		seedRemediationPath(t, db, "/media/movies", true, false)
 
 		mockEventBus := testutil.NewMockEventBus()
 		mockArrClient := &testutil.MockArrClient{
@@ -445,6 +477,7 @@ func TestRemediatorService_Concurrency(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		seedRemediationPath(t, db, "/media/movies", true, false)
 
 		mockEventBus := testutil.NewMockEventBus()
 
@@ -1379,6 +1412,7 @@ func TestRemediatorService_Stop(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		seedRemediationPath(t, db, "/media/movies", true, false)
 
 		mockEventBus := testutil.NewMockEventBus()
 		remediationStarted := make(chan struct{})
@@ -1447,6 +1481,7 @@ func TestRemediatorService_Stop(t *testing.T) {
 			t.Fatalf("Failed to create test DB: %v", err)
 		}
 		defer db.Close()
+		seedRemediationPath(t, db, "/media/movies", true, false)
 
 		mockEventBus := testutil.NewMockEventBus()
 		blockingDone := make(chan struct{})
@@ -1801,20 +1836,30 @@ func TestRemediator_ResolveRemediationPolicy_RespectsCurrentPathConfig(t *testin
 
 	// Manual path: event claims auto_remediate=true (as recovery hardcodes), but the
 	// live config says false, so we must NOT auto-remediate.
-	if auto, _ := r.resolveRemediationPolicy(manualID, true, false); auto {
+	if auto, _ := r.resolveRemediationPolicy(manualID, true, false, "/media/manual/file.mkv"); auto {
 		t.Error("manual-mode path must not auto-remediate even when the event claims true")
 	}
 	// Dry-run path: live dry_run=true wins even though the (retry) event omits it.
-	if auto, dry := r.resolveRemediationPolicy(dryID, true, false); !auto || !dry {
+	if auto, dry := r.resolveRemediationPolicy(dryID, true, false, "/media/dry/file.mkv"); !auto || !dry {
 		t.Errorf("dry-run path: got auto=%v dry=%v, want auto=true dry=true", auto, dry)
 	}
-	// Unknown/deleted path: refuse to auto-remediate (safe default).
-	if auto, _ := r.resolveRemediationPolicy(999999, true, false); auto {
+	// Unknown/deleted path id: refuse to auto-remediate (safe default). The file
+	// path is outside every configured root, so the fallback cannot resolve it.
+	if auto, _ := r.resolveRemediationPolicy(999999, true, false, "/elsewhere/file.mkv"); auto {
 		t.Error("unknown path must not auto-remediate")
 	}
-	// Legacy event without a path id: fall back to what the event claimed.
-	if auto, dry := r.resolveRemediationPolicy(0, true, true); !auto || !dry {
-		t.Errorf("pathID=0 fallback: got auto=%v dry=%v, want true/true", auto, dry)
+	// Event without a path id (webhook corruptions pre-fix, recovery/monitor
+	// retries): the file path resolves the owning scan path, whose CURRENT
+	// config wins over the event's invented auto_remediate=true.
+	if auto, dry := r.resolveRemediationPolicy(0, true, false, "/media/dry/Show/ep.mkv"); !auto || !dry {
+		t.Errorf("pathID=0 + resolvable file: got auto=%v dry=%v, want auto=true dry=true (path config)", auto, dry)
+	}
+	if auto, _ := r.resolveRemediationPolicy(0, true, false, "/media/manual/Show/ep.mkv"); auto {
+		t.Error("pathID=0 + manual-mode path: must not auto-remediate despite event claiming true")
+	}
+	// pathID=0 and the file matches NO configured path: never invent consent.
+	if auto, _ := r.resolveRemediationPolicy(0, true, true, "/unmatched/file.mkv"); auto {
+		t.Error("pathID=0 + unmatched file: must refuse to auto-remediate")
 	}
 }
 
@@ -2095,7 +2140,7 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		}
 		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
 
-		if !r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+		if !r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv", "/media/tv/x.mkv") {
 			t.Fatal("expected blocklisted=true")
 		}
 		if removed != 1 {
@@ -2121,7 +2166,7 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
 		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
 
-		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv", "/media/tv/x.mkv") {
 			t.Fatal("expected false when the latest failure is not a download timeout")
 		}
 		if arr.CallCount("RemoveFromQueueByPath") != 0 {
@@ -2143,7 +2188,7 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		arr := &testutil.MockArrClient{}
 		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
 
-		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv", "/media/tv/x.mkv") {
 			t.Fatal("expected false when nothing is queued")
 		}
 		if arr.CallCount("RemoveFromQueueByPath") != 0 {
@@ -2165,7 +2210,7 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
 		r := NewRemediatorService(eb, arr, &testutil.MockPathMapper{}, db)
 
-		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv", "/media/tv/x.mkv") {
 			t.Fatal("expected false in dry-run")
 		}
 		if arr.CallCount("RemoveFromQueueByPath") != 0 || eb.EventCount(domain.ReleaseBlocklisted) != 0 {
@@ -2186,7 +2231,7 @@ func TestRemediator_HandleStalledDownloadBeforeSearch(t *testing.T) {
 		arr := &testutil.MockArrClient{FindQueueItemsByMediaIDForPathFunc: stalledQueueFunc()}
 		r := NewRemediatorService(testutil.NewMockEventBus(), arr, &testutil.MockPathMapper{}, db)
 
-		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv") {
+		if r.handleStalledDownloadBeforeSearch("agg1", pathID, 123, "/data/tv/x.mkv", "/media/tv/x.mkv") {
 			t.Fatal("expected false on non-auto path")
 		}
 		if arr.CallCount("RemoveFromQueueByPath") != 0 {
@@ -2335,6 +2380,7 @@ func TestRemediator_LoopBreaker_PausesAndDoesNotDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+	seedRemediationPath(t, db, "/local/movies", true, false)
 
 	const fp = "/local/movies/loop.mkv"
 	for _, agg := range []string{"a1", "a2", "a3"} {
@@ -2359,4 +2405,55 @@ func TestRemediator_LoopBreaker_PausesAndDoesNotDelete(t *testing.T) {
 	if arr.CallCount("DeleteFile") != 0 {
 		t.Error("a paused remediation must not delete the file")
 	}
+}
+
+// TestRemediator_RecoveryRetryCannotInventConsent reproduces the audit's
+// CRITICAL finding 1: a RetryScheduled event shaped exactly like the recovery
+// sweep / stuck monitor emit it (auto_remediate hardcoded true, no dry_run
+// key, path_id absent) must NOT delete anything on a dry-run or manual path.
+// Consent comes from the path config, resolved by file path when the event
+// carries no path_id.
+func TestRemediator_RecoveryRetryCannotInventConsent(t *testing.T) {
+	run := func(t *testing.T, autoRemediate, dryRun bool, wantDelete bool) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		seedRemediationPath(t, db, "/media/tv", autoRemediate, dryRun)
+
+		eb := testutil.NewMockEventBus()
+		arr := &testutil.MockArrClient{
+			FindMediaByPathFunc: func(string) (int64, error) { return 7, nil },
+			DeleteFileFunc: func(int64, string) (map[string]interface{}, error) {
+				return map[string]interface{}{}, nil
+			},
+			TriggerSearchFunc: func(int64, string, []int64) error { return nil },
+		}
+		pm := &testutil.MockPathMapper{ToArrPathFunc: func(p string) (string, error) { return p, nil }}
+		r := NewRemediatorService(eb, arr, pm, db)
+
+		// Exactly the recovery/monitor payload shape: hardcoded consent, no
+		// path_id, no dry_run key.
+		r.handleRetry(domain.Event{
+			AggregateID:   "recovered-1",
+			AggregateType: "corruption",
+			EventType:     domain.RetryScheduled,
+			EventData: map[string]interface{}{
+				"file_path":       "/media/tv/Show/S01E01.mkv",
+				"auto_remediate":  true,
+				"recovery_action": "startup_recovery",
+			},
+		})
+		time.Sleep(200 * time.Millisecond)
+
+		got := arr.CallCount("DeleteFile") > 0
+		if got != wantDelete {
+			t.Errorf("auto=%v dry=%v: DeleteFile called=%v, want %v", autoRemediate, dryRun, got, wantDelete)
+		}
+	}
+
+	t.Run("dry-run path: no delete", func(t *testing.T) { run(t, true, true, false) })
+	t.Run("manual path: no delete", func(t *testing.T) { run(t, false, false, false) })
+	t.Run("auto path: delete proceeds", func(t *testing.T) { run(t, true, false, true) })
 }

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/pathutil"
 	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
 )
@@ -294,6 +295,7 @@ func (p *ScanProgress) Snapshot() ScanProgressView {
 
 // scanPathConfig holds cached scan path configuration
 type scanPathConfig struct {
+	ID            int64
 	LocalPath     string
 	AutoRemediate bool
 	DryRun        bool
@@ -805,7 +807,7 @@ func (s *ScannerService) ScanFile(localPath string) error {
 	logger.Infof("Scan started for file: %s (ID: %s)", localPath, scanID)
 
 	// Find scan path config for this file
-	autoRemediate, dryRun, err := s.getScanPathConfig(localPath)
+	autoRemediate, dryRun, pathID, err := s.getScanPathConfig(localPath)
 	if err != nil {
 		// Log warning but proceed with defaults (false, false)
 		// This is important for ops visibility - file scanned without matching path config
@@ -855,7 +857,10 @@ func (s *ScannerService) ScanFile(localPath string) error {
 		return nil
 	}
 
-	// Emit event - critical entry point for remediation journey, use retry
+	// Emit event - critical entry point for remediation journey, use retry.
+	// path_id is REQUIRED for the remediator's consent re-read: without it the
+	// recovery/retry paths cannot resolve the path's current auto_remediate /
+	// dry_run and historically invented consent (deleted files on dry-run paths).
 	if err := s.eventBus.PublishWithRetry(domain.Event{
 		AggregateType: "corruption",
 		AggregateID:   uuid.New().String(),
@@ -866,6 +871,7 @@ func (s *ScannerService) ScanFile(localPath string) error {
 			"corruption_type": healthErr.Type,
 			"error_details":   healthErr.Message,
 			"source":          "webhook",
+			"path_id":         pathID,
 			"auto_remediate":  autoRemediate,
 			"dry_run":         dryRun,
 		},
@@ -2377,6 +2383,7 @@ func (s *ScannerService) refreshScanPathCache() error {
 	cache := make([]scanPathConfig, 0, len(rows))
 	for _, p := range rows {
 		cache = append(cache, scanPathConfig{
+			ID:            p.ID,
 			LocalPath:     p.LocalPath,
 			AutoRemediate: p.AutoRemediate,
 			DryRun:        p.DryRun,
@@ -2398,11 +2405,20 @@ func (s *ScannerService) InvalidateScanPathCache() {
 
 // getScanPathConfig finds the matching scan path configuration for a file path.
 // Uses cached scan paths to avoid N+1 query problem (was: 1 query per file).
-// Returns auto_remediate, dry_run, and any error.
-func (s *ScannerService) getScanPathConfig(filePath string) (autoRemediate bool, dryRun bool, err error) {
+// Returns auto_remediate, dry_run, the matched scan path's ID, and any error.
+//
+// The returned pathID rides on the CorruptionDetected event so the remediator
+// can re-read the path's CURRENT consent at action time: without it, webhook
+// corruptions carried path_id=0 and the recovery/retry paths could invent
+// auto-remediate consent the operator never gave.
+//
+// Matching uses pathutil.IsWithinRoot, the shared separator-agnostic boundary
+// semantics, so a trailing slash in the stored local_path or a Windows-native
+// deployment does not silently drop the configured dry_run/auto_remediate.
+func (s *ScannerService) getScanPathConfig(filePath string) (autoRemediate bool, dryRun bool, pathID int64, err error) {
 	// Ensure cache is fresh
 	if err := s.refreshScanPathCache(); err != nil {
-		return false, false, err
+		return false, false, 0, err
 	}
 
 	s.scanPathCacheMu.RLock()
@@ -2412,24 +2428,20 @@ func (s *ScannerService) getScanPathConfig(filePath string) (autoRemediate bool,
 	found := false
 
 	for _, cfg := range s.scanPathCache {
-		// Check if filePath starts with rootPath AND is followed by / or end of string
-		// This prevents /mnt/media/TV from matching /mnt/media/TV2
-		if strings.HasPrefix(filePath, cfg.LocalPath) {
-			remainder := filePath[len(cfg.LocalPath):]
-			// Valid match only if remainder is empty or starts with /
-			if remainder == "" || strings.HasPrefix(remainder, "/") {
-				if len(cfg.LocalPath) > bestMatchLen {
-					bestMatchLen = len(cfg.LocalPath)
-					autoRemediate = cfg.AutoRemediate
-					dryRun = cfg.DryRun
-					found = true
-				}
-			}
+		if !pathutil.IsWithinRoot(cfg.LocalPath, filePath) {
+			continue
+		}
+		if l := pathutil.MatchedRootLen(cfg.LocalPath); l > bestMatchLen {
+			bestMatchLen = l
+			autoRemediate = cfg.AutoRemediate
+			dryRun = cfg.DryRun
+			pathID = cfg.ID
+			found = true
 		}
 	}
 
 	if !found {
-		return false, false, fmt.Errorf("no matching scan path found")
+		return false, false, 0, fmt.Errorf("no matching scan path found")
 	}
-	return autoRemediate, dryRun, nil
+	return autoRemediate, dryRun, pathID, nil
 }

--- a/internal/services/scanner_rescan.go
+++ b/internal/services/scanner_rescan.go
@@ -124,7 +124,7 @@ func (s *ScannerService) updateRescanRetry(f pendingRescanFile, healthErr *integ
 
 // emitRescanCorruption emits a corruption event for a rescan that found actual corruption
 func (s *ScannerService) emitRescanCorruption(f pendingRescanFile, healthErr *integration.HealthCheckError) {
-	autoRemediate, dryRun, _ := s.getScanPathConfig(f.FilePath)
+	autoRemediate, dryRun, _, _ := s.getScanPathConfig(f.FilePath)
 
 	var fileSize int64
 	if info, err := os.Stat(f.FilePath); err == nil {

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -1093,7 +1093,7 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 	scanner.initRepositories()
 
 	t.Run("returns error for no matching path", func(t *testing.T) {
-		_, _, err := scanner.getScanPathConfig("/non/existent/path/file.mkv")
+		_, _, _, err := scanner.getScanPathConfig("/non/existent/path/file.mkv")
 		if err == nil {
 			t.Error("Expected error for non-matching path")
 		}
@@ -1110,7 +1110,7 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		}
 		scanner.InvalidateScanPathCache()
 
-		autoRemediate, dryRun, err := scanner.getScanPathConfig("/media/movies/test.mkv")
+		autoRemediate, dryRun, pathID, err := scanner.getScanPathConfig("/media/movies/test.mkv")
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1119,6 +1119,9 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		}
 		if dryRun {
 			t.Error("Expected dryRun to be false")
+		}
+		if pathID != 1 {
+			t.Errorf("Expected pathID=1 (for the consent re-read chain), got %d", pathID)
 		}
 	})
 
@@ -1133,7 +1136,7 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		}
 		scanner.InvalidateScanPathCache()
 
-		autoRemediate, dryRun, err := scanner.getScanPathConfig("/media/movies/4k/test.mkv")
+		autoRemediate, dryRun, pathID, err := scanner.getScanPathConfig("/media/movies/4k/test.mkv")
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -1142,6 +1145,9 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		}
 		if !dryRun {
 			t.Error("Expected dryRun to be true (from more specific path)")
+		}
+		if pathID != 2 {
+			t.Errorf("Expected pathID=2 (the more specific path), got %d", pathID)
 		}
 	})
 
@@ -1160,7 +1166,7 @@ func TestScannerService_GetScanPathConfig(t *testing.T) {
 		}
 		scanner.InvalidateScanPathCache()
 
-		_, _, err = scanner.getScanPathConfig("/media/movies2/test.mkv")
+		_, _, _, err = scanner.getScanPathConfig("/media/movies2/test.mkv")
 		if err == nil {
 			t.Error("Expected error for partial prefix match")
 		}
@@ -2755,7 +2761,7 @@ func BenchmarkScannerService_GetScanPathConfig(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		scanner.getScanPathConfig("/media/patha/movies/test.mkv")
+		_, _, _, _ = scanner.getScanPathConfig("/media/patha/movies/test.mkv")
 	}
 }
 
@@ -3235,6 +3241,22 @@ func TestScannerService_ScanFile_WithCorruption(t *testing.T) {
 		}
 		if count == 0 {
 			t.Error("Expected corruption event to be created")
+		}
+
+		// The event must carry the owning scan path's id: the remediator's
+		// consent re-read depends on it, and webhook corruptions historically
+		// published path_id=0, letting recovery/retry paths invent consent.
+		var pathID int64
+		err = db.QueryRow(`
+			SELECT json_extract(event_data, '$.path_id') FROM events
+			WHERE event_type = 'CorruptionDetected'
+			AND json_extract(event_data, '$.file_path') = ?
+		`, testFile).Scan(&pathID)
+		if err != nil {
+			t.Fatalf("Failed to read path_id: %v", err)
+		}
+		if pathID <= 0 {
+			t.Errorf("CorruptionDetected from ScanFile must carry the scan path id, got %d", pathID)
 		}
 	})
 }


### PR DESCRIPTION
Fixes CRITICAL findings 1 and 4 from the Fable 5 audit (FABLE5_AUDIT_REPORT.md).

## Finding 1: invented consent for path_id-less corruptions

Three event producers hardcode `auto_remediate:true` and omit `dry_run` (startup recovery, stuck monitor, manual retry). For corruptions with no `path_id` on their events (every webhook detection), `resolveRemediationPolicy` fell through to honoring those invented values: a dry-run or manual-mode path could have files **deleted** by a retry or recovery sweep.

**Fix, three layers:**
1. `ScanFile` now publishes `path_id` (via `getScanPathConfig`, which now returns the matched path's id) — webhook corruptions are no longer a consent blind spot.
2. `resolveRemediationPolicy` with `pathID<=0` resolves the owning path **from the file path** and uses its CURRENT config; unresolvable → refuse to auto-remediate. The event's own claim is never honored.
3. The blocklist helpers (`handleCorruptReplacementBeforeSearch`, `handleStalledDownloadBeforeSearch`) no longer pass literal `true` to the resolver.

## Finding 4: ignore-veto overridden

The stuck sweep excluded only `VerificationSuccess`/`MaxRetriesReached`, so an **ignored** corruption was flagged stuck after 24h and the monitor's consented retry deleted the vetoed file.

**Fix:** sweep excludes `CorruptionIgnored`, `RemediationPaused`, `SearchExhausted`, `DownloadIgnored`, `ManuallyRemoved`; plus a belt-and-braces veto check in `handleStuckRemediation` (fails toward refusal on query error; manual UI retry bypasses it so users can still un-park).

## Also: shared path matching (consent dims of finding 12)

New `internal/pathutil` package — ONE implementation of root-matching semantics (the same separator bug was fixed 3x in 3 siblings). `getScanPathConfig` now uses it, fixing trailing-slash-in-config and Windows-native gaps that silently dropped configured dry_run.

## Test plan
- [x] New: recovery-shaped `RetryScheduled` end-to-end (dry-run/manual → no delete; auto → delete proceeds)
- [x] New: `resolveRemediationPolicy` fallback matrix; `ScanFile` path_id assertion; sweep exclusion of all 5 parking states; monitor ignore-veto; pathutil tables
- [x] Remediator tests that expect remediation now seed the owning path (consent from config, not events)
- [x] Full services suite green (45s); `golangci-lint` 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of user ignore actions across remediation workflows
  * Fixed remediation policy resolution to consistently use scan path configuration

* **New Features**
  * Enhanced path matching to properly handle multiple path separator types
  * Expanded stuck-remediation detection to exclude additional deliberately-parked states (ignored, paused, exhausted searches, etc.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->