### PR TITLE
fix(integration): tool failures are never file corruption (audit findings 2+3, CRITICAL)

### DIFF
--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -630,13 +630,22 @@ func (hc *CmdHealthChecker) CheckWithConfig(path string, config DetectionConfig)
 	case DetectionHandBrake:
 		err := hc.runHandBrakeWithArgs(path, config.Args, mode, config.Overrides)
 		if err != nil {
-			// HandBrake errors are typically stream-level corruption
-			errStr := err.Error()
-			if strings.Contains(errStr, "No such file or directory") ||
-				strings.Contains(errStr, "does not exist") {
-				return false, &HealthCheckError{Type: ErrorTypePathNotFound, Message: errStr}
+			// Route through the shared classifier like the other detectors:
+			// the old HandBrake-only branch matched two path patterns and
+			// then declared EVERYTHING else CorruptStream, so a scan
+			// timeout, a missing HandBrakeCLI binary, or a mount failure
+			// mass-flagged whole libraries as corrupt under the Paranoid
+			// preset. The classifier maps tool/infra failures to
+			// recoverable types and re-checks accessibility before any
+			// corruption verdict.
+			hcErr := hc.classifyDetectorError(err, path)
+			if hcErr.Type == ErrorTypeCorruptHeader {
+				// Preserve HandBrake's corruption flavor: when the
+				// classifier's fallthrough concludes genuine content
+				// corruption, HandBrake failures are stream-level.
+				hcErr.Type = ErrorTypeCorruptStream
 			}
-			return false, &HealthCheckError{Type: ErrorTypeCorruptStream, Message: errStr}
+			return false, hcErr
 		}
 	default:
 		return false, &HealthCheckError{Type: ErrorTypeInvalidConfig, Message: "unknown detection method"}
@@ -782,11 +791,31 @@ func (hc *CmdHealthChecker) classifyOSError(err error, path string, isParent boo
 // infra error is classified recoverable rather than as a corrupt file.
 func (hc *CmdHealthChecker) classifyDetectorError(err error, path string) *HealthCheckError {
 	errStr := err.Error()
+	// Match case-insensitively: tool stderr uses sentence case ("No such
+	// file or directory") while Go's os/exec errors are lowercase
+	// ("fork/exec /x/ffprobe: no such file or directory"). The old
+	// case-sensitive patterns let exec failures fall through to the
+	// corruption fallthrough below, so a missing custom-path binary
+	// mass-flagged every scanned file as CorruptHeader.
+	errLower := strings.ToLower(errStr)
+
+	// Tool launch failures and tool crashes come FIRST: "fork/exec ...: no
+	// such file or directory" must not be mistaken for the media file being
+	// missing, and a detector dying to a signal (SIGSEGV decoder crash,
+	// OOM kill) is a statement about the tool, never about the file.
+	if strings.Contains(errLower, "fork/exec") ||
+		strings.Contains(errLower, "executable file not found") ||
+		strings.Contains(errLower, "signal:") {
+		return &HealthCheckError{
+			Type:    ErrorTypeToolFailure,
+			Message: errStr,
+		}
+	}
 
 	// Check for path-related errors (file disappeared, wrong path, symlink issues)
-	if strings.Contains(errStr, "No such file or directory") ||
-		strings.Contains(errStr, "does not exist") ||
-		strings.Contains(errStr, "not found") {
+	if strings.Contains(errLower, "no such file or directory") ||
+		strings.Contains(errLower, "does not exist") ||
+		strings.Contains(errLower, "not found") {
 		return &HealthCheckError{
 			Type:    ErrorTypePathNotFound,
 			Message: errStr,
@@ -794,8 +823,8 @@ func (hc *CmdHealthChecker) classifyDetectorError(err error, path string) *Healt
 	}
 
 	// Check for permission errors
-	if strings.Contains(errStr, "Permission denied") ||
-		strings.Contains(errStr, "access denied") {
+	if strings.Contains(errLower, "permission denied") ||
+		strings.Contains(errLower, "access denied") {
 		return &HealthCheckError{
 			Type:    ErrorTypeAccessDenied,
 			Message: errStr,
@@ -803,10 +832,10 @@ func (hc *CmdHealthChecker) classifyDetectorError(err error, path string) *Healt
 	}
 
 	// Check for I/O errors (network/mount issues that manifest during read)
-	if strings.Contains(errStr, "Input/output error") ||
-		strings.Contains(errStr, "Connection refused") ||
-		strings.Contains(errStr, "Network is unreachable") ||
-		strings.Contains(errStr, "transport endpoint") {
+	if strings.Contains(errLower, "input/output error") ||
+		strings.Contains(errLower, "connection refused") ||
+		strings.Contains(errLower, "network is unreachable") ||
+		strings.Contains(errLower, "transport endpoint") {
 		return &HealthCheckError{
 			Type:    ErrorTypeIOError,
 			Message: errStr,
@@ -814,7 +843,7 @@ func (hc *CmdHealthChecker) classifyDetectorError(err error, path string) *Healt
 	}
 
 	// Check for timeout
-	if strings.Contains(errStr, "timed out") {
+	if strings.Contains(errLower, "timed out") {
 		return &HealthCheckError{
 			Type:    ErrorTypeTimeout,
 			Message: errStr,

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -2163,3 +2163,107 @@ func TestDetectionMode_ScanValue(t *testing.T) {
 		t.Error("Scan(invalid) expected error, got nil")
 	}
 }
+
+// =============================================================================
+// Detector-failure classification table (audit findings 2+3)
+// =============================================================================
+//
+// The structural invariant: a detector TOOL failing (missing binary, signal
+// death, timeout, exec error) is never evidence of FILE corruption. Before
+// this table existed, three inputs slipped through to CorruptHeader (exec
+// failures on absolute custom tool paths, signal deaths, empty-stderr
+// mediainfo crashes) and the HandBrake branch declared everything
+// CorruptStream — each a mass-flag-then-mass-delete hazard under
+// auto_remediate.
+
+func TestClassifyDetectorError_ToolFailuresNeverCorruption(t *testing.T) {
+	hc := NewHealthChecker()
+
+	// The media file exists and is readable: the fallthrough accessibility
+	// re-check must NOT be what saves these cases.
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "healthy.mkv")
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		errText  string
+		wantType string
+	}{
+		// Go exec failures (lowercase!) from absolute custom tool paths
+		{"missing absolute-path binary", "fork/exec /config/tools/ffprobe: no such file or directory", ErrorTypeToolFailure},
+		{"non-executable binary", "fork/exec /config/tools/ffprobe: permission denied", ErrorTypeToolFailure},
+		{"bare name not in PATH", `exec: "ffprobe": executable file not found in $PATH`, ErrorTypeToolFailure},
+		// Signal deaths (text embedded by the tool runner for hwaccel retry)
+		{"SIGSEGV decoder crash", "ffmpeg failed (signal: segmentation fault): ", ErrorTypeToolFailure},
+		{"OOM-killed tool", "ffmpeg failed (signal: killed): ", ErrorTypeToolFailure},
+		{"mediainfo crash empty stderr", "mediainfo failed (signal: segmentation fault): ", ErrorTypeToolFailure},
+		{"handbrake exec failure", "HandBrake failed (fork/exec /usr/bin/HandBrakeCLI: no such file or directory): ", ErrorTypeToolFailure},
+		// Timeouts (any casing)
+		{"ffprobe timeout", "ffprobe timed out after 30s", ErrorTypeTimeout},
+		{"handbrake timeout", "HandBrake scan timed out after 5m0s", ErrorTypeTimeout},
+		// Path/permission/I/O in tool-stderr sentence case AND syscall lowercase
+		{"sentence-case missing file", "No such file or directory", ErrorTypePathNotFound},
+		{"lowercase missing file", "stat /media/x.mkv: no such file or directory", ErrorTypePathNotFound},
+		{"sentence-case permission", "Permission denied", ErrorTypeAccessDenied},
+		{"lowercase permission", "open /media/x.mkv: permission denied", ErrorTypeAccessDenied},
+		{"io error", "Input/output error", ErrorTypeIOError},
+		{"lowercase io error", "read /media/x.mkv: input/output error", ErrorTypeIOError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hc.classifyDetectorError(errors.New(tc.errText), path)
+			if got.Type != tc.wantType {
+				t.Errorf("classifyDetectorError(%q) = %s, want %s", tc.errText, got.Type, tc.wantType)
+			}
+			if got.IsTrueCorruption() {
+				t.Errorf("classifyDetectorError(%q) classified as TRUE CORRUPTION (%s) — a tool/infra failure must never route to deletion", tc.errText, got.Type)
+			}
+		})
+	}
+
+	// The fallthrough still works: an unrecognized detector error on an
+	// accessible file IS content corruption (this is what catches genuinely
+	// corrupt files whose stderr we don't pattern-match).
+	t.Run("unrecognized error on accessible file stays corruption", func(t *testing.T) {
+		got := hc.classifyDetectorError(errors.New("ffmpeg failed (exit status 183): EBML header parsing failed"), path)
+		if got.Type != ErrorTypeCorruptHeader {
+			t.Errorf("got %s, want CorruptHeader for unrecognized content error", got.Type)
+		}
+	})
+}
+
+// CheckWithConfig's HandBrake branch must route errors through the shared
+// classifier: a timeout or exec failure is recoverable, never CorruptStream.
+func TestCheckWithConfig_HandBrakeFailuresAreRecoverable(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "file.mkv")
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the HandBrake binary at something that cannot exist so the run
+	// fails with an exec error rather than a real scan.
+	t.Setenv("HEALARR_HANDBRAKE_PATH", filepath.Join(tmp, "no-such-handbrake"))
+
+	hc := NewHealthChecker()
+	healthy, hcErr := hc.CheckWithConfig(path, DetectionConfig{
+		Method: DetectionHandBrake,
+		Mode:   ModeQuick,
+	})
+	if healthy {
+		t.Fatal("expected unhealthy result for failed handbrake run")
+	}
+	if hcErr == nil {
+		t.Fatal("expected a HealthCheckError")
+	}
+	if hcErr.IsTrueCorruption() {
+		t.Errorf("HandBrake exec failure classified as corruption (%s); must be recoverable", hcErr.Type)
+	}
+	if !hcErr.IsRecoverable() {
+		t.Errorf("HandBrake exec failure not recoverable (%s)", hcErr.Type)
+	}
+}

--- a/internal/integration/health_checker_tools.go
+++ b/internal/integration/health_checker_tools.go
@@ -248,7 +248,12 @@ func (hc *CmdHealthChecker) runHandBrakeWithArgs(path string, customArgs []strin
 		return fmt.Errorf("HandBrake scan timed out after %v", timeout)
 	case err := <-done:
 		if err != nil {
-			return fmt.Errorf("HandBrake failed: %s", stderr.String())
+			// Include the wait/exec error itself (%v), not just stderr: a
+			// missing binary or signal death has empty stderr, and the
+			// classifier needs the "fork/exec ..." / "signal: ..." text to
+			// map the failure to a recoverable ToolFailure instead of
+			// corruption.
+			return fmt.Errorf("HandBrake failed (%v): %s", err, stderr.String())
 		}
 	}
 
@@ -305,7 +310,10 @@ func runCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration, toolName string
 		return nil, fmt.Errorf("%s timed out after %v", toolName, timeout)
 	case err := <-done:
 		if err != nil {
-			return nil, fmt.Errorf("%s failed: %s", toolName, stderr.String())
+			// Include the wait/exec error (%v) alongside stderr so signal
+			// deaths and launch failures (empty stderr) carry the text the
+			// classifier maps to recoverable ToolFailure.
+			return nil, fmt.Errorf("%s failed (%v): %s", toolName, err, stderr.String())
 		}
 	}
 	return stdout.Bytes(), nil

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -203,6 +203,7 @@ const (
 	ErrorTypeIOError       = "IOError"       // Generic I/O error (network, disk)
 	ErrorTypeTimeout       = "Timeout"       // Operation timed out
 	ErrorTypeInvalidConfig = "InvalidConfig" // Bad detection configuration
+	ErrorTypeToolFailure   = "ToolFailure"   // Detector tool failed to launch or crashed (fork/exec, signal death) - never evidence of file corruption
 )
 
 // HealthCheckError contains details about why a file is unhealthy
@@ -259,6 +260,7 @@ var errorCategories = map[string]ErrorCategory{
 	ErrorTypeIOError:       CategoryRecoverable,
 	ErrorTypeTimeout:       CategoryRecoverable,
 	ErrorTypeInvalidConfig: CategoryRecoverable,
+	ErrorTypeToolFailure:   CategoryRecoverable,
 }
 
 // category returns the registered category for this error type. Missing


### PR DESCRIPTION
Fixes CRITICAL findings 2 and 3 from the Fable 5 audit.

## Finding 2: HandBrake bypassed the classifier
The HandBrake branch matched two path patterns and declared everything else `CorruptStream` — a timeout, missing HandBrakeCLI, or mount failure under the **Paranoid preset** mass-flagged whole libraries. Now routed through `classifyDetectorError` (genuine-corruption fallthrough re-typed to CorruptStream to keep the stream-level flavor).

## Finding 3: classifier missed exec failures and signal deaths
- Case-sensitive patterns ("No such file or directory") missed Go's lowercase exec errors (`fork/exec /config/tools/ffprobe: no such file or directory`) → CorruptHeader on every file when a custom tool path breaks. **Matching is now case-insensitive.**
- New first-priority pattern group: `fork/exec`, `executable file not found`, `signal:` → new recoverable `ErrorTypeToolFailure` (registered in errorCategories).
- HandBrake + mediainfo wraps now embed the exec error (`%v`), so empty-stderr signal deaths carry matchable text (the ffprobe runner already did this for the hwaccel-retry matcher).

## Safety analysis
- The hwaccel retry-without-hwaccel (#278) still happens BEFORE classification; if both attempts die to signals, the final classification is now recoverable ToolFailure instead of CorruptHeader — defense-in-depth, not a behavior regression.
- The corruption fallthrough (unrecognized error + accessible file → CorruptHeader) is preserved and pinned by test: genuinely corrupt files still route to remediation.

## Test plan
- [x] New `TestClassifyDetectorError_ToolFailuresNeverCorruption`: 15 failure shapes × never-IsTrueCorruption (exec errors, signals, timeouts, sentence-case + lowercase path/perm/I/O), plus fallthrough-still-corruption case
- [x] New `TestCheckWithConfig_HandBrakeFailuresAreRecoverable`: end-to-end exec failure → recoverable
- [x] Full integration + services suites green; lint 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error classification to distinguish transient media detection tool failures from actual media corruption
  * Improved error messages when detection tools fail to execute or become unavailable

* **Tests**
  * Added comprehensive test coverage for tool execution failures and timeout scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->