### PR TITLE
fix(verifier): recoverable-error triage + arr-path mapping (audit findings 6+11, HIGH)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -269,6 +269,7 @@ func initCoreServices(
 	logger.Infof("✓ Monitor Service (tracks corruption lifecycle)")
 
 	healthMonitorService := services.NewHealthMonitorService(sqlDB, eb, arrClient, cfg.StaleThreshold)
+	healthMonitorService.SetPathMapper(pathMapper)
 	logger.Infof("✓ Health Monitor Service (detects stuck remediations)")
 
 	recoveryService := services.NewRecoveryService(sqlDB, eb, arrClient, pathMapper, healthChecker, cfg.StaleThreshold)

--- a/internal/services/health_monitor.go
+++ b/internal/services/health_monitor.go
@@ -23,6 +23,7 @@ type HealthMonitorService struct {
 	db         *sql.DB
 	eventBus   eventbus.Publisher
 	arrClient  integration.ArrClient
+	pathMapper integration.PathMapper
 	shutdownCh chan struct{}
 	wg         sync.WaitGroup
 
@@ -36,6 +37,25 @@ type HealthMonitorService struct {
 	repeatedFailureCount   int
 	instanceHealthInterval time.Duration
 	arrSyncInterval        time.Duration
+}
+
+// SetPathMapper wires the local-to-arr path translation used for arr-side
+// API lookups. Optional: without it, lookups fall back to the raw local
+// path, which only matches on same-path setups.
+func (h *HealthMonitorService) SetPathMapper(pm integration.PathMapper) {
+	h.pathMapper = pm
+}
+
+// arrPathFor maps a local path to the *arr's path form for arr-side API
+// lookups; falls back to the raw path when no mapping applies.
+func (h *HealthMonitorService) arrPathFor(localPath string) string {
+	if h.pathMapper == nil {
+		return localPath
+	}
+	if mapped, err := h.pathMapper.ToArrPath(localPath); err == nil && mapped != "" {
+		return mapped
+	}
+	return localPath
 }
 
 // NewHealthMonitorService creates a new health monitoring service
@@ -675,7 +695,7 @@ func (h *HealthMonitorService) scanSyncRow(rows *sql.Rows) (arrSyncItem, bool) {
 func (h *HealthMonitorService) checkArrHasFile(filePath string, mediaID int64) (bool, error) {
 	// Use GetAllFilePaths to check if arr has file(s) for this media
 	// Pass nil metadata since we're just checking existence
-	allPaths, err := h.arrClient.GetAllFilePaths(mediaID, nil, filePath)
+	allPaths, err := h.arrClient.GetAllFilePaths(mediaID, nil, h.arrPathFor(filePath))
 	if err != nil {
 		return false, err
 	}
@@ -684,7 +704,7 @@ func (h *HealthMonitorService) checkArrHasFile(filePath string, mediaID int64) (
 
 // isInArrQueue checks if there's an active download for this file path
 func (h *HealthMonitorService) isInArrQueue(filePath string) (bool, error) {
-	queueItems, err := h.arrClient.GetQueueForPath(filePath)
+	queueItems, err := h.arrClient.GetQueueForPath(h.arrPathFor(filePath))
 	if err != nil {
 		return false, err
 	}

--- a/internal/services/recovery.go
+++ b/internal/services/recovery.go
@@ -523,7 +523,7 @@ func (r *RecoveryService) isInArrQueue(item staleItem) (bool, error) {
 		return false, nil
 	}
 
-	queueItems, err := r.arrClient.GetQueueForPath(item.FilePath)
+	queueItems, err := r.arrClient.GetQueueForPath(r.arrPathFor(item.FilePath))
 	if err != nil {
 		return false, err
 	}
@@ -546,7 +546,7 @@ func (r *RecoveryService) checkArrHasFile(item staleItem) (hasFile bool, filePat
 
 	// Use GetAllFilePaths to check if arr has file(s) for this media
 	// Pass nil metadata since we're just checking existence
-	allPaths, err := r.arrClient.GetAllFilePaths(item.MediaID, nil, item.FilePath)
+	allPaths, err := r.arrClient.GetAllFilePaths(item.MediaID, nil, r.arrPathFor(item.FilePath))
 	if err != nil {
 		return false, "", err
 	}
@@ -557,6 +557,20 @@ func (r *RecoveryService) checkArrHasFile(item staleItem) (hasFile bool, filePat
 	}
 
 	return false, "", nil
+}
+
+// arrPathFor maps a local path to the *arr's path form for arr-side API
+// lookups; falls back to the raw path for same-path setups. Queue and
+// file-path checks match against the instance's ARR root folder, so a local
+// path silently never matches on mapped or Windows setups.
+func (r *RecoveryService) arrPathFor(localPath string) string {
+	if r.pathMapper == nil {
+		return localPath
+	}
+	if mapped, err := r.pathMapper.ToArrPath(localPath); err == nil && mapped != "" {
+		return mapped
+	}
+	return localPath
 }
 
 // verifyAndComplete verifies the file health and emits success or exhausted.
@@ -572,6 +586,13 @@ func (r *RecoveryService) verifyAndComplete(item staleItem, filePath string) str
 		healthy, healthErr := r.detector.Check(localPath, "thorough")
 		if healthy {
 			return r.emitVerificationSuccess(item, localPath)
+		}
+		// A RECOVERABLE failure (mount glitch, timeout, tool failure) says
+		// nothing about the file: defer, do not conclude. The item stays in
+		// its current state and the next recovery sweep re-attempts.
+		if healthErr != nil && healthErr.IsRecoverable() {
+			logger.Infof("Recovery: health check for %s hit a recoverable infra error (%s); deferring verification", localPath, healthErr.Message)
+			return ""
 		}
 		// File exists but is corrupt - emit SearchExhausted (user needs to retry)
 		errMsg := "unknown error"

--- a/internal/services/recovery_test.go
+++ b/internal/services/recovery_test.go
@@ -1043,7 +1043,10 @@ func TestVerifyAndComplete_CorruptFile(t *testing.T) {
 
 	mockDetector := &testutil.MockHealthChecker{
 		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
-			return false, &integration.HealthCheckError{Message: "video stream corrupt"}
+			// A typed TRUE-CORRUPTION error: the recoverable-vs-corrupt
+			// triage (audit finding 6) inspects the type, and the category
+			// registry panics in test binaries on untyped errors.
+			return false, &integration.HealthCheckError{Type: integration.ErrorTypeCorruptStream, Message: "video stream corrupt"}
 		},
 	}
 
@@ -2402,5 +2405,39 @@ func TestParseTimestamp(t *testing.T) {
 				t.Errorf("parseTimestamp(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// Recovery's verification must defer (no terminal event) on a RECOVERABLE
+// detector error: concluding SearchExhausted from a mount glitch parks a
+// healthy item in a needs-attention state and burns operator time.
+func TestRecovery_VerifyAndComplete_DefersOnRecoverableError(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := testutil.NewMockEventBus()
+	det := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			return false, &integration.HealthCheckError{
+				Type:    integration.ErrorTypeMountLost,
+				Message: "mount appears lost",
+			}
+		},
+	}
+	r := NewRecoveryService(db, eb, &testutil.MockArrClient{}, &testutil.MockPathMapper{}, det, time.Hour)
+
+	state := r.verifyAndComplete(staleItem{CorruptionID: "rec-1", FilePath: "/media/tv/x.mkv"}, "/media/tv/x.mkv")
+
+	if state != "" {
+		t.Errorf("verifyAndComplete = %q, want empty (deferred)", state)
+	}
+	if n := eb.EventCount(domain.SearchExhausted); n != 0 {
+		t.Errorf("SearchExhausted published %d times for recoverable error, want 0", n)
+	}
+	if n := eb.EventCount(domain.VerificationSuccess); n != 0 {
+		t.Errorf("VerificationSuccess published %d times, want 0", n)
 	}
 }

--- a/internal/services/verifier.go
+++ b/internal/services/verifier.go
@@ -78,6 +78,10 @@ type VerifierService struct {
 	// the production values in NewVerifierService.
 	historyRetryInterval time.Duration
 	retryBackoffBase     time.Duration
+	// infraRetryDelay spaces re-attempts when verification hits a
+	// RECOVERABLE detector error (mount glitch, timeout): the replacement
+	// is not failed, the check is just retried.
+	infraRetryDelay time.Duration
 
 	// Graceful shutdown support
 	shutdownCh chan struct{}
@@ -121,6 +125,7 @@ func NewVerifierService(eb eventbus.Publisher, detector integration.HealthChecke
 	}
 	v.historyRetryInterval = defaultHistoryRetryInterval
 	v.retryBackoffBase = defaultRetryBackoffBase
+	v.infraRetryDelay = 30 * time.Second
 	if testing.Testing() {
 		// Shrink retry waits to ~0 under test binaries: the retry COUNT logic
 		// is unchanged, but the history/file-path retry helpers no longer pay
@@ -129,6 +134,7 @@ func NewVerifierService(eb eventbus.Publisher, detector integration.HealthChecke
 		// crypto.go / integration.interfaces.go.
 		v.historyRetryInterval = time.Millisecond
 		v.retryBackoffBase = time.Millisecond
+		v.infraRetryDelay = time.Millisecond
 	}
 	if db != nil {
 		v.scanPaths = repository.NewScanPathRepository(db)
@@ -895,7 +901,7 @@ func (v *VerifierService) checkAndEmitFilesFromArrAPI(corruptionID, filePath str
 		return false
 	}
 
-	allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, filePath)
+	allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, v.arrPathFor(filePath))
 	if err != nil || len(allPaths) == 0 {
 		return false
 	}
@@ -1019,7 +1025,7 @@ func (v *VerifierService) getFilePathsWithRetry(mediaID int64, metadata map[stri
 			return nil, errors.New(errMsgShutdownInProgress)
 		}
 
-		allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, referencePath)
+		allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, v.arrPathFor(referencePath))
 		if err == nil {
 			return allPaths, nil
 		}
@@ -1154,7 +1160,7 @@ func (v *VerifierService) logFilesDetected(corruptionID string, attempt int, fou
 // findFilesForVerification looks for files via *arr API or direct path check.
 func (v *VerifierService) findFilesForVerification(mediaID int64, metadata map[string]interface{}, referencePath string, useSmartVerification bool) []string {
 	if useSmartVerification && v.arrClient != nil {
-		allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, referencePath)
+		allPaths, err := v.arrClient.GetAllFilePaths(mediaID, metadata, v.arrPathFor(referencePath))
 		if err == nil && len(allPaths) > 0 {
 			foundPaths := v.convertAndVerifyPaths(allPaths)
 			// Only return if ALL files exist
@@ -1265,8 +1271,28 @@ func (v *VerifierService) emitFilesDetected(corruptionID string, filePaths []str
 	v.verifyHealthMultiple(corruptionID, filePaths)
 }
 
-// verifyFilesHealth checks all files and returns failed paths and last error.
-func (v *VerifierService) verifyFilesHealth(filePaths []string) (failedPaths []string, lastError string) {
+// arrPathFor maps a local path to the *arr's own path form for arr-side API
+// lookups (queue checks, GetAllFilePaths): the instance-ownership matcher
+// compares against the instance's ARR root folder, so feeding it a local
+// path silently fails on every mapped or Windows setup. Falls back to the
+// raw path when no mapping exists (same-path setups).
+func (v *VerifierService) arrPathFor(localPath string) string {
+	if v.pathMapper == nil {
+		return localPath
+	}
+	if mapped, err := v.pathMapper.ToArrPath(localPath); err == nil && mapped != "" {
+		return mapped
+	}
+	return localPath
+}
+
+// verifyFilesHealth checks all files and returns failed paths, the last
+// error, and whether every failure was a RECOVERABLE infra error (mount
+// glitch, timeout, tool failure) rather than file corruption. Recoverable
+// failures must never fail a verification: that verdict re-deletes the
+// replacement and can blocklist a perfectly good release.
+func (v *VerifierService) verifyFilesHealth(filePaths []string) (failedPaths []string, lastError string, recoverableOnly bool) {
+	recoverableOnly = true
 	for _, filePath := range filePaths {
 		healthy, err := v.detector.Check(filePath, "thorough")
 		if healthy {
@@ -1275,12 +1301,16 @@ func (v *VerifierService) verifyFilesHealth(filePaths []string) (failedPaths []s
 		failedPaths = append(failedPaths, filePath)
 		if err != nil {
 			lastError = err.Message
+			if !err.IsRecoverable() {
+				recoverableOnly = false
+			}
 		} else {
 			lastError = "unknown error"
+			recoverableOnly = false
 		}
 		logger.Infof("Verification failed for %s: %s", filePath, lastError)
 	}
-	return failedPaths, lastError
+	return failedPaths, lastError, recoverableOnly
 }
 
 // buildSuccessEventData builds event data for a successful verification.
@@ -1310,7 +1340,32 @@ func (v *VerifierService) verifyHealthMultiple(corruptionID string, filePaths []
 		logger.Errorf("Failed to publish VerificationStarted event: %v", err)
 	}
 
-	failedPaths, lastError := v.verifyFilesHealth(filePaths)
+	// Up to maxInfraVerifyRetries re-attempts when ALL failures are
+	// recoverable infra errors (NAS hiccup exactly when the thorough check
+	// runs). If the infra problem persists, return WITHOUT a terminal
+	// event: the aggregate stays in its in-progress state and the recovery
+	// sweep re-attempts verification later. Failing it instead would
+	// re-delete a healthy replacement and could blocklist a good release.
+	const maxInfraVerifyRetries = 3
+	var failedPaths []string
+	var lastError string
+	var recoverableOnly bool
+	for attempt := 0; ; attempt++ {
+		failedPaths, lastError, recoverableOnly = v.verifyFilesHealth(filePaths)
+		if len(failedPaths) == 0 || !recoverableOnly {
+			break
+		}
+		if attempt >= maxInfraVerifyRetries {
+			logger.Warnf("Verification for %s deferred: %d file(s) unreachable due to recoverable infra errors (%s); leaving for recovery to re-attempt", corruptionID, len(failedPaths), lastError)
+			return
+		}
+		logger.Infof("Verification for %s hit a recoverable infra error (%s); retrying in %s (attempt %d/%d)", corruptionID, lastError, v.infraRetryDelay, attempt+1, maxInfraVerifyRetries)
+		select {
+		case <-v.shutdownCh:
+			return
+		case <-time.After(v.infraRetryDelay):
+		}
+	}
 	v.clearVerifyMeta(corruptionID)
 
 	if len(failedPaths) == 0 {

--- a/internal/services/verifier_test.go
+++ b/internal/services/verifier_test.go
@@ -3153,3 +3153,97 @@ func TestVerifierService_StartVerificationWithSemaphore(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Recoverable-error triage + arr-path mapping (audit findings 6+11)
+// =============================================================================
+
+// A RECOVERABLE detector error during verification (mount glitch, timeout,
+// tool failure) must never publish VerificationFailed: that verdict
+// re-deletes the replacement and can blocklist a good release. The
+// verification is deferred (no terminal event) for recovery to re-attempt.
+func TestVerifier_RecoverableErrorDefersInsteadOfFailing(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := testutil.NewMockEventBus()
+	mockHC := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			return false, &integration.HealthCheckError{
+				Type:    integration.ErrorTypeIOError,
+				Message: "read /media/tv/x.mkv: input/output error",
+			}
+		},
+	}
+	v := NewVerifierService(eb, mockHC, &testutil.MockPathMapper{}, &testutil.MockArrClient{}, db)
+
+	v.verifyHealthMultiple("defer-1", []string{"/media/tv/x.mkv"})
+
+	if n := eb.EventCount(domain.VerificationFailed); n != 0 {
+		t.Errorf("VerificationFailed published %d times for a recoverable error, want 0 (defer)", n)
+	}
+	if n := eb.EventCount(domain.VerificationSuccess); n != 0 {
+		t.Errorf("VerificationSuccess published %d times, want 0", n)
+	}
+}
+
+// True corruption during verification must still fail it (the corrupt
+// replacement is handled by the retry path: delete + blocklist + re-search).
+func TestVerifier_TrueCorruptionStillFailsVerification(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := testutil.NewMockEventBus()
+	mockHC := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			return false, &integration.HealthCheckError{
+				Type:    integration.ErrorTypeCorruptHeader,
+				Message: "EBML header parsing failed",
+			}
+		},
+	}
+	v := NewVerifierService(eb, mockHC, &testutil.MockPathMapper{}, &testutil.MockArrClient{}, db)
+
+	v.verifyHealthMultiple("corrupt-1", []string{"/media/tv/x.mkv"})
+
+	if n := eb.EventCount(domain.VerificationFailed); n != 1 {
+		t.Errorf("VerificationFailed published %d times for true corruption, want 1", n)
+	}
+}
+
+// arr-side lookups must receive the ARR path, not the local path: the
+// instance-ownership matcher compares against the instance's arr root
+// folder, so a local path silently never matches on mapped/Windows setups.
+func TestVerifier_ArrLookupsUseMappedPath(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var gotReference string
+	arr := &testutil.MockArrClient{
+		GetAllFilePathsFunc: func(mediaID int64, metadata map[string]interface{}, referencePath string) ([]string, error) {
+			gotReference = referencePath
+			return []string{`D:\Media\TV\Show\S01E01.mkv`}, nil
+		},
+	}
+	pm := &testutil.MockPathMapper{
+		ToArrPathFunc: func(localPath string) (string, error) {
+			return `D:\Media\TV\Show\S01E01.mkv`, nil
+		},
+	}
+	v := NewVerifierService(testutil.NewMockEventBus(), &testutil.MockHealthChecker{}, pm, arr, db)
+
+	_, _ = v.getFilePathsWithRetry(7, nil, "/media/tv/Show/S01E01.mkv", 1)
+
+	if gotReference != `D:\Media\TV\Show\S01E01.mkv` {
+		t.Errorf("GetAllFilePaths received %q, want the mapped arr path", gotReference)
+	}
+}


### PR DESCRIPTION
Fixes HIGH findings 6 and 11 from the Fable 5 audit.

## Finding 6: mount glitch during verification re-deleted healthy replacements
`grep IsRecoverable` in verifier.go + recovery.go returned zero hits. A transient NAS hiccup during thorough verification published `VerificationFailed`, and the retry path then deletes the healthy replacement and blocklists its release.

Now: recoverable-only failures retry 3x (30s spacing, shutdown-aware), then **defer** (no terminal event; recovery re-attempts later). True corruption fails verification exactly as before (pinned by test). Recovery's `verifyAndComplete` gets the same triage (was concluding SearchExhausted from infra errors).

## Finding 11: smart verification dead on mapped/Windows setups
Verifier (3 sites), recovery (2 sites), and health monitor (2 sites) fed LOCAL paths into arr-side lookups that match against the instance's ARR root. `arrPathFor` helpers map via `ToArrPath` (raw fallback for same-path setups). Health monitor gains `SetPathMapper` (wired in main) instead of a constructor ripple.

## Test plan
- [x] New: recoverable defers (no terminal events), corruption still fails, arr lookups receive mapped path, recovery defers on MountLost
- [x] Full services suite green; lint 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary infrastructure failures; verification now intelligently defers instead of immediately marking items as failed, allowing retries on subsequent checks.
  * Enhanced file path consistency across verification services.
  * Added configurable retry timing for infrastructure-related delays and better differentiation between temporary failures and actual file corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->