### PR TITLE
fix(scanner): webhook stability gates + live dedup re-check (audit findings 5+10, HIGH)

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -856,18 +856,42 @@ func (s *ScannerService) ScanFile(localPath string) error {
 
 	logger.Infof("Scanning single file: %s", localPath)
 
-	// NOTE: We do NOT check for recently-modified files here because webhook scans
-	// are triggered by Sonarr/Radarr AFTER import is complete - the file is done being written.
-	// The recently-modified check only applies to path scans where we might find in-progress downloads.
-
-	// Capture file size before health check (for enriched corruption data)
+	// The *arr fires the import webhook the moment ITS view of the move
+	// completes — but when *arr and Healarr see the storage through
+	// different mounts (NFS attribute caching, SMB, rclone/mergerfs),
+	// Healarr's view can lag by seconds: a stat here may show 0 bytes or a
+	// partial file, and a quick probe would flag a healthy, just-imported
+	// file as corrupt — deleting it and possibly blocklisting a good
+	// release. Gate on size stability first; an unstable file goes to the
+	// rescan queue (retried in ~5 min, when the view has settled).
 	var fileSize int64
 	if info, err := os.Stat(localPath); err == nil {
+		fileSize = info.Size()
+	}
+	time.Sleep(s.sizeStabilityDelay)
+	if info, err := os.Stat(localPath); err == nil {
+		if info.Size() != fileSize {
+			logger.Infof("Webhook scan deferred: %s is still changing size (%d -> %d bytes); queued for rescan", localPath, fileSize, info.Size())
+			s.queueForRescan(localPath, pathID, "SizeChanging", "file size still changing at webhook time")
+			return nil
+		}
 		fileSize = info.Size()
 	}
 
 	// Use quick mode for single file scans (called from webhooks)
 	healthy, healthErr := s.detector.Check(localPath, "quick")
+
+	// Two-probe confirmation: a TRUE-corruption verdict on a just-imported
+	// file gets one re-probe after a short delay before any remediation is
+	// triggered. A stale-mount artifact (0-byte stat, truncated view)
+	// clears on the second probe; genuine corruption does not.
+	if !healthy && healthErr != nil && healthErr.IsTrueCorruption() {
+		time.Sleep(s.sizeStabilityDelay)
+		healthy, healthErr = s.detector.Check(localPath, "quick")
+		if healthy {
+			logger.Infof("Webhook scan: %s healthy on re-probe (initial verdict was a stale-view artifact)", localPath)
+		}
+	}
 
 	progress.FilesDone = 1
 	s.emitProgress(progress)
@@ -1589,12 +1613,17 @@ func (s *ScannerService) handleRecoverableError(progress *ScanProgress, sfc *sca
 func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *ScanProgress, sfc *scanFileContext, healthErr *integration.HealthCheckError) scanLoopAction {
 	logger.Infof("Corruption detected in file: %s (Type: %s)", sfc.filePath, healthErr.Type)
 
-	// DEDUPLICATION: Check if already being processed
-	// Use preloaded map for path scans (O(1) lookup), fall back to query for single-file scans
-	hasActive := false
-	if sfc.activeCorruptions != nil {
-		hasActive = sfc.activeCorruptions[sfc.filePath]
-	} else {
+	// DEDUPLICATION: Check if already being processed.
+	// The preloaded snapshot is taken once at scan START; on a long scan it
+	// can be hours stale, and a webhook may have opened (and still be
+	// running) a remediation journey for this same file in the meantime.
+	// Two concurrent journeys for one file can end with the loser deleting
+	// the winner's healthy replacement. The snapshot remains the fast path
+	// for the common case (file already active at scan start); a snapshot
+	// MISS gets a live re-check before we open a new journey — corrupt
+	// files are rare, so the extra query is negligible.
+	hasActive := sfc.activeCorruptions != nil && sfc.activeCorruptions[sfc.filePath]
+	if !hasActive {
 		hasActive = s.hasActiveCorruption(sfc.filePath)
 	}
 	if hasActive {

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -5175,3 +5175,160 @@ func TestScannerService_FinalizeScan_AbortedStaysAborted(t *testing.T) {
 		t.Errorf("finalized status = %q, want aborted", status)
 	}
 }
+
+// =============================================================================
+// Webhook stability gates + live dedup (audit findings 5+10)
+// =============================================================================
+
+// A webhook scan of a file whose size is still changing (cross-mount
+// visibility lag right after import) must defer to the rescan queue instead
+// of probing — a partial view yields a false corruption verdict that deletes
+// a healthy, just-downloaded file.
+func TestScannerService_ScanFile_DefersWhenSizeChanging(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	tmpDir := t.TempDir()
+	if _, err := db.Exec(`INSERT INTO scan_paths (local_path, arr_path, enabled, auto_remediate, dry_run) VALUES (?, ?, 1, 1, 0)`, tmpDir, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	testFile := filepath.Join(tmpDir, "growing.mkv")
+	if err := os.WriteFile(testFile, []byte("partial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	detectorCalled := false
+	mockHC := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			detectorCalled = true
+			return false, &integration.HealthCheckError{Type: integration.ErrorTypeZeroByte, Message: "zero"}
+		},
+	}
+
+	scanner := NewScannerService(db, eb, mockHC, nil)
+	// Give the stability window real duration and grow the file inside it.
+	scanner.sizeStabilityDelay = 150 * time.Millisecond
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(testFile, []byte("partial-plus-more-data"), 0644)
+	}()
+
+	if err := scanner.ScanFile(testFile); err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+
+	if detectorCalled {
+		t.Error("detector probed a file whose size was still changing")
+	}
+	var queued int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM pending_rescans WHERE file_path = ?`, testFile).Scan(&queued)
+	if queued != 1 {
+		t.Errorf("pending_rescans rows = %d, want 1 (deferred for rescan)", queued)
+	}
+	var corruptions int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_type='CorruptionDetected'`).Scan(&corruptions)
+	if corruptions != 0 {
+		t.Errorf("CorruptionDetected published %d times for an unstable file, want 0", corruptions)
+	}
+}
+
+// A corruption verdict that clears on the re-probe (stale-view artifact)
+// must not publish CorruptionDetected.
+func TestScannerService_ScanFile_ReprobeClearsStaleVerdict(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	tmpDir := t.TempDir()
+	if _, err := db.Exec(`INSERT INTO scan_paths (local_path, arr_path, enabled, auto_remediate, dry_run) VALUES (?, ?, 1, 1, 0)`, tmpDir, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	testFile := filepath.Join(tmpDir, "settling.mkv")
+	if err := os.WriteFile(testFile, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	mockHC := &testutil.MockHealthChecker{
+		CheckFunc: func(path, mode string) (bool, *integration.HealthCheckError) {
+			calls++
+			if calls == 1 {
+				// First probe sees the stale partial view.
+				return false, &integration.HealthCheckError{Type: integration.ErrorTypeZeroByte, Message: "0 bytes"}
+			}
+			return true, nil
+		},
+	}
+
+	scanner := NewScannerService(db, eb, mockHC, nil)
+	scanner.sizeStabilityDelay = time.Millisecond
+
+	if err := scanner.ScanFile(testFile); err != nil {
+		t.Fatalf("ScanFile: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("detector calls = %d, want 2 (probe + confirming re-probe)", calls)
+	}
+	var corruptions int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_type='CorruptionDetected'`).Scan(&corruptions)
+	if corruptions != 0 {
+		t.Errorf("CorruptionDetected published %d times for a verdict that cleared on re-probe, want 0", corruptions)
+	}
+}
+
+// Live dedup: a snapshot MISS in handleTrueCorruption must re-check the
+// database before opening a second journey for the same file.
+func TestScannerService_HandleTrueCorruption_LiveDedupOnSnapshotMiss(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	// An ACTIVE corruption journey for the file (opened after the scan's
+	// snapshot was taken, e.g. by a webhook).
+	if _, err := db.Exec(`
+		INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, created_at)
+		VALUES ('corruption', 'live-1', 'CorruptionDetected', '{"file_path":"/media/tv/x.mkv"}', datetime('now', '-1 hour'))
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	scanner := NewScannerService(db, eb, &testutil.MockHealthChecker{}, nil)
+	scanner.initRepositories()
+
+	progress := &ScanProgress{ID: "dedup-scan", resumeChan: make(chan struct{})}
+	sfc := &scanFileContext{
+		filePath: "/media/tv/x.mkv",
+		// Empty (stale) snapshot: the file was NOT active at scan start.
+		activeCorruptions: map[string]bool{},
+	}
+
+	action := scanner.handleTrueCorruption(context.Background(), progress, sfc, &integration.HealthCheckError{
+		Type: integration.ErrorTypeCorruptHeader, Message: "corrupt",
+	})
+	if action != scanSkipToNext {
+		t.Fatalf("action = %v, want scanSkipToNext (the dedup skip)", action)
+	}
+
+	var n int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM events WHERE event_type='CorruptionDetected' AND json_extract(event_data,'$.file_path')='/media/tv/x.mkv'`).Scan(&n)
+	if n != 1 {
+		t.Errorf("CorruptionDetected events = %d, want 1 (live re-check must dedup the stale snapshot miss)", n)
+	}
+}


### PR DESCRIPTION
Fixes HIGH findings 5 and 10 from the Fable 5 audit.

## Finding 5: webhook scans could flag (and delete) a healthy, just-imported file
Webhook scans skipped both write-in-progress guards. When *arr and Healarr see storage through different mounts (NFS attribute caching, SMB, rclone/mergerfs), Healarr's view lags the import by seconds: a stat shows 0 bytes or a partial file, the quick probe says corrupt, remediation deletes the healthy import.

Two gates, both sized by the existing `sizeStabilityDelay`:
- **Size-stability gate**: a file changing size across the window defers to the `pending_rescans` queue (retried in ~5 min) instead of probing a moving target.
- **Two-probe confirmation**: a TRUE-corruption verdict gets one re-probe after the delay; stale-view artifacts clear, genuine corruption does not. Recoverable errors keep their existing no-remediation path.

## Finding 10: stale dedup snapshot allowed duplicate remediation journeys
Path scans consult an active-corruption snapshot taken at scan START (hours stale on long scans); a webhook journey opened mid-scan was invisible, and two concurrent journeys can end with the loser deleting the winner's healthy replacement. `handleTrueCorruption` now does a live `hasActiveCorruption` re-check on a snapshot MISS (corrupt files are rare; negligible cost).

## Test plan
- [x] New: size-changing file defers to rescan queue without probing; verdict clearing on re-probe publishes nothing; stale-snapshot miss dedups against live DB
- [x] Full services suite green; lint 0 issues