### PR TITLE
fix(control-plane): shared corruption buckets, real scan statuses, overlap guard, limiter refill, retention

### DIFF
--- a/internal/api/handlers_corruptions.go
+++ b/internal/api/handlers_corruptions.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/repository"
 )
 
 // dbTimeout is the maximum time to wait for database operations
@@ -20,20 +21,24 @@ const dbTimeout = 5 * time.Second
 
 // statusFilterClauses maps status filter values to SQL WHERE clauses.
 // Includes both granular technical filters (for API compatibility) and user-friendly combined filters.
+// statusFilterClauses is built from the SHARED bucket constants in the
+// repository so the /corruptions filters and the dashboard StateCounts can
+// never partition the lifecycle differently (the audit found nine states
+// visible in one view but missing from the other).
 var statusFilterClauses = map[string]string{
 	// Granular technical filters (kept for API compatibility and detail views)
-	"active":              "current_state != 'VerificationSuccess' AND current_state != 'MaxRetriesReached' AND current_state != 'CorruptionIgnored'",
-	"pending":             "current_state = 'CorruptionDetected'",
-	"in_progress":         "(current_state LIKE '%Started' OR current_state LIKE '%Queued' OR current_state LIKE '%Progress' OR current_state = 'RemediationQueued')",
-	"resolved":            "current_state = 'VerificationSuccess'",
-	"failed":              "current_state LIKE '%Failed'",
-	"orphaned":            "current_state = 'MaxRetriesReached'",
-	"ignored":             "current_state = 'CorruptionIgnored'",
-	"manual_intervention": "(current_state = 'ImportBlocked' OR current_state = 'ManuallyRemoved')",
+	"active":              "current_state NOT IN " + repository.InClause(append(append(append([]string{}, repository.BucketResolved...), repository.BucketOrphaned...), repository.BucketIgnored...)),
+	"pending":             "current_state IN " + repository.InClause(repository.BucketPending),
+	"in_progress":         "current_state IN " + repository.InClause(repository.BucketInProgress),
+	"resolved":            "current_state IN " + repository.InClause(repository.BucketResolved),
+	"failed":              "current_state IN " + repository.InClause(repository.BucketFailed),
+	"orphaned":            "current_state IN " + repository.InClause(repository.BucketOrphaned),
+	"ignored":             "current_state IN " + repository.InClause(repository.BucketIgnored),
+	"manual_intervention": "current_state IN " + repository.InClause(repository.BucketManualIntervention),
 
 	// User-friendly combined filters (for simplified UI)
-	"action_required": "(current_state = 'ImportBlocked' OR current_state = 'ManuallyRemoved' OR current_state = 'MaxRetriesReached')",
-	"working":         "(current_state = 'CorruptionDetected' OR current_state LIKE '%Started' OR current_state LIKE '%Queued' OR current_state LIKE '%Progress' OR current_state = 'RemediationQueued' OR (current_state LIKE '%Failed' AND current_state != 'MaxRetriesReached'))",
+	"action_required": "current_state IN " + repository.InClause(append(append([]string{}, repository.BucketManualIntervention...), repository.BucketOrphaned...)),
+	"working":         "current_state IN " + repository.InClause(append(append(append([]string{}, repository.BucketPending...), repository.BucketInProgress...), repository.BucketFailed...)),
 }
 
 // extractJSONString extracts a string value from a map if it exists and is non-empty.

--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mescon/Healarr/internal/logger"
 	"github.com/mescon/Healarr/internal/repository"
 	"github.com/mescon/Healarr/internal/safego"
+	"github.com/mescon/Healarr/internal/services"
 )
 
 func (s *RESTServer) triggerScan(c *gin.Context) {
@@ -30,9 +31,11 @@ func (s *RESTServer) triggerScan(c *gin.Context) {
 	}
 	localPath := path.LocalPath
 
-	// Check if scan is already in progress
-	if s.scanner.IsPathBeingScanned(localPath) {
-		c.JSON(http.StatusConflict, gin.H{"error": "Scan already in progress for this path"})
+	// Check for overlap with any active scan: same path, ancestor, or
+	// descendant. Exact compare let /media and /media/TV run concurrently
+	// over the same files (duplicate scan_files, duplicate journeys).
+	if conflict, overlaps := s.scanner.ScanOverlapsActive(localPath); overlaps {
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Scan already in progress for an overlapping path (%s)", conflict)})
 		return
 	}
 
@@ -143,7 +146,10 @@ func (s *RESTServer) pauseAllScans(c *gin.Context) {
 	activeScans := s.scanner.GetActiveScans()
 	paused := 0
 	for i := range activeScans {
-		if activeScans[i].Status == "running" {
+		// In-memory statuses are enumerating/scanning/paused — never
+		// "running" (a DB-only status). Filtering on "running" made
+		// pause-all a silent no-op.
+		if services.ScanStatusIsPausable(activeScans[i].Status) {
 			if s.scanner.PauseScan(activeScans[i].ID) == nil {
 				paused++
 			}
@@ -169,7 +175,7 @@ func (s *RESTServer) cancelAllScans(c *gin.Context) {
 	activeScans := s.scanner.GetActiveScans()
 	cancelled := 0
 	for i := range activeScans {
-		if activeScans[i].Status == "running" || activeScans[i].Status == "paused" {
+		if services.ScanStatusIsActive(activeScans[i].Status) {
 			if s.scanner.CancelScan(activeScans[i].ID) == nil {
 				cancelled++
 			}
@@ -198,9 +204,17 @@ func (s *RESTServer) rescanPath(c *gin.Context) {
 	}
 	path := scan.Path
 
-	// Don't allow rescanning a currently running scan
-	if scan.Status == "running" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Scan is currently running"})
+	// Don't allow rescanning a currently active scan. The DB row can be in
+	// any of the active statuses (running/enumerating/scanning/paused), and
+	// the live scanner may hold an overlapping path even when this row is
+	// terminal.
+	switch scan.Status {
+	case "running", "enumerating", "scanning", "paused":
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Scan is currently active"})
+		return
+	}
+	if conflict, overlaps := s.scanner.ScanOverlapsActive(path); overlaps {
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Scan already in progress for an overlapping path (%s)", conflict)})
 		return
 	}
 

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -1171,6 +1171,13 @@ func (m *scansMockScanner) IsPathBeingScanned(_ string) bool {
 	return m.isPathScanning
 }
 
+func (m *scansMockScanner) ScanOverlapsActive(path string) (string, bool) {
+	if m.isPathScanning {
+		return path, true
+	}
+	return "", false
+}
+
 func (m *scansMockScanner) GetActiveScans() []services.ScanProgressView {
 	return m.activeScans
 }
@@ -1220,9 +1227,12 @@ func TestPauseAllScans_WithActiveScans(t *testing.T) {
 	defer eb.Shutdown()
 
 	mockScanner := newScansMockScanner()
+	// In-memory scan statuses are "enumerating"/"scanning"/"paused" - never
+	// "running" (a DB-only status). These fixtures pin that pause-all matches
+	// the statuses the scanner actually reports.
 	mockScanner.activeScans = []services.ScanProgressView{
-		{ID: "scan-1", Status: "running", Path: "/test/path1"},
-		{ID: "scan-2", Status: "running", Path: "/test/path2"},
+		{ID: "scan-1", Status: "scanning", Path: "/test/path1"},
+		{ID: "scan-2", Status: "enumerating", Path: "/test/path2"},
 		{ID: "scan-3", Status: "paused", Path: "/test/path3"}, // Should not be paused (already paused)
 	}
 
@@ -1271,7 +1281,7 @@ func TestResumeAllScans_WithActiveScans(t *testing.T) {
 	mockScanner.activeScans = []services.ScanProgressView{
 		{ID: "scan-1", Status: "paused", Path: "/test/path1"},
 		{ID: "scan-2", Status: "paused", Path: "/test/path2"},
-		{ID: "scan-3", Status: "running", Path: "/test/path3"}, // Should not be resumed (already running)
+		{ID: "scan-3", Status: "scanning", Path: "/test/path3"}, // Should not be resumed (still scanning)
 	}
 
 	server := createMockScanServer(t, db, eb, mockScanner)
@@ -1317,7 +1327,7 @@ func TestCancelAllScans_WithActiveScans(t *testing.T) {
 
 	mockScanner := newScansMockScanner()
 	mockScanner.activeScans = []services.ScanProgressView{
-		{ID: "scan-1", Status: "running", Path: "/test/path1"},
+		{ID: "scan-1", Status: "scanning", Path: "/test/path1"},
 		{ID: "scan-2", Status: "paused", Path: "/test/path2"},
 		{ID: "scan-3", Status: "completed", Path: "/test/path3"}, // Should not be cancelled
 	}
@@ -1540,6 +1550,13 @@ type scansMockScannerWithPathCheck struct {
 
 func (m *scansMockScannerWithPathCheck) IsPathBeingScanned(path string) bool {
 	return m.scanningPaths[path]
+}
+
+func (m *scansMockScannerWithPathCheck) ScanOverlapsActive(path string) (string, bool) {
+	if m.scanningPaths[path] {
+		return path, true
+	}
+	return "", false
 }
 
 func createMockScanServerWithPathCheck(t *testing.T, db *sql.DB, eb *eventbus.EventBus, scanner *scansMockScannerWithPathCheck) *RESTServer {

--- a/internal/api/handlers_webhook_test.go
+++ b/internal/api/handlers_webhook_test.go
@@ -40,6 +40,7 @@ func (m *webhookMockScanner) ScanFile(path string) error {
 
 func (m *webhookMockScanner) ScanPath(_ int64, _ string) error            { return nil }
 func (m *webhookMockScanner) IsPathBeingScanned(_ string) bool            { return false }
+func (m *webhookMockScanner) ScanOverlapsActive(_ string) (string, bool)  { return "", false }
 func (m *webhookMockScanner) GetActiveScans() []services.ScanProgressView { return nil }
 func (m *webhookMockScanner) CancelScan(_ string) error                   { return nil }
 func (m *webhookMockScanner) PauseScan(_ string) error                    { return nil }

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -58,14 +58,22 @@ func (rl *RateLimiter) Allow(ip string) bool {
 		return true
 	}
 
-	// Refill tokens based on elapsed time
+	// Refill tokens based on elapsed time. lastCheck advances ONLY by the
+	// whole intervals actually consumed: resetting it to now on every
+	// request meant any stream with sub-interval arrivals never refilled at
+	// all (each request restarted the clock), so a burst — e.g. a season-
+	// pack import firing webhooks — drained the bucket and then starved it
+	// forever, with the *arrs never retrying the 429'd webhooks and those
+	// files silently going unscanned.
 	elapsed := now.Sub(bucket.lastCheck)
-	tokensToAdd := int(elapsed/rl.interval) * rl.rate
-	bucket.tokens += tokensToAdd
-	if bucket.tokens > rl.burst {
-		bucket.tokens = rl.burst
+	intervals := int(elapsed / rl.interval)
+	if intervals > 0 {
+		bucket.tokens += intervals * rl.rate
+		if bucket.tokens > rl.burst {
+			bucket.tokens = rl.burst
+		}
+		bucket.lastCheck = bucket.lastCheck.Add(time.Duration(intervals) * rl.interval)
 	}
-	bucket.lastCheck = now
 
 	if bucket.tokens > 0 {
 		bucket.tokens--

--- a/internal/api/ratelimit_refill_test.go
+++ b/internal/api/ratelimit_refill_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// The old refill reset bucket.lastCheck to now on EVERY call. Any client
+// arriving faster than the interval therefore never accumulated a full
+// interval and starved forever once the burst was spent - e.g. a season-pack
+// import firing webhooks drained the bucket and every later webhook got a
+// 429 the *arrs never retry, so those files were silently never scanned.
+
+// TestRateLimiter_Allow_SubIntervalArrivalsStillRefill hammers the limiter
+// with arrivals shorter than the interval and asserts the bucket still
+// refills on schedule.
+func TestRateLimiter_Allow_SubIntervalArrivalsStillRefill(t *testing.T) {
+	rl := NewRateLimiter(1, 100*time.Millisecond, 1)
+	defer rl.Shutdown()
+
+	ip := "10.99.0.1"
+	if !rl.Allow(ip) {
+		t.Fatal("first request should be allowed")
+	}
+
+	deadline := time.Now().Add(450 * time.Millisecond)
+	allowed := 0
+	for time.Now().Before(deadline) {
+		if rl.Allow(ip) {
+			allowed++
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if allowed == 0 {
+		t.Error("bucket never refilled under sub-interval arrivals (refill clock reset on every request)")
+	}
+}
+
+// TestRateLimiter_Allow_RefillConsumesWholeIntervalsOnly verifies the clock
+// arithmetic directly: refilling advances lastCheck by exactly the whole
+// intervals consumed, preserving the partial-interval remainder.
+func TestRateLimiter_Allow_RefillConsumesWholeIntervalsOnly(t *testing.T) {
+	const interval = time.Second
+	rl := NewRateLimiter(1, interval, 5)
+	defer rl.Shutdown()
+
+	ip := "10.99.0.2"
+	rl.Allow(ip) // create the bucket
+
+	rl.mu.Lock()
+	bucket := rl.clients[ip]
+	bucket.tokens = 0
+	before := time.Now().Add(-2500 * time.Millisecond) // 2.5 intervals ago
+	bucket.lastCheck = before
+	rl.mu.Unlock()
+
+	if !rl.Allow(ip) {
+		t.Fatal("2 whole intervals elapsed - expected a refilled token")
+	}
+
+	rl.mu.Lock()
+	tokens := bucket.tokens
+	lastCheck := bucket.lastCheck
+	rl.mu.Unlock()
+
+	// 2 whole intervals refilled 2 tokens, the request consumed 1.
+	if tokens != 1 {
+		t.Errorf("tokens = %d, want 1 (2 intervals refilled, 1 consumed)", tokens)
+	}
+	// The 0.5-interval remainder must keep accruing toward the next refill.
+	if want := before.Add(2 * interval); !lastCheck.Equal(want) {
+		t.Errorf("lastCheck advanced by %v, want exactly 2 intervals (partial interval must be preserved)", lastCheck.Sub(before))
+	}
+}

--- a/internal/db/repository.go
+++ b/internal/db/repository.go
@@ -565,8 +565,14 @@ func (r *Repository) RunMaintenance(retentionDays int) error {
 				format: "Pruned %d old events",
 			},
 			{
-				name:   "prune old scans",
-				query:  "DELETE FROM scans WHERE status IN ('completed', 'cancelled', 'error') AND completed_at < ?",
+				name: "prune old scans",
+				// aborted/interrupted are included: an aborted scan is
+				// terminal, and an interrupted one older than the retention
+				// window will never be resumed. COALESCE covers rows whose
+				// terminal write never stamped completed_at (MarkAborted /
+				// MarkInterrupted) — they previously never matched and the
+				// table only grew.
+				query:  "DELETE FROM scans WHERE status IN ('completed', 'cancelled', 'error', 'aborted', 'interrupted') AND COALESCE(completed_at, started_at) < ?",
 				args:   []interface{}{cutoff},
 				format: "Pruned %d old scan records",
 			},

--- a/internal/db/repository_prune_test.go
+++ b/internal/db/repository_prune_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRepository_RunMaintenance_PrunesAbortedAndInterrupted pins the
+// retention fix: MarkAborted/MarkInterrupted never stamp completed_at, and
+// the old prune predicate (status IN ('completed','cancelled','error') AND
+// completed_at < cutoff) therefore never matched those rows - the scans
+// table only grew. The fix prunes all five terminal statuses and falls back
+// to started_at when completed_at is NULL.
+func TestRepository_RunMaintenance_PrunesAbortedAndInterrupted(t *testing.T) {
+	repo, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	oldTime := time.Now().AddDate(0, 0, -10).Format(time.RFC3339)
+
+	for _, status := range []string{"aborted", "interrupted"} {
+		_, err := repo.DB.Exec(`
+			INSERT INTO scans (path, status, started_at, completed_at)
+			VALUES (?, ?, ?, NULL)
+		`, "/test/old-"+status, status, oldTime)
+		if err != nil {
+			t.Fatalf("insert old %s scan: %v", status, err)
+		}
+	}
+
+	// A fresh interrupted scan is a resume candidate and must survive.
+	_, err := repo.DB.Exec(`
+		INSERT INTO scans (path, status, started_at, completed_at)
+		VALUES (?, 'interrupted', ?, NULL)
+	`, "/test/fresh-interrupted", time.Now().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("insert fresh interrupted scan: %v", err)
+	}
+
+	if err := repo.RunMaintenance(7); err != nil {
+		t.Fatalf("RunMaintenance: %v", err)
+	}
+
+	var oldCount int
+	if err := repo.DB.QueryRow(`SELECT COUNT(*) FROM scans WHERE path LIKE '/test/old-%'`).Scan(&oldCount); err != nil {
+		t.Fatalf("count old scans: %v", err)
+	}
+	if oldCount != 0 {
+		t.Errorf("old aborted/interrupted scans not pruned: %d rows remain (completed_at is NULL for these statuses)", oldCount)
+	}
+
+	var freshCount int
+	if err := repo.DB.QueryRow(`SELECT COUNT(*) FROM scans WHERE path = '/test/fresh-interrupted'`).Scan(&freshCount); err != nil {
+		t.Fatalf("count fresh scan: %v", err)
+	}
+	if freshCount != 1 {
+		t.Errorf("fresh interrupted scan pruned - it is a resume candidate and must be kept")
+	}
+}

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -293,23 +293,63 @@ type TypeCount struct {
 	Count int
 }
 
+// Corruption lifecycle buckets: the ONE state-to-bucket mapping consumed by
+// the dashboard StateCounts AND the /corruptions filter clauses, so the two
+// views can never partition states differently again. Every lifecycle event
+// type that can become corruption_summary.current_state must appear in
+// exactly one bucket; the audit found nine states falling through (and two
+// phantom types, SearchQueued/DownloadStarted, that no code publishes).
+var (
+	BucketResolved = []string{"VerificationSuccess"}
+	BucketOrphaned = []string{"MaxRetriesReached"}
+	// In flight: remediation machinery is actively working the item.
+	BucketInProgress = []string{
+		"RemediationQueued", "DeletionStarted", "DeletionCompleted",
+		"SearchStarted", "SearchCompleted", "DownloadProgress",
+		"FileDetected", "VerificationStarted", "RetryScheduled",
+		"StuckRemediation", "ReleaseBlocklisted", "MonitorOverridden",
+	}
+	// Deliberately parked: the system stopped and a human decides.
+	BucketManualIntervention = []string{
+		"ImportBlocked", "ManuallyRemoved", "SearchExhausted",
+		"RemediationPaused", "DownloadIgnored",
+	}
+	BucketPending = []string{"CorruptionDetected"}
+	// Failed-but-retryable: counts toward the retry budget.
+	BucketFailed = []string{
+		"DeletionFailed", "SearchFailed", "VerificationFailed",
+		"DownloadFailed", "DownloadTimeout",
+	}
+	BucketIgnored = []string{"CorruptionIgnored"}
+)
+
+// InClause renders a bucket as a SQL IN(...) literal. Safe by construction:
+// the inputs are the hardcoded bucket constants above, never user input.
+func InClause(states []string) string {
+	quoted := make([]string, len(states))
+	for i, st := range states {
+		quoted[i] = "'" + st + "'"
+	}
+	return "(" + strings.Join(quoted, ", ") + ")"
+}
+
 // StateCounts returns the dashboard breakdown of corruptions by lifecycle
-// bucket in a single pass over corruption_status.
+// bucket in a single pass over corruption_status. Built from the shared
+// bucket constants so it cannot drift from the /corruptions filters.
 func (r *CorruptionRepository) StateCounts(ctx context.Context) (CorruptionStateCounts, error) {
 	var c CorruptionStateCounts
-	err := r.db.QueryRowContext(ctx, `
+	query := `
 		SELECT
-			COUNT(DISTINCT CASE WHEN current_state = 'VerificationSuccess' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'MaxRetriesReached' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state IN ('SearchStarted', 'SearchQueued', 'RemediationQueued',
-				'DownloadStarted', 'DownloadProgress', 'SearchCompleted', 'DeletionCompleted', 'FileDetected')
-				THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state IN ('ImportBlocked', 'ManuallyRemoved') THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionDetected' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state LIKE '%Failed' AND current_state != 'MaxRetriesReached' THEN corruption_id END),
-			COUNT(DISTINCT CASE WHEN current_state = 'CorruptionIgnored' THEN corruption_id END)
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketResolved) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketOrphaned) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketInProgress) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketManualIntervention) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketPending) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketFailed) + ` THEN corruption_id END),
+			COUNT(DISTINCT CASE WHEN current_state IN ` + InClause(BucketIgnored) + ` THEN corruption_id END)
 		FROM corruption_status
-	`).Scan(&c.Resolved, &c.Orphaned, &c.InProgress, &c.ManualIntervention, &c.Pending, &c.Failed, &c.Ignored)
+	`
+	err := r.db.QueryRowContext(ctx, query).Scan(&c.Resolved, &c.Orphaned, &c.InProgress, &c.ManualIntervention, &c.Pending, &c.Failed, &c.Ignored)
 	if err != nil {
 		return CorruptionStateCounts{}, fmt.Errorf("query corruption state counts: %w", err)
 	}

--- a/internal/repository/corruption_buckets_test.go
+++ b/internal/repository/corruption_buckets_test.go
@@ -1,0 +1,90 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// allBuckets returns the named lifecycle buckets. Kept as a function so each
+// test gets its own copy.
+func allBuckets() map[string][]string {
+	return map[string][]string{
+		"Resolved":           BucketResolved,
+		"Orphaned":           BucketOrphaned,
+		"InProgress":         BucketInProgress,
+		"ManualIntervention": BucketManualIntervention,
+		"Pending":            BucketPending,
+		"Failed":             BucketFailed,
+		"Ignored":            BucketIgnored,
+	}
+}
+
+// TestCorruptionBuckets_Disjoint pins the bucket invariant: a lifecycle state
+// in two buckets would be double-counted by StateCounts and matched by two
+// /corruptions filters at once.
+func TestCorruptionBuckets_Disjoint(t *testing.T) {
+	t.Parallel()
+	seen := map[string]string{}
+	for name, states := range allBuckets() {
+		for _, st := range states {
+			if prev, dup := seen[st]; dup {
+				t.Errorf("state %q appears in both %s and %s buckets", st, prev, name)
+			}
+			seen[st] = name
+		}
+	}
+}
+
+// TestInClause verifies the SQL rendering of a bucket.
+func TestInClause(t *testing.T) {
+	t.Parallel()
+	got := InClause([]string{"A", "B"})
+	if got != "('A', 'B')" {
+		t.Errorf("InClause = %q, want ('A', 'B')", got)
+	}
+	if !strings.HasPrefix(InClause(BucketResolved), "('VerificationSuccess'") {
+		t.Errorf("InClause(BucketResolved) = %q", InClause(BucketResolved))
+	}
+}
+
+// TestCorruptionRepository_StateCounts_EveryStateIsBucketed seeds one
+// corruption per lifecycle state across ALL buckets and asserts the dashboard
+// counts them all. Before the shared bucket constants, nine states fell
+// through StateCounts' hardcoded lists and silently vanished from the
+// dashboard while still matching a /corruptions filter (audit finding 15).
+func TestCorruptionRepository_StateCounts_EveryStateIsBucketed(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	total := 0
+	for _, bucket := range allBuckets() {
+		for _, state := range bucket {
+			id := fmt.Sprintf("c%d", total)
+			seedCorruption(t, db, id, fmt.Sprintf("/f%d.mkv", total), state, base.Add(time.Duration(total)*time.Hour))
+			total++
+		}
+	}
+
+	c, err := repo.StateCounts(context.Background())
+	if err != nil {
+		t.Fatalf("StateCounts: %v", err)
+	}
+	sum := c.Resolved + c.Orphaned + c.InProgress + c.ManualIntervention + c.Pending + c.Failed + c.Ignored
+	if sum != total {
+		t.Errorf("StateCounts buckets cover %d of %d lifecycle states - some state falls through the dashboard", sum, total)
+	}
+	if c.InProgress != len(BucketInProgress) {
+		t.Errorf("InProgress = %d, want %d", c.InProgress, len(BucketInProgress))
+	}
+	if c.ManualIntervention != len(BucketManualIntervention) {
+		t.Errorf("ManualIntervention = %d, want %d", c.ManualIntervention, len(BucketManualIntervention))
+	}
+	if c.Failed != len(BucketFailed) {
+		t.Errorf("Failed = %d, want %d", c.Failed, len(BucketFailed))
+	}
+}

--- a/internal/repository/scan.go
+++ b/internal/repository/scan.go
@@ -126,7 +126,7 @@ func (r *ScanRepository) GetScanStats(ctx context.Context) (ScanStats, error) {
 	var s ScanStats
 	err := r.db.QueryRowContext(ctx, `
 		SELECT
-			COUNT(CASE WHEN status = 'running' THEN 1 END),
+			COUNT(CASE WHEN status IN ('running', 'enumerating', 'scanning', 'paused') THEN 1 END),
 			COUNT(*),
 			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) = date('now') THEN files_scanned END), 0),
 			COALESCE(SUM(CASE WHEN substr(started_at, 1, 10) >= date('now', '-7 days') THEN files_scanned END), 0)
@@ -287,10 +287,12 @@ func (r *ScanRepository) SetStatus(ctx context.Context, scanID int64, status str
 }
 
 // Finalize sets the terminal status, the final files_scanned count, and
-// stamps completed_at to now.
+// stamps completed_at to now. file_list is cleared: terminal scans are never
+// resumed, and the serialized list weighs ~10 MB per 100k-file scan — left
+// in place it made the scans table the dominant source of database growth.
 func (r *ScanRepository) Finalize(ctx context.Context, scanID int64, status string, filesScanned int) error {
 	_, err := r.db.ExecContext(ctx, `
-		UPDATE scans SET status = ?, files_scanned = ?, completed_at = datetime('now')
+		UPDATE scans SET status = ?, files_scanned = ?, completed_at = datetime('now'), file_list = NULL
 		WHERE id = ?
 	`, status, filesScanned, scanID)
 	if err != nil {
@@ -356,7 +358,7 @@ func (r *ScanRepository) MarkAborted(ctx context.Context, scanID int64, errorMes
 // scan" from "scan was already done" for error reporting.
 func (r *ScanRepository) MarkCancelled(ctx context.Context, scanID int64, reason string) (bool, error) {
 	res, err := r.db.ExecContext(ctx, `
-		UPDATE scans SET status = 'cancelled', completed_at = datetime('now'), error_message = ?
+		UPDATE scans SET status = 'cancelled', completed_at = datetime('now'), error_message = ?, file_list = NULL
 		WHERE id = ? AND status NOT IN ('cancelled', 'completed', 'aborted')
 	`, reason, scanID)
 	if err != nil {

--- a/internal/repository/scan_filelist_test.go
+++ b/internal/repository/scan_filelist_test.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// Terminal writes must clear file_list: the enumeration snapshot exists only
+// so interrupted scans can resume, and keeping it on completed/cancelled rows
+// stored the full path list of every scan forever (multi-MB per row on large
+// libraries).
+
+func TestScanRepository_Finalize_ClearsFileList(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	mustExecScan(t, db, `INSERT INTO scans (path, status, file_list, current_file_index) VALUES ('/media', 'scanning', '["a.mkv","b.mkv"]', 1)`)
+	var id int64
+	if err := db.QueryRow(`SELECT id FROM scans`).Scan(&id); err != nil {
+		t.Fatalf("fetch scan id: %v", err)
+	}
+
+	if err := repo.Finalize(context.Background(), id, "completed", 2); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	var status string
+	var fileList sql.NullString
+	if err := db.QueryRow(`SELECT status, file_list FROM scans WHERE id = ?`, id).Scan(&status, &fileList); err != nil {
+		t.Fatalf("read back scan: %v", err)
+	}
+	if status != "completed" {
+		t.Errorf("status = %q, want completed", status)
+	}
+	if fileList.Valid {
+		t.Errorf("file_list survived Finalize (snapshot kept forever): %q", fileList.String)
+	}
+}
+
+func TestScanRepository_MarkCancelled_ClearsFileList(t *testing.T) {
+	t.Parallel()
+	db := newScanTestDB(t)
+	repo := NewScanRepository(db)
+	mustExecScan(t, db, `INSERT INTO scans (path, status, file_list, current_file_index) VALUES ('/media', 'scanning', '["a.mkv","b.mkv"]', 1)`)
+	var id int64
+	if err := db.QueryRow(`SELECT id FROM scans`).Scan(&id); err != nil {
+		t.Fatalf("fetch scan id: %v", err)
+	}
+
+	ok, err := repo.MarkCancelled(context.Background(), id, "user cancelled")
+	if err != nil || !ok {
+		t.Fatalf("MarkCancelled = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	var fileList sql.NullString
+	if err := db.QueryRow(`SELECT file_list FROM scans WHERE id = ?`, id).Scan(&fileList); err != nil {
+		t.Fatalf("read back scan: %v", err)
+	}
+	if fileList.Valid {
+		t.Errorf("file_list survived MarkCancelled (snapshot kept forever): %q", fileList.String)
+	}
+}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -350,6 +350,7 @@ type Scanner interface {
 	ScanFile(localPath string) error
 	ScanPath(pathID int64, localPath string) error
 	IsPathBeingScanned(path string) bool
+	ScanOverlapsActive(path string) (string, bool)
 	GetActiveScans() []ScanProgressView
 	CancelScan(scanID string) error
 	PauseScan(scanID string) error
@@ -1235,7 +1236,22 @@ func (s *ScannerService) ScanPath(pathID int64, localPath string) error {
 	}
 	progress.cancel = cancel
 
+	// Overlap guard INSIDE the registration lock (no TOCTOU): refuse to
+	// start when any active path scan covers the same tree (same path,
+	// ancestor, or descendant). This is the single enforcement point — it
+	// protects the scheduler (which never checked) and any direct caller,
+	// not just the HTTP trigger handler.
 	s.mu.Lock()
+	for _, active := range s.activeScans {
+		if active.Type != "path" {
+			continue
+		}
+		if pathutil.IsWithinRoot(active.Path, localPath) || pathutil.IsWithinRoot(localPath, active.Path) {
+			conflict := active.Path
+			s.mu.Unlock()
+			return fmt.Errorf("scan already in progress for overlapping path %s", conflict)
+		}
+	}
 	s.activeScans[scanID] = progress
 	s.mu.Unlock()
 
@@ -2324,6 +2340,41 @@ func (s *ScannerService) GetActiveScans() []ScanProgressView {
 		views = append(views, scan.Snapshot())
 	}
 	return views
+}
+
+// ScanStatusIsPausable reports whether an in-memory scan status can be
+// paused. The in-memory Status field is only ever "enumerating", "scanning",
+// "paused", or a terminal value — never "running" (that is a DB-only
+// status). The pause-all/cancel-all handlers used to filter on "running"
+// and therefore matched nothing.
+func ScanStatusIsPausable(status string) bool {
+	return status == ScanStatusEnumerating || status == ScanStatusScanning
+}
+
+// ScanStatusIsActive reports whether an in-memory scan status represents a
+// scan that is still alive (pausable or paused) and therefore cancellable.
+func ScanStatusIsActive(status string) bool {
+	return ScanStatusIsPausable(status) || status == ScanStatusPaused
+}
+
+// ScanOverlapsActive reports whether path overlaps any active path scan:
+// the same path, an ancestor of it, or a descendant — boundary-aware via
+// pathutil, so /media and /media/TV conflict but /media/TV and /media/TV2
+// do not. Returns the conflicting scan's path. The exact-compare
+// IsPathBeingScanned missed ancestor/descendant overlap, letting two scans
+// race over the same files (duplicate scan_files, duplicate journeys).
+func (s *ScannerService) ScanOverlapsActive(path string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, scan := range s.activeScans {
+		if scan.Type != "path" {
+			continue
+		}
+		if pathutil.IsWithinRoot(scan.Path, path) || pathutil.IsWithinRoot(path, scan.Path) {
+			return scan.Path, true
+		}
+	}
+	return "", false
 }
 
 // IsPathBeingScanned checks if a scan is already in progress for the given path

--- a/internal/services/scanner_overlap_test.go
+++ b/internal/services/scanner_overlap_test.go
@@ -1,0 +1,40 @@
+package services
+
+import "testing"
+
+// TestScannerService_ScanOverlapsActive pins the boundary-aware overlap
+// check: the old exact-compare IsPathBeingScanned guard let /media and
+// /media/TV scan concurrently over the same files (duplicate scan_files
+// rows, duplicate corruption journeys), while naive prefix matching would
+// wrongly conflict /media/TV with /media/TV2.
+func TestScannerService_ScanOverlapsActive(t *testing.T) {
+	t.Parallel()
+	s := &ScannerService{activeScans: map[string]*ScanProgress{
+		"scan-1": {ID: "scan-1", Type: "path", Path: "/media/TV"},
+		"scan-2": {ID: "scan-2", Type: "file", Path: "/downloads/movie.mkv"},
+	}}
+
+	cases := []struct {
+		name         string
+		path         string
+		wantConflict string
+		wantOverlap  bool
+	}{
+		{"exact match", "/media/TV", "/media/TV", true},
+		{"descendant of active scan", "/media/TV/Show S01", "/media/TV", true},
+		{"ancestor of active scan", "/media", "/media/TV", true},
+		{"trailing separator", "/media/TV/", "/media/TV", true},
+		{"sibling sharing name prefix", "/media/TV2", "", false},
+		{"unrelated path", "/data", "", false},
+		{"file scans never block path scans", "/downloads/movie.mkv", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conflict, overlaps := s.ScanOverlapsActive(tc.path)
+			if overlaps != tc.wantOverlap || conflict != tc.wantConflict {
+				t.Errorf("ScanOverlapsActive(%q) = (%q, %v), want (%q, %v)",
+					tc.path, conflict, overlaps, tc.wantConflict, tc.wantOverlap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR 7 of 7 from the Fable 5 audit remediation: control-plane integrity (audit finding 15) plus the below-the-cut items.

### Finding 15: dashboard vs filter state-partition drift
- Corruption lifecycle buckets are now ONE shared constant set (`repository.Bucket*` + `InClause`) consumed by BOTH the dashboard `StateCounts` and the `/corruptions` status filter clauses, so the two views can never partition the lifecycle differently again.
- Nine previously fall-through states (e.g. `StuckRemediation`, `ReleaseBlocklisted`, `RemediationPaused`, `DownloadIgnored`) are now bucketed; the phantom `SearchQueued`/`DownloadStarted` types (published by no code) are removed; `DownloadTimeout` counts as failed in both views.

### Below-the-cut items
- **pause-all/cancel-all matched nothing**: they filtered on the DB-only status `running`, which the in-memory scanner never reports. New `ScanStatusIsPausable`/`ScanStatusIsActive` helpers match the real in-memory statuses (`enumerating`/`scanning`/`paused`).
- **Overlapping concurrent scans**: the trigger guard was an exact path compare, letting `/media` and `/media/TV` scan the same files concurrently (duplicate scan_files, duplicate journeys). `ScanOverlapsActive` is boundary-aware in both directions via `pathutil` (`/media/TV2` does NOT conflict), and the check is repeated inside `ScanPath`'s registration lock so two concurrent triggers cannot both pass.
- **rescanPath** rejects all four active DB statuses, not only `running`.
- **GetScanStats** counts `enumerating`/`scanning`/`paused` as active.
- **Rate limiter starvation**: refill reset `lastCheck` to now on every request, so any client arriving faster than the interval never refilled - webhook bursts (season-pack imports) got 429s forever and those files were silently never scanned. `lastCheck` now advances only by whole consumed intervals.
- **Scan retention**: `aborted`/`interrupted` rows never get `completed_at` stamped and were never pruned; the predicate now covers all five terminal statuses with `COALESCE(completed_at, started_at)`. `Finalize`/`MarkCancelled` clear `file_list` (only needed for resume).

## Test plan
- New regression tests pin each behavior: bucket disjointness + every-state-bucketed StateCounts parity, pause/cancel-all against the statuses the scanner actually reports, overlap boundary cases (exact/ancestor/descendant/name-prefix-sibling/file-scan), refill clock arithmetic + sub-interval-arrival starvation, retention of NULL-`completed_at` terminals (fresh interrupted survives), and `file_list` clearing on Finalize/MarkCancelled.
- `go test ./internal/services/ ./internal/api/ ./internal/repository/ ./internal/db/ -count=1 -race`: all green.
- `/usr/bin/golangci-lint run ./internal/...`: 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added path overlap detection to prevent concurrent scans of overlapping directories.

* **Bug Fixes**
  * Fixed rate limiter starvation that could block requests when arrivals occurred at frequent intervals.
  * Enhanced scan lifecycle handling to properly manage various active scan states.
  * Improved scan termination to clean up temporary data during cancellation and completion.

* **Chores**
  * Aligned corruption status filtering with internal bucket definitions for consistency.
  * Extended scan maintenance to prune additional terminal scan states and improve timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->