### PR TITLE
fix(scanner): scan lifecycle integrity (audit findings 7+8+9, HIGH)

### DIFF
--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -301,9 +301,16 @@ func (r *ScanRepository) Finalize(ctx context.Context, scanID int64, status stri
 
 // MarkInterrupted records a shutdown-time interruption, saving the file
 // index reached so the scan can resume there.
+//
+// The status guard keeps it from resurrecting terminal scans: Shutdown calls
+// this for every entry still in activeScans, and a scan that just aborted
+// (dead mount) or was cancelled mid-shutdown must not be flipped back to
+// 'interrupted' — resume would then replay it against a possibly still-dead
+// mount on the next startup.
 func (r *ScanRepository) MarkInterrupted(ctx context.Context, scanID int64, currentFileIndex int) error {
 	_, err := r.db.ExecContext(ctx, `
-		UPDATE scans SET status = 'interrupted', current_file_index = ? WHERE id = ?
+		UPDATE scans SET status = 'interrupted', current_file_index = ?
+		WHERE id = ? AND status NOT IN ('cancelled', 'completed', 'aborted')
 	`, currentFileIndex, scanID)
 	if err != nil {
 		return fmt.Errorf("mark scan interrupted: %w", err)
@@ -408,6 +415,12 @@ func (r *ScanRepository) MarkOrphansCancelled(ctx context.Context) (int64, error
 // (the #274 zombie pattern) IS exactly what this query is supposed to
 // reap. activeScans is empty at startup, so any row in an active status
 // is by definition an orphan.
+//
+// 'paused' is included: the pause lives in process memory (pauseChan /
+// isPaused on the in-memory ScanProgress), so after a restart no code path
+// can ever resume a paused row — it used to survive reconcile as a
+// permanently stranded "paused" scan. A paused row with progress is exactly
+// as resumable as an interrupted one; one without progress scanned nothing.
 func (r *ScanRepository) ReconcileOrphans(ctx context.Context) (ReconcileOrphansResult, error) {
 	var out ReconcileOrphansResult
 
@@ -421,7 +434,7 @@ func (r *ScanRepository) ReconcileOrphans(ctx context.Context) (ReconcileOrphans
 		UPDATE scans
 		SET status = 'interrupted',
 		    error_message = 'auto-marked interrupted on Healarr restart'
-		WHERE status IN ('running', 'scanning')
+		WHERE status IN ('running', 'scanning', 'paused')
 		  AND current_file_index > 0
 		  AND total_files > 0
 		  AND file_list IS NOT NULL
@@ -436,7 +449,7 @@ func (r *ScanRepository) ReconcileOrphans(ctx context.Context) (ReconcileOrphans
 		SET status = 'cancelled',
 		    completed_at = datetime('now'),
 		    error_message = 'abandoned on Healarr restart'
-		WHERE status IN ('running', 'enumerating', 'scanning')
+		WHERE status IN ('running', 'enumerating', 'scanning', 'paused')
 	`)
 	if err != nil {
 		return out, fmt.Errorf("mark orphan scans cancelled: %w", err)

--- a/internal/repository/scan_test.go
+++ b/internal/repository/scan_test.go
@@ -449,9 +449,12 @@ func TestScanRepository_MarkOrphansCancelled(t *testing.T) {
 		t.Fatalf("Finalize setup: %v", err)
 	}
 
+	// running + enumerating cancel; the paused row (it has progress via
+	// MarkPaused) demotes to interrupted — pause state cannot survive a
+	// restart, so a paused-with-progress row is resumable, not spared.
 	n, err := repo.MarkOrphansCancelled(ctx)
-	if err != nil || n != 2 {
-		t.Fatalf("MarkOrphansCancelled: got (%d, %v), want (2, nil)", n, err)
+	if err != nil || n != 3 {
+		t.Fatalf("MarkOrphansCancelled: got (%d, %v), want (3, nil)", n, err)
 	}
 
 	check := func(id int64, want string) {
@@ -463,7 +466,7 @@ func TestScanRepository_MarkOrphansCancelled(t *testing.T) {
 	}
 	check(running, "cancelled")
 	check(enumerating, "cancelled")
-	check(paused, "paused")           // spared
+	check(paused, "interrupted")      // paused with progress: demoted for resume
 	check(interrupted, "interrupted") // spared
 	check(completed, "completed")     // untouched
 
@@ -511,8 +514,8 @@ func TestScanRepository_ReconcileOrphans_ResumesProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReconcileOrphans: %v", err)
 	}
-	if out.Interrupted != 1 {
-		t.Errorf("Interrupted count: got %d, want 1 (only the row with progress)", out.Interrupted)
+	if out.Interrupted != 2 {
+		t.Errorf("Interrupted count: got %d, want 2 (running-with-progress + paused-with-progress)", out.Interrupted)
 	}
 	if out.Cancelled != 2 {
 		t.Errorf("Cancelled count: got %d, want 2 (zero-progress running + enumerating)", out.Cancelled)
@@ -528,7 +531,7 @@ func TestScanRepository_ReconcileOrphans_ResumesProgress(t *testing.T) {
 	check(resumable, "interrupted") // demoted, resume will pick up
 	check(zero, "cancelled")        // no progress to resume
 	check(enumerating, "cancelled") // file list not built
-	check(paused, "paused")         // spared
+	check(paused, "interrupted")    // paused with progress: resumable after restart
 	check(completed, "completed")   // untouched
 
 	// Resumable row's progress fields must survive so resume can use them.
@@ -630,7 +633,9 @@ func TestScanRepository_MarkCancelled_NoOpOnTerminalStates(t *testing.T) {
 }
 
 // MarkOrphansCancelled must catch zombie active-with-completed_at rows
-// at startup (the #274 fix). Paused and interrupted are still spared.
+// at startup (the #274 fix). Interrupted is still spared; paused is now an
+// orphan too (pause state lives in process memory and cannot survive a
+// restart) — without progress it cancels, with progress it resumes.
 func TestScanRepository_MarkOrphansCancelled_CatchesZombieRows(t *testing.T) {
 	t.Parallel()
 	db := newScanTestDB(t)
@@ -644,14 +649,14 @@ func TestScanRepository_MarkOrphansCancelled_CatchesZombieRows(t *testing.T) {
 	`)
 	// A clean orphan: status='running', completed_at NULL.
 	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (11, '/clean', 'running')`)
-	// Paused: must NOT be touched.
+	// Paused without progress: orphaned by restart, nothing to resume -> cancelled.
 	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (12, '/p', 'paused')`)
 	// Interrupted: must NOT be touched.
 	mustExecScan(t, db, `INSERT INTO scans (id, path, status) VALUES (13, '/i', 'interrupted')`)
 
 	n, err := repo.MarkOrphansCancelled(ctx)
-	if err != nil || n != 2 {
-		t.Fatalf("MarkOrphansCancelled: got (%d, %v), want (2, nil)", n, err)
+	if err != nil || n != 3 {
+		t.Fatalf("MarkOrphansCancelled: got (%d, %v), want (3, nil)", n, err)
 	}
 
 	check := func(id int64, want string) {
@@ -663,7 +668,7 @@ func TestScanRepository_MarkOrphansCancelled_CatchesZombieRows(t *testing.T) {
 	}
 	check(10, "cancelled")   // zombie reaped
 	check(11, "cancelled")   // clean orphan reaped
-	check(12, "paused")      // spared
+	check(12, "cancelled")   // paused without progress: nothing to resume
 	check(13, "interrupted") // spared
 }
 
@@ -772,5 +777,39 @@ func TestScanRepository_ReconcileOrphans_EnumeratingGoesCancelled(t *testing.T) 
 	_ = db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&status)
 	if status != "cancelled" {
 		t.Errorf("status = %q, want cancelled", status)
+	}
+}
+
+// MarkInterrupted must not resurrect terminal scans: Shutdown calls it for
+// everything still in activeScans, and flipping a just-aborted scan to
+// 'interrupted' would resume it on next startup against a possibly
+// still-dead mount.
+func TestScanRepository_MarkInterrupted_DoesNotResurrectTerminal(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	ctx := context.Background()
+
+	for _, status := range []string{"aborted", "cancelled", "completed"} {
+		id := seedScan(t, db, "/t-"+status, status, 10, 0, "")
+		if err := repo.MarkInterrupted(ctx, id, 5); err != nil {
+			t.Fatalf("MarkInterrupted(%s): %v", status, err)
+		}
+		var got string
+		_ = db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&got)
+		if got != status {
+			t.Errorf("terminal %q row flipped to %q by MarkInterrupted", status, got)
+		}
+	}
+
+	// And an active scan IS marked interrupted (the normal shutdown path).
+	id := seedScan(t, db, "/active", "running", 10, 0, "")
+	if err := repo.MarkInterrupted(ctx, id, 5); err != nil {
+		t.Fatalf("MarkInterrupted(running): %v", err)
+	}
+	var got string
+	_ = db.QueryRow(`SELECT status FROM scans WHERE id=?`, id).Scan(&got)
+	if got != "interrupted" {
+		t.Errorf("running row = %q, want interrupted", got)
 	}
 }

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -251,6 +251,16 @@ type ScanProgress struct {
 	isPaused        bool               `json:"-"` // Track pause state
 	corruptionCount int                `json:"-"` // Track corruptions found in this scan for throttling
 	isThrottled     bool               `json:"-"` // Whether this scan is being throttled
+
+	// usesWatermark + resumeIndex carry the parallel scan's contiguous-done
+	// watermark (maintained by the watermark goroutine in scanFilesParallel,
+	// under mu). When usesWatermark is true, shutdown/pause persistence MUST
+	// use resumeIndex: workers complete out of order, so both FilesDone (a
+	// count) and the dispatch frontier OVERSHOOT the highest index for which
+	// everything before it is done — persisting either would make a resumed
+	// scan silently skip the unfinished gap.
+	usesWatermark bool `json:"-"`
+	resumeIndex   int  `json:"-"`
 }
 
 // ScanProgressView is a race-free value-type snapshot of a ScanProgress.
@@ -322,6 +332,15 @@ type scanFilesConfig struct {
 	AutoRemediate   bool
 	DryRun          bool
 	ScanDBID        int64
+
+	// persistProgressInline gates markFileProcessed's every-10-files
+	// UpdateProgress write. True only on the serial path, where files
+	// complete in order and the worker's own index IS the resume point. In
+	// parallel mode the watermark goroutine owns all progress persistence:
+	// an out-of-order worker writing its own index would overshoot the
+	// contiguous watermark and make resume skip unfinished files. Set by
+	// scanFiles when it picks the execution mode.
+	persistProgressInline bool
 }
 
 // Scanner defines the interface for scan operations.
@@ -577,12 +596,21 @@ func (s *ScannerService) Shutdown() {
 			filesDone := scan.FilesDone
 			totalFiles := scan.TotalFiles
 			scanDBID := scan.ScanDBID
+			resumeAt := filesDone
+			if scan.usesWatermark {
+				// Parallel scan: FilesDone is a completion COUNT, not an
+				// index, and workers finish out of order — persisting it
+				// would overshoot the contiguous watermark and make resume
+				// skip unfinished files. The watermark goroutine keeps
+				// resumeIndex at the highest safe replay point.
+				resumeAt = scan.resumeIndex
+			}
 			scan.mu.Unlock()
 
-			logger.Infof("Scanner: saving state for scan %s (file %d/%d)", scanID, filesDone, totalFiles)
+			logger.Infof("Scanner: saving state for scan %s (resume at %d, %d/%d files done)", scanID, resumeAt, filesDone, totalFiles)
 			// Mark as interrupted in database - state is already saved during scanning
 			ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-			err := s.scanRepo().MarkInterrupted(ctx, scanDBID, filesDone)
+			err := s.scanRepo().MarkInterrupted(ctx, scanDBID, resumeAt)
 			cancel()
 			if err != nil {
 				logger.Errorf("Failed to save scan state for %s: %v", scanID, err)
@@ -705,8 +733,20 @@ func (s *ScannerService) resumeScan(cfg resumeScanConfig) {
 	}
 
 	defer func() {
+		// Mirror finalizeScan: an INTERRUPTED scan must NOT be finalized.
+		// Finalize unconditionally stamps completed_at, and ListInterrupted
+		// requires completed_at IS NULL — so finalizing here made any scan
+		// that was resumed once and interrupted again permanently
+		// unresumable. Shutdown's MarkInterrupted already persisted the
+		// resume state; leave the row alone.
+		if progress.Status == ScanStatusInterrupted {
+			s.mu.Lock()
+			delete(s.activeScans, scanID)
+			s.mu.Unlock()
+			return
+		}
 		finalStatus := ScanStatusCompleted
-		if progress.Status == ScanStatusCancelled || progress.Status == ScanStatusInterrupted {
+		if progress.Status == ScanStatusCancelled || progress.Status == ScanStatusAborted {
 			finalStatus = progress.Status
 		}
 		deferCtx, deferCancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
@@ -1103,8 +1143,14 @@ func (s *ScannerService) handlePathInaccessible(scanID, localPath string, access
 func (s *ScannerService) finalizeScan(scanID string, progress *ScanProgress, scanDBID int64) {
 	if progress.Status != ScanStatusInterrupted {
 		finalStatus := ScanStatusCompleted
-		if progress.Status == ScanStatusCancelled {
+		switch progress.Status {
+		case ScanStatusCancelled:
 			finalStatus = ScanStatusCancelled
+		case ScanStatusAborted:
+			// A mount-failure abort must stay ABORTED: finalizing it as
+			// completed made a failed scan masquerade as a successful one in
+			// "Last Scan" and the dashboard.
+			finalStatus = ScanStatusAborted
 		}
 		if scanDBID > 0 {
 			ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
@@ -1340,15 +1386,25 @@ const (
 // checkScanCancellation checks if the scan should be cancelled due to context cancellation or shutdown.
 // Returns scanReturn if cancelled, scanContinue otherwise.
 func (s *ScannerService) checkScanCancellation(ctx context.Context, progress *ScanProgress, localPath string, fileIndex, totalFiles int) scanLoopAction {
+	// Check shutdown FIRST and on its own: Shutdown closes shutdownCh, marks
+	// the scan interrupted in the DB, then cancels the ctx — so by the time
+	// a goroutine sees ctx.Done(), shutdownCh is also closed. A combined
+	// select picks pseudo-randomly between two ready channels, which made
+	// roughly half of all graceful shutdowns finalize the scan as
+	// "cancelled" (terminal, never resumed) instead of "interrupted",
+	// silently discarding hours of progress per docker restart.
+	select {
+	case <-s.shutdownCh:
+		logger.Infof("Scan interrupted for graceful shutdown: %s (at file %d/%d)", localPath, fileIndex, totalFiles)
+		progress.Status = ScanStatusInterrupted
+		s.emitProgress(progress)
+		return scanReturn
+	default:
+	}
 	select {
 	case <-ctx.Done():
 		logger.Infof("Scan cancelled: %s", localPath)
 		progress.Status = ScanStatusCancelled
-		s.emitProgress(progress)
-		return scanReturn
-	case <-s.shutdownCh:
-		logger.Infof("Scan interrupted for graceful shutdown: %s (at file %d/%d)", localPath, fileIndex, totalFiles)
-		progress.Status = ScanStatusInterrupted
 		s.emitProgress(progress)
 		return scanReturn
 	default:
@@ -1370,10 +1426,19 @@ func (s *ScannerService) handleScanPause(ctx context.Context, progress *ScanProg
 
 	logger.Infof("Scan paused: %s (at file %d/%d)", localPath, fileIndex+1, progress.TotalFiles)
 
-	// Save current position
+	// Save current position. For parallel scans, fileIndex is the DISPATCH
+	// frontier (files handed to workers), which overshoots the contiguous
+	// watermark; persist the watermark so a resume after pause+restart
+	// cannot skip files still in flight at pause time.
+	resumeAt := fileIndex
+	progress.mu.Lock()
+	if progress.usesWatermark {
+		resumeAt = progress.resumeIndex
+	}
+	progress.mu.Unlock()
 	if scanDBID > 0 {
 		pauseCtx, pauseCancel := context.WithTimeout(ctx, scannerQueryTimeout)
-		if err := s.scanRepo().MarkPaused(pauseCtx, scanDBID, fileIndex); err != nil {
+		if err := s.scanRepo().MarkPaused(pauseCtx, scanDBID, resumeAt); err != nil {
 			logger.Warnf("Failed to update scan pause state for scan %d: %v", scanDBID, err)
 		}
 		pauseCancel()
@@ -1656,10 +1721,16 @@ func (s *ScannerService) scanFiles(ctx context.Context, progress *ScanProgress, 
 	// (default for &ScannerService{}-direct test fixtures) keeps the original
 	// single-file-at-a-time path untouched.
 	if s.scanWorkers > 1 {
+		// Parallel mode: the watermark goroutine owns ALL progress
+		// persistence; workers must not write their own out-of-order index.
+		cfg.persistProgressInline = false
 		s.scanFilesParallel(ctx, progress, cfg, activeCorruptions)
 		return
 	}
 
+	// Serial mode: files complete in order, so the inline every-10-files
+	// checkpoint in markFileProcessed is the correct resume point.
+	cfg.persistProgressInline = true
 	for i := cfg.StartIndex; i < len(cfg.Files); i++ {
 		action := s.processFileInScan(ctx, progress, cfg, i, activeCorruptions)
 		if action == scanReturn {
@@ -1727,12 +1798,28 @@ func (s *ScannerService) scanFilesParallel(
 	sem := make(chan struct{}, s.scanWorkers)
 	var wg sync.WaitGroup
 
+	// Mark this scan watermark-managed: shutdown/pause persistence must use
+	// progress.resumeIndex (the contiguous-done watermark) instead of
+	// FilesDone or the dispatch frontier, both of which overshoot under
+	// out-of-order completion.
+	progress.mu.Lock()
+	progress.usesWatermark = true
+	progress.resumeIndex = cfg.StartIndex
+	progress.mu.Unlock()
+
 	// Watermark persister: walks `done` from cfg.StartIndex forward over
 	// consecutive trues, advances an in-memory watermark, and flushes it to
 	// scans.current_file_index every ~watermarkPersistInterval. Owning the
 	// DB write here means workers can finish out of order without
 	// corrupting the resume floor.
+	//
+	// workersDone closes after wg.Wait() so the goroutine always terminates
+	// even when the scan stops early WITHOUT a ctx cancel (worker panic,
+	// mount-lost abort): before this exit path existed, scanFilesParallel
+	// blocked forever on <-watermarkDone, the deferred ctx cancel in
+	// ScanPath never ran, and the path stayed "being scanned" until restart.
 	watermarkDone := make(chan struct{})
+	workersDone := make(chan struct{})
 	safego.Run("scan-watermark", func() {
 		defer close(watermarkDone)
 		watermark := cfg.StartIndex
@@ -1744,6 +1831,9 @@ func (s *ScannerService) scanFilesParallel(
 			for watermark < len(files) && done[watermark].Load() {
 				watermark++
 			}
+			progress.mu.Lock()
+			progress.resumeIndex = watermark
+			progress.mu.Unlock()
 		}
 		persistIfAdvanced := func() {
 			if cfg.ScanDBID <= 0 || watermark == lastPersisted {
@@ -1775,6 +1865,13 @@ func (s *ScannerService) scanFilesParallel(
 			case <-ticker.C:
 				persistIfAdvanced()
 			case <-ctx.Done():
+				persistIfAdvanced()
+				return
+			case <-workersDone:
+				// All workers finished but the watermark did not reach the
+				// end (early stop). Persist the final contiguous position
+				// and exit so scanFilesParallel can return.
+				advance()
 				persistIfAdvanced()
 				return
 			}
@@ -1814,6 +1911,21 @@ func (s *ScannerService) scanFilesParallel(
 		safego.Run("scan-detect-worker", func() {
 			defer wg.Done()
 			defer func() { <-sem }()
+			// A panic inside detection/handling must not wedge the scan:
+			// without this recover, done[idx] stayed false forever, the
+			// watermark never reached len(files), and the whole scan
+			// deadlocked on <-watermarkDone with the path locked until
+			// restart. Recover locally, count the file as processed
+			// (skipped), and let the scan continue. (safego's top-level
+			// recover never fires for this closure anymore, which is fine —
+			// it exists as the generic backstop.)
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Errorf("Scan worker panicked on %s (file skipped): %v", files[idx], r)
+					s.markFileProcessedNoSync(progress)
+					done[idx].Store(true)
+				}
+			}()
 
 			// Late-bail: another worker may have flipped `stopped` between
 			// our dispatch and our start. Don't mark done — resume must
@@ -1861,6 +1973,7 @@ func (s *ScannerService) scanFilesParallel(
 	}
 
 	wg.Wait()
+	close(workersDone)
 	<-watermarkDone
 
 	if !stopped.Load() {
@@ -1940,7 +2053,7 @@ func (s *ScannerService) processFileInScan(
 	if s.filesInProgress[filePath] {
 		s.filesMu.Unlock()
 		logger.Debugf("Skipping file already being scanned: %s", filePath)
-		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
+		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID, cfg.persistProgressInline)
 		return scanContinue
 	}
 	s.filesInProgress[filePath] = true
@@ -2090,7 +2203,7 @@ func (s *ScannerService) handleDetection(
 		return s.handleHealthCheckResult(ctx, progress, cfg, fileIndex, sfc, result.healthErr)
 	}
 
-	s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
+	s.markFileProcessed(progress, fileIndex, cfg.ScanDBID, cfg.persistProgressInline)
 	return scanContinue
 }
 
@@ -2108,7 +2221,7 @@ func (s *ScannerService) handleHealthCheckResult(
 		if s.handleRecoverableError(progress, sfc, healthErr) == scanReturn {
 			return scanReturn
 		}
-		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
+		s.markFileProcessed(progress, fileIndex, cfg.ScanDBID, cfg.persistProgressInline)
 		return scanContinue
 	}
 
@@ -2116,12 +2229,15 @@ func (s *ScannerService) handleHealthCheckResult(
 	if s.handleTrueCorruption(ctx, progress, sfc, healthErr) == scanReturn {
 		return scanReturn
 	}
-	s.markFileProcessed(progress, fileIndex, cfg.ScanDBID)
+	s.markFileProcessed(progress, fileIndex, cfg.ScanDBID, cfg.persistProgressInline)
 	return scanContinue
 }
 
-// markFileProcessed increments the file counter and saves progress periodically
-func (s *ScannerService) markFileProcessed(progress *ScanProgress, fileIndex int, scanDBID int64) {
+// markFileProcessed increments the file counter and, on the serial path
+// (persistInline), saves progress periodically. Parallel-mode callers pass
+// persistInline=false: their fileIndex is out of order and the watermark
+// goroutine owns progress persistence.
+func (s *ScannerService) markFileProcessed(progress *ScanProgress, fileIndex int, scanDBID int64, persistInline bool) {
 	// Lock to safely update mutable fields (fixes data race with GetActiveScans/Shutdown)
 	progress.mu.Lock()
 	progress.FilesDone++
@@ -2129,7 +2245,7 @@ func (s *ScannerService) markFileProcessed(progress *ScanProgress, fileIndex int
 	progress.mu.Unlock()
 
 	// Save state to database periodically (every 10 files) to avoid excessive I/O
-	if fileIndex%10 == 0 {
+	if persistInline && fileIndex%10 == 0 {
 		if scanDBID > 0 {
 			progressCtx, progressCancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
 			if err := s.scanRepo().UpdateProgress(progressCtx, scanDBID, fileIndex, filesDone); err != nil {

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4145,7 +4145,7 @@ func TestScannerService_MarkFileProcessed(t *testing.T) {
 			FilesDone: 10,
 		}
 
-		scanner.markFileProcessed(progress, 5, 0)
+		scanner.markFileProcessed(progress, 5, 0, true)
 
 		if progress.FilesDone != 11 {
 			t.Errorf("Expected FilesDone 11, got %d", progress.FilesDone)
@@ -4167,7 +4167,7 @@ func TestScannerService_MarkFileProcessed(t *testing.T) {
 		}
 
 		// Index 20 should trigger save (20 % 10 == 0)
-		scanner.markFileProcessed(progress, 20, scanDBID)
+		scanner.markFileProcessed(progress, 20, scanDBID, true)
 
 		// Verify database was updated
 		var currentIndex, filesScanned int
@@ -4189,7 +4189,7 @@ func TestScannerService_MarkFileProcessed(t *testing.T) {
 		}
 
 		// Should not panic with scanDBID 0
-		scanner.markFileProcessed(progress, 10, 0)
+		scanner.markFileProcessed(progress, 10, 0, true)
 
 		if progress.FilesDone != 10 {
 			t.Errorf("Expected FilesDone 10, got %d", progress.FilesDone)
@@ -5005,5 +5005,173 @@ func TestScannerService_ScanFile_Healthy(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("healthy file emitted %d corruption events, want 0", count)
+	}
+}
+
+// =============================================================================
+// Scan lifecycle integrity (audit findings 7+8+9)
+// =============================================================================
+
+// A worker panic must not wedge the parallel scan: before the in-worker
+// recover, done[idx] stayed false forever, the watermark never reached the
+// end, and scanFilesParallel deadlocked on <-watermarkDone with the path
+// locked until restart.
+func TestScannerService_ScanFilesParallel_SurvivesWorkerPanic(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("NewTestDB: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckWithConfigFunc: func(path string, _ integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+			if strings.Contains(path, "f05") {
+				panic("simulated detection panic")
+			}
+			return true, nil
+		},
+	}
+
+	scanner := &ScannerService{
+		db:              db,
+		eventBus:        eb,
+		detector:        mockHC,
+		activeScans:     make(map[string]*ScanProgress),
+		filesInProgress: make(map[string]bool),
+		shutdownCh:      make(chan struct{}),
+		scanWorkers:     4,
+	}
+
+	tmpDir := t.TempDir()
+	const n = 20
+	files := make([]string, n)
+	oldTime := time.Now().Add(-10 * time.Minute)
+	for i := 0; i < n; i++ {
+		f := filepath.Join(tmpDir, fmt.Sprintf("f%02d.mkv", i))
+		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		_ = os.Chtimes(f, oldTime, oldTime)
+		files[i] = f
+	}
+
+	res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files, files_scanned) VALUES (?, 1, 'running', ?, 0)`, tmpDir, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanDBID, _ := res.LastInsertId()
+
+	progress := &ScanProgress{
+		ID: "panic-scan", Type: "path", Path: tmpDir, PathID: 1,
+		TotalFiles: n, ScanDBID: scanDBID, resumeChan: make(chan struct{}),
+	}
+
+	doneCh := make(chan struct{})
+	go func() {
+		scanner.scanFiles(context.Background(), progress, scanFilesConfig{
+			Files: files, StartIndex: 0,
+			DetectionConfig: integration.DetectionConfig{Method: "ffprobe", Mode: "quick"},
+			ScanDBID:        scanDBID,
+		})
+		close(doneCh)
+	}()
+
+	select {
+	case <-doneCh:
+		// Scan returned: no deadlock.
+	case <-time.After(15 * time.Second):
+		t.Fatal("parallel scan deadlocked after worker panic (watermark never released)")
+	}
+
+	if progress.Status != "completed" {
+		t.Errorf("Status = %q, want completed (panicked file is skipped, not fatal)", progress.Status)
+	}
+	// 19 healthy rows; the panicked file has no row but was counted processed.
+	var healthy int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM scan_files WHERE scan_id = ? AND status='healthy'`, scanDBID).Scan(&healthy)
+	if healthy != n-1 {
+		t.Errorf("healthy rows = %d, want %d", healthy, n-1)
+	}
+	// Watermark must have reached the end so resume cannot skip anything.
+	var idx int
+	_ = db.QueryRow(`SELECT current_file_index FROM scans WHERE id = ?`, scanDBID).Scan(&idx)
+	if idx != n {
+		t.Errorf("current_file_index = %d, want %d", idx, n)
+	}
+}
+
+// During graceful shutdown both shutdownCh and the scan ctx become ready;
+// the old combined select picked pseudo-randomly, finalizing ~half of all
+// scans as cancelled (terminal) instead of interrupted (resumable). The
+// check must be deterministic: shutdown wins.
+func TestScannerService_CheckScanCancellation_ShutdownWinsDeterministically(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	scanner := &ScannerService{
+		db:          db,
+		eventBus:    eb,
+		activeScans: make(map[string]*ScanProgress),
+		shutdownCh:  make(chan struct{}),
+	}
+	close(scanner.shutdownCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for i := 0; i < 100; i++ {
+		progress := &ScanProgress{ID: "s", resumeChan: make(chan struct{})}
+		action := scanner.checkScanCancellation(ctx, progress, "/p", 1, 10)
+		if action != scanReturn {
+			t.Fatal("expected scanReturn")
+		}
+		if progress.Status != ScanStatusInterrupted {
+			t.Fatalf("iteration %d: Status = %q, want interrupted (select race regressed)", i, progress.Status)
+		}
+	}
+}
+
+// finalizeScan must keep an aborted scan ABORTED: mapping it to completed
+// made a mount-failure scan masquerade as a successful one in "Last Scan".
+func TestScannerService_FinalizeScan_AbortedStaysAborted(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files) VALUES ('/p', 1, 'running', 10)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanDBID, _ := res.LastInsertId()
+
+	scanner := &ScannerService{
+		db:          db,
+		activeScans: make(map[string]*ScanProgress),
+		shutdownCh:  make(chan struct{}),
+	}
+	scanner.initRepositories()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+	scanner.eventBus = eb
+
+	progress := &ScanProgress{ID: "abort-scan", Status: ScanStatusAborted, FilesDone: 3}
+	scanner.activeScans["abort-scan"] = progress
+
+	scanner.finalizeScan("abort-scan", progress, scanDBID)
+
+	var status string
+	_ = db.QueryRow(`SELECT status FROM scans WHERE id = ?`, scanDBID).Scan(&status)
+	if status != "aborted" {
+		t.Errorf("finalized status = %q, want aborted", status)
 	}
 }


### PR DESCRIPTION
Fixes HIGH findings 7, 8, 9 from the Fable 5 audit.

## Finding 7: resume could silently skip up to scanWorkers-1 files
Three writers disagreed with the #300 watermark: workers' inline every-10-files `UpdateProgress` (out-of-order index), Shutdown persisting `FilesDone` (a count), pause persisting the dispatch frontier. Now: inline persist gated to the serial path (`cfg.persistProgressInline`); the watermark goroutine mirrors into `progress.resumeIndex`; shutdown/pause persist the watermark for parallel scans.

## Finding 8: progress discarded on restart, four ways
1. **Select race**: shutdownCh now checked before ctx.Done (deterministic interrupted; was a coin flip per scan per restart).
2. **resumeScan finalizer**: now skips Finalize for interrupted (was stamping completed_at, making twice-interrupted scans permanently unresumable).
3. **Paused stranded**: ReconcileOrphans demotes paused-with-progress → interrupted, cancels paused-without (pause state cannot survive restart).
4. **MarkInterrupted guard** + **finalizeScan aborted-stays-aborted**.

## Finding 9: worker panic / mount-abort deadlocked the scan forever
Workers recover their own panics (file counted + skipped, done[idx] set); new `workersDone` channel guarantees the watermark goroutine exits even on early stop without ctx cancel.

## Test plan
- [x] New: panic-resilience (scan completes, watermark reaches end), deterministic shutdown select (100 iter), aborted-stays-aborted, MarkInterrupted terminal guard, paused demote/cancel matrix
- [x] Full services suite green under `-race` (40s); repository green; lint 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan state recovery during restart by properly handling paused scans and preventing resurrection of terminal statuses.
  * Enhanced parallel scan progress tracking to correctly support out-of-order file processing and ensure consistent resume points.
  * Fixed scan finalization to preserve aborted status and prevent orphaned scan states after shutdown.

* **Tests**
  * Added coverage for worker resilience, cancellation determinism, and terminal status protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->