### PR TITLE
fix(state-machine): lifecycle-only summary trigger, media-keyed loop-breaker, manual-retry override (audit findings 13+14, HIGH)

### DIFF
--- a/internal/db/migrations/012_summary_trigger_lifecycle_only.sql
+++ b/internal/db/migrations/012_summary_trigger_lifecycle_only.sql
@@ -1,0 +1,106 @@
+-- 012_summary_trigger_lifecycle_only.sql
+--
+-- Stops notification bookkeeping from corrupting the corruption state
+-- machine, and unifies the retry-count definition (audit finding 13).
+--
+-- The migration-004 trigger updated corruption_summary for EVERY event on a
+-- corruption aggregate: current_state = NEW.event_type and retry_count =
+-- COUNT(event_type LIKE '%Failed'). The notifier publishes
+-- NotificationSent / NotificationFailed under the SOURCE event's aggregate
+-- (so the corruption timeline shows them), which meant:
+--   a) a "remediation complete" notification set current_state =
+--      'NotificationSent', knocking the item out of the resolved filter and
+--      counting it active forever;
+--   b) a broken notification provider appended NotificationFailed per
+--      corruption event, each matching LIKE '%Failed' - three of those
+--      exhausted the retry budget so the first real failure jumped straight
+--      to MaxRetriesReached with zero actual remediation attempts.
+--
+-- The trigger now ignores notification bookkeeping entirely, and
+-- retry_count counts the explicit retry-relevant set - including
+-- DownloadTimeout, which the monitor's cap check already counted while the
+-- summary's counter did not (the two cap checks disagreed in both
+-- directions). monitor.getRetryCount is aligned to the same list in Go.
+--
+-- Step 2 repairs rows already clobbered by notification events.
+
+-- 1. Replace the trigger
+DROP TRIGGER IF EXISTS trg_update_corruption_summary;
+
+CREATE TRIGGER trg_update_corruption_summary
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'corruption'
+  AND NEW.event_type NOT IN ('NotificationSent', 'NotificationFailed')
+BEGIN
+    INSERT OR REPLACE INTO corruption_summary (
+        corruption_id,
+        current_state,
+        retry_count,
+        file_path,
+        path_id,
+        last_error,
+        corruption_type,
+        detected_at,
+        last_updated_at
+    )
+    SELECT
+        NEW.aggregate_id,
+        NEW.event_type,
+        (SELECT COUNT(*) FROM events WHERE aggregate_id = NEW.aggregate_id
+           AND event_type IN ('DeletionFailed', 'SearchFailed', 'VerificationFailed', 'DownloadFailed', 'DownloadTimeout')),
+        COALESCE(
+            CASE WHEN NEW.event_type = 'CorruptionDetected' THEN json_extract(NEW.event_data, '$.file_path') ELSE NULL END,
+            (SELECT file_path FROM corruption_summary WHERE corruption_id = NEW.aggregate_id),
+            (SELECT json_extract(event_data, '$.file_path') FROM events
+             WHERE aggregate_id = NEW.aggregate_id AND event_type = 'CorruptionDetected' LIMIT 1)
+        ),
+        COALESCE(
+            CASE WHEN NEW.event_type = 'CorruptionDetected' THEN json_extract(NEW.event_data, '$.path_id') ELSE NULL END,
+            (SELECT path_id FROM corruption_summary WHERE corruption_id = NEW.aggregate_id),
+            (SELECT json_extract(event_data, '$.path_id') FROM events
+             WHERE aggregate_id = NEW.aggregate_id AND event_type = 'CorruptionDetected' LIMIT 1)
+        ),
+        json_extract(NEW.event_data, '$.error'),
+        COALESCE(
+            CASE WHEN NEW.event_type = 'CorruptionDetected' THEN json_extract(NEW.event_data, '$.corruption_type') ELSE NULL END,
+            (SELECT corruption_type FROM corruption_summary WHERE corruption_id = NEW.aggregate_id),
+            (SELECT json_extract(event_data, '$.corruption_type') FROM events
+             WHERE aggregate_id = NEW.aggregate_id AND event_type = 'CorruptionDetected' LIMIT 1)
+        ),
+        COALESCE(
+            (SELECT detected_at FROM corruption_summary WHERE corruption_id = NEW.aggregate_id),
+            NEW.created_at
+        ),
+        NEW.created_at;
+END;
+
+-- 2. Repair rows already clobbered: recompute current_state from the latest
+--    LIFECYCLE event and retry_count from the explicit failure set. Rows
+--    whose aggregates only ever had notification events keep their state
+--    (the subquery guard below skips them).
+UPDATE corruption_summary
+SET current_state = (
+        SELECT e.event_type FROM events e
+        WHERE e.aggregate_id = corruption_summary.corruption_id
+          AND e.aggregate_type = 'corruption'
+          AND e.event_type NOT IN ('NotificationSent', 'NotificationFailed')
+        ORDER BY e.created_at DESC, e.id DESC
+        LIMIT 1
+    ),
+    retry_count = (
+        SELECT COUNT(*) FROM events e
+        WHERE e.aggregate_id = corruption_summary.corruption_id
+          AND e.event_type IN ('DeletionFailed', 'SearchFailed', 'VerificationFailed', 'DownloadFailed', 'DownloadTimeout')
+    ),
+    last_updated_at = (
+        SELECT MAX(e.created_at) FROM events e
+        WHERE e.aggregate_id = corruption_summary.corruption_id
+          AND e.aggregate_type = 'corruption'
+          AND e.event_type NOT IN ('NotificationSent', 'NotificationFailed')
+    )
+WHERE EXISTS (
+    SELECT 1 FROM events e
+    WHERE e.aggregate_id = corruption_summary.corruption_id
+      AND e.aggregate_type = 'corruption'
+      AND e.event_type NOT IN ('NotificationSent', 'NotificationFailed')
+);

--- a/internal/db/repository_test.go
+++ b/internal/db/repository_test.go
@@ -4525,3 +4525,55 @@ func TestConfigureSQLite_Idempotent(t *testing.T) {
 		t.Errorf("auto_vacuum=%d, want 2", mode)
 	}
 }
+
+// Migration 012: notification bookkeeping must not clobber the corruption
+// state machine. NotificationSent must not become current_state, and
+// NotificationFailed must not count toward the retry budget.
+func TestCorruptionSummary_IgnoresNotificationBookkeeping(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+	db := repo.DB
+
+	insert := func(eventType string) {
+		t.Helper()
+		if _, err := db.Exec(`
+			INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data)
+			VALUES ('corruption', 'notif-1', ?, '{"file_path":"/media/x.mkv"}')
+		`, eventType); err != nil {
+			t.Fatalf("insert %s: %v", eventType, err)
+		}
+	}
+
+	insert("CorruptionDetected")
+	insert("RemediationQueued")
+	insert("VerificationSuccess")
+	// The "remediation complete" notification fires AFTER resolution: it must
+	// not knock the item out of the resolved state.
+	insert("NotificationSent")
+	// A broken provider appends failures: they must not burn the retry budget.
+	insert("NotificationFailed")
+	insert("NotificationFailed")
+	insert("NotificationFailed")
+
+	var state string
+	var retries int
+	if err := db.QueryRow(`SELECT current_state, retry_count FROM corruption_summary WHERE corruption_id = 'notif-1'`).Scan(&state, &retries); err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if state != "VerificationSuccess" {
+		t.Errorf("current_state = %q, want VerificationSuccess (notification events must not clobber)", state)
+	}
+	if retries != 0 {
+		t.Errorf("retry_count = %d, want 0 (NotificationFailed must not count)", retries)
+	}
+
+	// Real failures DO count, including DownloadTimeout (unified definition).
+	insert("DeletionFailed")
+	insert("DownloadTimeout")
+	if err := db.QueryRow(`SELECT retry_count FROM corruption_summary WHERE corruption_id = 'notif-1'`).Scan(&retries); err != nil {
+		t.Fatal(err)
+	}
+	if retries != 2 {
+		t.Errorf("retry_count = %d, want 2 (DeletionFailed + DownloadTimeout)", retries)
+	}
+}

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -481,3 +481,54 @@ func (r *CorruptionRepository) ListActiveFilePathsUnderRoot(ctx context.Context,
 	}
 	return result, nil
 }
+
+// CountSuccessfulRemediationsForMedia counts VerificationSuccess events in
+// the window whose remediation journey handled the given *arr media id
+// (identified via the journey's DeletionCompleted event). This is the
+// rename-proof sibling of CountSuccessfulRemediationsForPath: each
+// remediation round typically imports the replacement under a NEW release
+// filename, so a per-path counter never accumulates for exactly the
+// recurring-corruption scenario the loop-breaker exists for.
+func (r *CorruptionRepository) CountSuccessfulRemediationsForMedia(ctx context.Context, mediaID int64, windowDays int) (int, error) {
+	var n int
+	modifier := fmt.Sprintf("-%d days", windowDays)
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events vs
+		WHERE vs.event_type = 'VerificationSuccess'
+		  AND vs.created_at > datetime('now', ?)
+		  AND vs.aggregate_id IN (
+		      SELECT dc.aggregate_id FROM events dc
+		      WHERE dc.event_type = 'DeletionCompleted'
+		        AND json_extract(dc.event_data, '$.media_id') = ?
+		  )
+	`, modifier, mediaID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count successful remediations for media: %w", err)
+	}
+	return n, nil
+}
+
+// CountExhaustedRemediationsForMedia counts MaxRetriesReached events in the
+// window for journeys that handled the given media id. Covers the
+// never-succeeds loop: when remediation never produces a verified
+// replacement there are no VerificationSuccess events to count, but each
+// exhausted journey burned deletes, searches, and timeouts on the same
+// media — that recurrence must also trip the loop-breaker.
+func (r *CorruptionRepository) CountExhaustedRemediationsForMedia(ctx context.Context, mediaID int64, windowDays int) (int, error) {
+	var n int
+	modifier := fmt.Sprintf("-%d days", windowDays)
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM events mr
+		WHERE mr.event_type = 'MaxRetriesReached'
+		  AND mr.created_at > datetime('now', ?)
+		  AND mr.aggregate_id IN (
+		      SELECT dc.aggregate_id FROM events dc
+		      WHERE dc.event_type = 'DeletionCompleted'
+		        AND json_extract(dc.event_data, '$.media_id') = ?
+		  )
+	`, modifier, mediaID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count exhausted remediations for media: %w", err)
+	}
+	return n, nil
+}

--- a/internal/services/monitor.go
+++ b/internal/services/monitor.go
@@ -323,11 +323,15 @@ func (m *MonitorService) getRetryCount(corruptionID string) (int, int, error) {
 
 	// Count failures and timeouts directly from the event stream; join scan_paths
 	// (LEFT JOIN, so a missing/deleted path falls back to the default limit).
+	// The explicit list matches the migration-012 trigger definition exactly,
+	// so the monitor's cap check and the summary's retry_count agree. The old
+	// LIKE '%Failed' also matched NotificationFailed, letting a broken
+	// notification provider burn the retry budget with zero real attempts.
 	query := `
 		SELECT
 			(SELECT COUNT(*) FROM events e
 			 WHERE e.aggregate_id = cs.corruption_id
-			   AND (e.event_type LIKE '%Failed' OR e.event_type = 'DownloadTimeout')),
+			   AND e.event_type IN ('DeletionFailed', 'SearchFailed', 'VerificationFailed', 'DownloadFailed', 'DownloadTimeout')),
 			sp.max_retries
 		FROM corruption_status cs
 		LEFT JOIN scan_paths sp ON sp.id = cs.path_id

--- a/internal/services/remediator.go
+++ b/internal/services/remediator.go
@@ -569,6 +569,51 @@ func (r *RemediatorService) shouldPauseForRecurringCorruption(filePath string) b
 	return n >= maxRemediationsBeforePause
 }
 
+// shouldPauseForRecurringMedia is the rename-proof sibling of
+// shouldPauseForRecurringCorruption: keyed on the *arr media id (via each
+// journey's DeletionCompleted event) instead of the exact file path, so a
+// replacement imported under a new release filename still counts toward the
+// loop. It also trips on repeated MaxRetriesReached for the same media (the
+// never-succeeds loop, where there are no successes to count but each round
+// still burns deletes, searches, and possibly blocklists).
+func (r *RemediatorService) shouldPauseForRecurringMedia(mediaID int64) bool {
+	if r.corruptions == nil || mediaID <= 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), remediatorQueryTimeout)
+	defer cancel()
+	successes, err := r.corruptions.CountSuccessfulRemediationsForMedia(ctx, mediaID, remediationLoopWindowDays)
+	if err != nil {
+		logger.Warnf("Loop-breaker: cannot count prior remediations for media %d; proceeding: %v", mediaID, err)
+		return false
+	}
+	if successes >= maxRemediationsBeforePause {
+		return true
+	}
+	exhausted, err := r.corruptions.CountExhaustedRemediationsForMedia(ctx, mediaID, remediationLoopWindowDays)
+	if err != nil {
+		logger.Warnf("Loop-breaker: cannot count exhausted remediations for media %d; proceeding: %v", mediaID, err)
+		return false
+	}
+	return exhausted >= maxRemediationsBeforePause
+}
+
+// pauseRemediation publishes RemediationPaused and logs the reason.
+func (r *RemediatorService) pauseRemediation(corruptionID, filePath, reason string) {
+	logger.Warnf("Remediation paused for %s (%s): recurring corruption — re-downloading will not fix a file that keeps re-corrupting", filePath, reason)
+	if err := r.eventBus.Publish(domain.Event{
+		AggregateID:   corruptionID,
+		AggregateType: "corruption",
+		EventType:     domain.RemediationPaused,
+		EventData: map[string]interface{}{
+			"file_path": filePath,
+			"reason":    reason,
+		},
+	}); err != nil {
+		logger.Errorf("Failed to publish RemediationPaused event: %v", err)
+	}
+}
+
 // ensureMonitoredForRemediation temporarily monitors an unmonitored item so the
 // *arr will grab a replacement, recording the original state (a MonitorOverridden
 // event) so handleRemediationTerminal can restore it later. Failing to read or
@@ -704,10 +749,18 @@ func (r *RemediatorService) handleCorruptionDetected(event domain.Event) {
 		})
 	} else {
 		logger.Infof("Auto-remediation enabled for %s, proceeding immediately", data.FilePath)
+		// manual_retry=true is the user's explicit one-cycle consent (the UI
+		// retry button) to bypass a RemediationPaused loop-breaker pause —
+		// previously the flag was written by the handler and read by nothing,
+		// so a user who fixed the root cause was stuck for up to 30 days.
+		manualRetry := false
+		if v, ok := event.EventData["manual_retry"].(bool); ok {
+			manualRetry = v
+		}
 		r.wg.Add(1)
 		safego.Run("remediator-execute", func() {
 			defer r.wg.Done()
-			r.executeRemediation(corruptionID, data.FilePath, arrPath, data.PathID)
+			r.executeRemediation(corruptionID, data.FilePath, arrPath, data.PathID, manualRetry)
 		})
 	}
 }
@@ -754,7 +807,7 @@ func (r *RemediatorService) executeDryRun(corruptionID, filePath, arrPath string
 }
 
 // executeRemediation performs the actual deletion and search trigger
-func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath string, pathID int64) {
+func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath string, pathID int64, bypassLoopBreaker bool) {
 	// Check if shutting down before starting work
 	if r.isShuttingDown() {
 		logger.Debugf("Remediator shutting down, skipping remediation for %s", corruptionID)
@@ -781,19 +834,10 @@ func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath s
 	// (a transcode pipeline or failing storage is re-corrupting it). Pause and
 	// surface it rather than thrash - and crucially do NOT delete, since deleting
 	// would just lose the file with no way to re-acquire a good one.
-	if r.shouldPauseForRecurringCorruption(filePath) {
-		logger.Warnf("Remediation paused for %s: still corrupt after %d successful restores in %d days", filePath, maxRemediationsBeforePause, remediationLoopWindowDays)
-		if err := r.eventBus.Publish(domain.Event{
-			AggregateID:   corruptionID,
-			AggregateType: "corruption",
-			EventType:     domain.RemediationPaused,
-			EventData: map[string]interface{}{
-				"file_path": filePath,
-				"reason":    "recurring_corruption",
-			},
-		}); err != nil {
-			logger.Errorf("Failed to publish RemediationPaused event: %v", err)
-		}
+	// bypassLoopBreaker is the user's explicit one-cycle consent (manual retry
+	// from the UI after fixing the root cause) to run despite the pause.
+	if !bypassLoopBreaker && r.shouldPauseForRecurringCorruption(filePath) {
+		r.pauseRemediation(corruptionID, filePath, "recurring_corruption")
 		return
 	}
 
@@ -802,6 +846,15 @@ func (r *RemediatorService) executeRemediation(corruptionID, filePath, arrPath s
 	if err != nil {
 		logger.Errorf("Failed to find media for path %s: %v", arrPath, err)
 		r.publishError(corruptionID, domain.DeletionFailed, err.Error())
+		return
+	}
+
+	// Media-keyed loop-breaker: each remediation round typically imports the
+	// replacement under a NEW filename, so the path-keyed check above never
+	// accumulates for exactly the recurring-corruption scenario it exists
+	// for. The media id is rename-proof.
+	if !bypassLoopBreaker && r.shouldPauseForRecurringMedia(mediaID) {
+		r.pauseRemediation(corruptionID, filePath, "recurring_corruption_media")
 		return
 	}
 

--- a/internal/services/remediator_test.go
+++ b/internal/services/remediator_test.go
@@ -976,7 +976,7 @@ func TestRemediatorService_ExecuteRemediation_FindMediaFails(t *testing.T) {
 	remediator := NewRemediatorService(mockEventBus, mockArrClient, mockPathMapper, db)
 
 	// Call executeRemediation directly
-	remediator.executeRemediation("test-id", "/test/path.mkv", "/arr/path.mkv", 1)
+	remediator.executeRemediation("test-id", "/test/path.mkv", "/arr/path.mkv", 1, false)
 
 	// Should only have DeletionFailed (no DeletionStarted since we fail before starting)
 	// DeletionStarted is now emitted AFTER FindMediaByPath succeeds to avoid false "started" events
@@ -1008,7 +1008,7 @@ func TestRemediatorService_ExecuteRemediation_DeleteFileFails(t *testing.T) {
 
 	remediator := NewRemediatorService(mockEventBus, mockArrClient, mockPathMapper, db)
 
-	remediator.executeRemediation("test-id", "/test/path.mkv", "/arr/path.mkv", 1)
+	remediator.executeRemediation("test-id", "/test/path.mkv", "/arr/path.mkv", 1, false)
 
 	// Should have DeletionFailed
 	if mockEventBus.EventCount(domain.DeletionFailed) != 1 {
@@ -1669,7 +1669,7 @@ func TestRemediatorService_ExecuteRemediation_SkipsWhenShuttingDown(t *testing.T
 	remediator.Stop()
 
 	// Now call executeRemediation - should return early due to shutdown
-	remediator.executeRemediation("test-id", "/media/test.mkv", "/movies/test.mkv", 1)
+	remediator.executeRemediation("test-id", "/media/test.mkv", "/movies/test.mkv", 1, false)
 
 	// Verify that no events were published (service skipped due to shutdown)
 	if mockEventBus.EventCount(domain.DeletionStarted) != 0 {
@@ -1713,6 +1713,7 @@ func TestRemediatorService_ExecuteRemediation_ShutdownWhileWaitingForSemaphore(t
 				"/media/blocking.mkv",
 				"/movies/blocking.mkv",
 				1,
+				false,
 			)
 		}(i)
 	}
@@ -1724,7 +1725,7 @@ func TestRemediatorService_ExecuteRemediation_ShutdownWhileWaitingForSemaphore(t
 	var testCompleted bool
 	var testMu sync.Mutex
 	go func() {
-		remediator.executeRemediation("waiting-test", "/media/test.mkv", "/movies/test.mkv", 1)
+		remediator.executeRemediation("waiting-test", "/media/test.mkv", "/movies/test.mkv", 1, false)
 		testMu.Lock()
 		testCompleted = true
 		testMu.Unlock()
@@ -2456,4 +2457,103 @@ func TestRemediator_RecoveryRetryCannotInventConsent(t *testing.T) {
 	t.Run("dry-run path: no delete", func(t *testing.T) { run(t, true, true, false) })
 	t.Run("manual path: no delete", func(t *testing.T) { run(t, false, false, false) })
 	t.Run("auto path: delete proceeds", func(t *testing.T) { run(t, true, false, true) })
+}
+
+// seedSuccessfulRemediationForMedia seeds a full journey (detected ->
+// deletion-completed with media_id -> verification success) under a UNIQUE
+// file path per aggregate, simulating the rename-per-round reality that
+// bypassed the path-keyed loop-breaker.
+func seedSuccessfulRemediationForMedia(t *testing.T, db *sql.DB, aggregateID, filePath string, mediaID int64) {
+	t.Helper()
+	seedSuccessfulRemediation(t, db, aggregateID, filePath)
+	dc, _ := json.Marshal(map[string]interface{}{"media_id": mediaID})
+	if _, err := db.Exec(`INSERT INTO events (aggregate_type, aggregate_id, event_type, event_data, event_version, created_at)
+		VALUES ('corruption', ?, 'DeletionCompleted', ?, 1, datetime('now'))`, aggregateID, string(dc)); err != nil {
+		t.Fatalf("seed DeletionCompleted: %v", err)
+	}
+}
+
+// The loop-breaker must trip on MEDIA identity even when every round
+// imported the replacement under a new filename (audit finding 14: the
+// rename bypass made the path-keyed counter useless for exactly the
+// Tdarr/silent-data-loss scenario it was built for).
+func TestRemediator_LoopBreaker_MediaKeyedSurvivesRenames(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	seedRemediationPath(t, db, "/local/movies", true, false)
+
+	// Three successful rounds, each under a DIFFERENT path, same media.
+	seedSuccessfulRemediationForMedia(t, db, "m1", "/local/movies/Film.Release-A.mkv", 55)
+	seedSuccessfulRemediationForMedia(t, db, "m2", "/local/movies/Film.Release-B.mkv", 55)
+	seedSuccessfulRemediationForMedia(t, db, "m3", "/local/movies/Film.Release-C.mkv", 55)
+
+	eb := testutil.NewMockEventBus()
+	arr := &testutil.MockArrClient{
+		FindMediaByPathFunc: func(string) (int64, error) { return 55, nil },
+		DeleteFileFunc:      func(int64, string) (map[string]interface{}, error) { return map[string]interface{}{}, nil },
+	}
+	pm := &testutil.MockPathMapper{ToArrPathFunc: func(p string) (string, error) { return p, nil }}
+	r := NewRemediatorService(eb, arr, pm, db)
+
+	// Round 4 arrives under yet another new filename.
+	event := testutil.NewCorruptionEventWithType("/local/movies/Film.Release-D.mkv", integration.ErrorTypeCorruptHeader, testutil.WithAutoRemediate(true))
+	r.handleCorruptionDetected(event)
+	time.Sleep(200 * time.Millisecond)
+
+	if eb.EventCount(domain.RemediationPaused) != 1 {
+		t.Errorf("RemediationPaused = %d, want 1 (media-keyed loop-breaker must survive renames)", eb.EventCount(domain.RemediationPaused))
+	}
+	if arr.CallCount("DeleteFile") != 0 {
+		t.Error("a paused remediation must not delete the file")
+	}
+}
+
+// manual_retry=true is the user's explicit consent to bypass a loop-breaker
+// pause after fixing the root cause; previously the flag was written by the
+// UI handler and read by nothing, leaving the user stuck for up to 30 days.
+func TestRemediator_ManualRetryBypassesLoopBreakerPause(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	seedRemediationPath(t, db, "/local/movies", true, false)
+
+	// Trip the path-keyed loop-breaker.
+	const fp = "/local/movies/loop.mkv"
+	for _, agg := range []string{"b1", "b2", "b3"} {
+		seedSuccessfulRemediation(t, db, agg, fp)
+	}
+
+	eb := testutil.NewMockEventBus()
+	arr := &testutil.MockArrClient{
+		FindMediaByPathFunc: func(string) (int64, error) { return 77, nil },
+		DeleteFileFunc:      func(int64, string) (map[string]interface{}, error) { return map[string]interface{}{}, nil },
+		TriggerSearchFunc:   func(int64, string, []int64) error { return nil },
+	}
+	pm := &testutil.MockPathMapper{ToArrPathFunc: func(p string) (string, error) { return p, nil }}
+	r := NewRemediatorService(eb, arr, pm, db)
+
+	// Without the flag: paused, no delete.
+	r.handleRetry(domain.Event{
+		AggregateID: "b-noflag", AggregateType: "corruption", EventType: domain.RetryScheduled,
+		EventData: map[string]interface{}{"file_path": fp, "auto_remediate": true},
+	})
+	time.Sleep(150 * time.Millisecond)
+	if arr.CallCount("DeleteFile") != 0 {
+		t.Fatal("retry without manual_retry must stay paused")
+	}
+
+	// With manual_retry=true: the user's one-cycle consent proceeds.
+	r.handleRetry(domain.Event{
+		AggregateID: "b-flag", AggregateType: "corruption", EventType: domain.RetryScheduled,
+		EventData: map[string]interface{}{"file_path": fp, "auto_remediate": true, "manual_retry": true},
+	})
+	time.Sleep(150 * time.Millisecond)
+	if arr.CallCount("DeleteFile") != 1 {
+		t.Errorf("DeleteFile calls = %d, want 1 (manual retry bypasses the pause)", arr.CallCount("DeleteFile"))
+	}
 }


### PR DESCRIPTION
Fixes HIGH findings 13 and 14 from the Fable 5 audit.

## Finding 13: notification bookkeeping corrupted the state machine
The migration-004 trigger updated `corruption_summary` for EVERY corruption-aggregate event, and the notifier publishes `NotificationSent`/`NotificationFailed` under the source aggregate. Consequences: a "remediation complete" notification set `current_state = NotificationSent` (item left the resolved filter, counted active forever); a broken provider's `NotificationFailed` events matched the trigger's `LIKE '%Failed'` retry counter, exhausting the budget with zero real attempts.

**Migration 012**: the trigger ignores notification bookkeeping, `retry_count` counts the explicit retry-relevant set (incl. `DownloadTimeout`, unifying the monitor's and the summary's previously-disagreeing cap definitions; `monitor.getRetryCount` aligned to the same list), and already-clobbered rows are repaired.

## Finding 14: loop-breaker bypassed by per-round renames; manual retry ignored
The recurring-corruption pause counted successes by EXACT file path, but each round imports under a new release filename — the counter never accumulated for exactly the Tdarr scenario it was built for. New **media-keyed** check (via `DeletionCompleted.media_id`) survives renames and also trips on repeated `MaxRetriesReached` (the never-succeeds loop). The path-keyed check remains as the cheap fast path.

`manual_retry=true` (written by the UI retry button since the flag existed, read by nothing) now bypasses both loop-breaker checks for one cycle, so a user who fixed the root cause is no longer stuck for up to 30 days.

## Test plan
- [x] New: trigger ignores notification events but counts real failures incl. DownloadTimeout; media-keyed pause trips across three renamed rounds (no delete); manual_retry bypasses while plain retry stays paused
- [x] db + services + repository suites green; lint 0 issues