### PR TITLE
fix(arr): match Windows arr paths in media/file lookup; health counts all unresolved corruptions

### DIFF
--- a/internal/api/handlers_health.go
+++ b/internal/api/handlers_health.go
@@ -148,10 +148,13 @@ func (s *RESTServer) handleHealth(c *gin.Context) {
 	// Check arr instances health
 	arrHealth := s.checkArrInstancesHealth(ctx)
 
-	// Get pending corruptions count
-	pending, err := s.corruptions.CountByState(ctx, "CorruptionDetected")
+	// Count every corruption that still needs something (not resolved, not
+	// ignored) - this is what external dashboards poll to decide whether to
+	// surface Healarr. Counting only CorruptionDetected here hid corruptions
+	// stuck mid-remediation (e.g. DeletionFailed) behind a zero.
+	pending, err := s.corruptions.CountUnresolved(ctx)
 	if err != nil {
-		logger.Debugf("Failed to query pending corruptions: %v", err)
+		logger.Debugf("Failed to query unresolved corruptions: %v", err)
 	}
 
 	// Determine overall status

--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +20,7 @@ import (
 	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/crypto"
 	"github.com/mescon/Healarr/internal/logger"
+	"github.com/mescon/Healarr/internal/pathutil"
 	"github.com/mescon/Healarr/internal/repository"
 )
 
@@ -581,9 +581,15 @@ func (c *HTTPArrClient) tryParseMedia(instance *ArrInstance, path string) (int64
 	return 0, false
 }
 
-// matchMediaItem checks if a media item matches the given file path
+// matchMediaItem checks if a media item matches the given file path.
+//
+// All splitting and prefix logic goes through pathutil: item.Path comes from
+// the *arr verbatim, so a Windows Sonarr/Radarr reports backslash/UNC paths
+// (\\server\share\Movies\Title) that filepath and hardcoded "/" can never
+// match on a Linux host - every lookup ended in "media not found" and the
+// remediation died as DeletionFailed (issue #331).
 func matchMediaItem(item MediaItem, path, fileDirBase, showDirBase string) bool {
-	mediaFolder := filepath.Base(item.Path)
+	mediaFolder := pathutil.Base(item.Path)
 
 	// Exact folder match (case-insensitive)
 	if strings.EqualFold(mediaFolder, fileDirBase) {
@@ -593,10 +599,9 @@ func matchMediaItem(item MediaItem, path, fileDirBase, showDirBase string) bool 
 	if strings.EqualFold(mediaFolder, showDirBase) {
 		return true
 	}
-	// Check if the media path is a prefix of the file path
-	normalizedMediaPath := strings.ToLower(strings.TrimSuffix(item.Path, "/"))
-	normalizedFilePath := strings.ToLower(path)
-	return strings.HasPrefix(normalizedFilePath, normalizedMediaPath+"/")
+	// Check if the media path contains the file path, boundary-aware and
+	// case-insensitive (Windows paths compare case-insensitively).
+	return pathutil.IsWithinRoot(strings.ToLower(item.Path), strings.ToLower(path))
 }
 
 // findMediaByListing lists all media and finds a match by path
@@ -625,11 +630,12 @@ func (c *HTTPArrClient) findMediaByListing(instance *ArrInstance, path string) (
 		return 0, err
 	}
 
-	// Precompute path components for matching
-	fileDir := filepath.Dir(path)
-	fileDirBase := filepath.Base(fileDir)
-	showDir := filepath.Dir(fileDir)
-	showDirBase := filepath.Base(showDir)
+	// Precompute path components for matching (pathutil: path may be a
+	// Windows-style *arr path even when Healarr runs on Linux)
+	fileDir := pathutil.Dir(path)
+	fileDirBase := pathutil.Base(fileDir)
+	showDir := pathutil.Dir(fileDir)
+	showDirBase := pathutil.Base(showDir)
 
 	for _, item := range items {
 		if matchMediaItem(item, path, fileDirBase, showDirBase) {
@@ -720,12 +726,16 @@ func findFileID(files []genericFile, path string) (int64, error) {
 			return f.ID, nil
 		}
 	}
-	// 2. Unique basename match.
-	targetBase := filepath.Base(path)
+	// 2. Unique basename match. pathutil.Base, not filepath.Base: f.Path is
+	// the *arr's own path and may use backslashes, in which case
+	// filepath.Base on Linux returns the whole path and this fallback never
+	// fires. Comparison stays case-SENSITIVE on purpose - loosening the
+	// delete path is not worth the marginal match rate.
+	targetBase := pathutil.Base(path)
 	var id int64
 	matches := 0
 	for _, f := range files {
-		if filepath.Base(f.Path) == targetBase {
+		if pathutil.Base(f.Path) == targetBase {
 			id = f.ID
 			matches++
 		}

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -316,6 +316,44 @@ func TestHTTPArrClient_FindMediaByPath_Fallback(t *testing.T) {
 	}
 }
 
+// TestHTTPArrClient_FindMediaByPath_WindowsArrPaths reproduces issue #331:
+// Radarr on Windows reports UNC backslash paths verbatim. The listing
+// fallback split them with filepath (which on Linux treats backslash as an
+// ordinary character) and a hardcoded "/" prefix check, so the lookup always
+// ended in "media not found" and remediation died as DeletionFailed.
+func TestHTTPArrClient_FindMediaByPath_WindowsArrPaths(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/parse":
+			// Parse can't resolve the path - forces the listing fallback.
+			json.NewEncoder(w).Encode(ParseResult{})
+		case "/api/v3/movie":
+			json.NewEncoder(w).Encode([]MediaItem{
+				{ID: 1, Title: "Other Movie", Path: `\\alexpr4100\media\Movies\Other Movie (2023)`},
+				{ID: 2, Title: "Zootopia 2", Path: `\\alexpr4100\media\Movies\Zootopia 2 (2025)`},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("api-key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Win Radarr', 'radarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/media/Movies', '\\alexpr4100\media\Movies', 1, 0, 0)`)
+
+	mediaID, err := client.FindMediaByPath(`\\alexpr4100\media\Movies\Zootopia 2 (2025)\Zootopia 2 (2025).mkv`)
+	if err != nil {
+		t.Fatalf("FindMediaByPath with Windows arr paths failed: %v", err)
+	}
+	if mediaID != 2 {
+		t.Errorf("Expected mediaID=2, got %d", mediaID)
+	}
+}
+
 func TestHTTPArrClient_FindMediaByPath_NotFound(t *testing.T) {
 	client, db := setupTestClient(t)
 	defer db.Close()
@@ -6256,6 +6294,20 @@ func TestFindFileID(t *testing.T) {
 		id, err := findFileID(files, "/data/tv/Other/ep99.mkv")
 		if err != nil || id != 0 {
 			t.Fatalf("got (%d, %v), want (0, nil)", id, err)
+		}
+	})
+
+	t.Run("unique basename match with Windows arr paths", func(t *testing.T) {
+		// A Windows *arr reports backslash paths; filepath.Base on a Linux
+		// host treated the whole path as the basename, so this fallback
+		// never fired (issue #331).
+		winFiles := []genericFile{
+			{ID: 10, Path: `\\srv\media\Movies\Film (2024)\Film (2024).mkv`},
+			{ID: 11, Path: `\\srv\media\Movies\Other (2023)\Other (2023).mkv`},
+		}
+		id, err := findFileID(winFiles, "/media/Movies/Film (2024)/Film (2024).mkv")
+		if err != nil || id != 10 {
+			t.Fatalf("got (%d, %v), want (10, nil)", id, err)
 		}
 	})
 }

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -58,3 +58,28 @@ func IsWithinRoot(root, path string) bool {
 func MatchedRootLen(root string) int {
 	return len(TrimTrailingSep(root))
 }
+
+// Base returns the last element of p, recognizing both separator styles.
+// filepath.Base is platform-locked: on a Linux host it treats backslash as
+// an ordinary character, so the "basename" of a Windows path a *arr
+// reported verbatim (\\server\share\Movies\Title) is the entire path and
+// every basename comparison silently fails (issue #331).
+func Base(p string) string {
+	p = TrimTrailingSep(p)
+	if i := strings.LastIndexAny(p, Separators); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// Dir returns the parent of p with the same dual-separator semantics as
+// Base. Unlike filepath.Dir it returns "" (not ".") when p has no
+// separator, and never invents a separator: callers here only feed the
+// result back into Base for folder-name comparisons.
+func Dir(p string) string {
+	p = TrimTrailingSep(p)
+	if i := strings.LastIndexAny(p, Separators); i >= 0 {
+		return TrimTrailingSep(p[:i])
+	}
+	return ""
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -48,3 +48,49 @@ func TestMatchedRootLen(t *testing.T) {
 		t.Error("trailing backslash must not change comparable root length")
 	}
 }
+
+func TestBase(t *testing.T) {
+	tests := []struct {
+		name string
+		p    string
+		want string
+	}{
+		{"unix file", "/media/Movies/Film (2024)/f.mkv", "f.mkv"},
+		{"unix dir trailing slash", "/media/Movies/Film (2024)/", "Film (2024)"},
+		{"no separator", "f.mkv", "f.mkv"},
+		{"empty", "", ""},
+		// The issue #331 shape: filepath.Base on Linux returns these whole.
+		{"UNC file", `\\alexpr4100\media\Movies\Zootopia 2 (2025)\Zootopia 2 (2025).mkv`, "Zootopia 2 (2025).mkv"},
+		{"UNC dir", `\\alexpr4100\media\Movies\Zootopia 2 (2025)`, "Zootopia 2 (2025)"},
+		{"drive letter", `D:\Media\TV\Show`, "Show"},
+		{"mixed separators", `/media/Movies\Film (2024)\f.mkv`, "f.mkv"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Base(tt.p); got != tt.want {
+				t.Errorf("Base(%q) = %q, want %q", tt.p, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDir(t *testing.T) {
+	tests := []struct {
+		name string
+		p    string
+		want string
+	}{
+		{"unix file", "/media/Movies/f.mkv", "/media/Movies"},
+		{"top level", "/media", ""},
+		{"no separator", "f.mkv", ""},
+		{"UNC file", `\\srv\media\Movies\Film\f.mkv`, `\\srv\media\Movies\Film`},
+		{"drive letter", `D:\Media\TV`, `D:\Media`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Dir(tt.p); got != tt.want {
+				t.Errorf("Dir(%q) = %q, want %q", tt.p, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -356,6 +356,24 @@ func (r *CorruptionRepository) StateCounts(ctx context.Context) (CorruptionState
 	return c, nil
 }
 
+// CountUnresolved returns the number of corruptions that still need
+// something: everything except resolved and user-ignored. This is the
+// "should I look at Healarr?" number for /api/health - counting only
+// CorruptionDetected there meant a corruption stuck in DeletionFailed
+// reported pending_corruptions: 0 and external dashboards showed all-clear
+// while remediation was failing (issue #331).
+func (r *CorruptionRepository) CountUnresolved(ctx context.Context) (int, error) {
+	settled := append(append([]string{}, BucketResolved...), BucketIgnored...)
+	var n int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT corruption_id) FROM corruption_status
+		WHERE current_state NOT IN `+InClause(settled)).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count unresolved corruptions: %w", err)
+	}
+	return n, nil
+}
+
 // CountDetectedToday returns the number of CorruptionDetected events created
 // today, excluding aggregates the user has ignored.
 func (r *CorruptionRepository) CountDetectedToday(ctx context.Context) (int, error) {

--- a/internal/repository/corruption_unresolved_test.go
+++ b/internal/repository/corruption_unresolved_test.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestCorruptionRepository_CountUnresolved pins the /api/health semantics
+// from issue #331: a corruption stuck mid-remediation (DeletionFailed) must
+// count as unresolved, while resolved and user-ignored ones must not.
+func TestCorruptionRepository_CountUnresolved(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	seedCorruption(t, db, "c1", "/a.mkv", "DeletionFailed", base)      // the #331 shape
+	seedCorruption(t, db, "c2", "/b.mkv", "CorruptionDetected", base)  // pending
+	seedCorruption(t, db, "c3", "/c.mkv", "RemediationPaused", base)   // parked, needs a human
+	seedCorruption(t, db, "c4", "/d.mkv", "VerificationSuccess", base) // resolved - settled
+	seedCorruption(t, db, "c5", "/e.mkv", "CorruptionIgnored", base)   // ignored - settled
+	seedCorruption(t, db, "c6", "/f.mkv", "MaxRetriesReached", base)   // orphaned still needs attention
+
+	n, err := repo.CountUnresolved(context.Background())
+	if err != nil {
+		t.Fatalf("CountUnresolved: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("CountUnresolved = %d, want 4 (DeletionFailed, CorruptionDetected, RemediationPaused, MaxRetriesReached)", n)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #331 (Radarr on Windows reporting UNC paths, Healarr on Linux/Docker).

### 1. "media not found" for Windows *arr paths
- `matchMediaItem`, `findMediaByListing` and `findFileID` split *arr-reported paths with `filepath.Base`/`Dir` and a hardcoded `/` prefix check. On a Linux host, backslash is an ordinary character to `filepath`, so `\\alexpr4100\media\Movies\Zootopia 2 (2025)\...` never matched anything; `FindMediaByPath` always fell through to "media not found" and the remediation surfaced as **Deletion Failed**.
- This is the fourth instance of the separator-bug class `pathutil` exists for (#298, #305, #322). `pathutil` gains separator-agnostic `Base`/`Dir`, and all three match sites now use it. The within-root check is also boundary-aware (`Movies` vs `MoviesArchive`) and case-insensitive as before.
- `findFileID`'s basename compare deliberately stays case-sensitive - it sits on the delete path.

### 2. `pending_corruptions: 0` while a corruption is failing
- `/api/health` counted only the `CorruptionDetected` state, so a corruption stuck mid-remediation (DeletionFailed, paused, exhausted...) reported 0 and homepage dashboards showed all-clear.
- It now reports `CountUnresolved`: everything except resolved and user-ignored, built from the shared lifecycle buckets from #336.

## Test plan
- Regression test reproducing the exact #331 scenario end-to-end (`FindMediaByPath` against a Windows-path Radarr fixture, parse fallback to listing)
- `pathutil.Base`/`Dir` table tests: UNC, drive-letter, trailing/mixed separators
- `findFileID` unique-basename match across separator styles (delete-safety subtests unchanged and green)
- `CountUnresolved` bucket-semantics test (DeletionFailed/pending/paused/orphaned count; resolved/ignored do not)
- `go test` integration/pathutil/repository/api suites green; lint 0 issues