### PR TITLE
feat(ui): scan controls where scans are visible; consistent active-status semantics

### DIFF
--- a/frontend/src/contexts/WebSocketProvider.tsx
+++ b/frontend/src/contexts/WebSocketProvider.tsx
@@ -169,10 +169,13 @@ export const WebSocketProvider = ({ children }: { children: React.ReactNode }) =
                 // Invalidate queries based on event type
                 const eventType = message.type;
 
-                // Scan events - refresh scan list and stats
+                // Scan events - refresh scan list and stats. 'health' feeds
+                // the sidebar's Active Scans count, which otherwise lags up
+                // to its 30s poll behind a scan starting or finishing.
                 if (eventType === 'ScanStarted' || eventType === 'ScanCompleted' || eventType === 'ScanFailed') {
                     queryClient.invalidateQueries({ queryKey: ['scans'] });
                     queryClient.invalidateQueries({ queryKey: ['dashboardStats'] });
+                    queryClient.invalidateQueries({ queryKey: ['health'] });
                 }
 
                 // Health events - refresh dashboard stats

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -177,6 +177,16 @@ export const cancelScan = async (scanId: string) => {
     return response.data;
 };
 
+export const pauseScan = async (scanId: string) => {
+    const response = await api.post(`/scans/${scanId}/pause`);
+    return response.data;
+};
+
+export const resumeScan = async (scanId: string) => {
+    const response = await api.post(`/scans/${scanId}/resume`);
+    return response.data;
+};
+
 export const pauseAllScans = async (): Promise<{ message: string; paused: number }> => {
     const { data } = await api.post<{ message: string; paused: number }>('/scans/pause-all');
     return data;

--- a/frontend/src/lib/scanStatus.ts
+++ b/frontend/src/lib/scanStatus.ts
@@ -1,0 +1,40 @@
+// Shared scan-status semantics for the UI.
+//
+// The backend reports two status vocabularies: DB rows go
+// running -> scanning -> completed/cancelled/error/aborted/interrupted
+// (and can sit at paused), while the live in-memory scanner reports
+// enumerating/scanning/paused. Pages used to check `status === 'running'`,
+// so a scan whose row had already advanced to 'scanning' (or was paused)
+// showed a Rescan button instead of Cancel while it was still running.
+// Every page must use these helpers instead of comparing raw strings.
+
+/** Statuses that mean the scan is still alive (running, in any phase, or paused). */
+export const scanStatusIsActive = (status: string): boolean =>
+    status === 'running' || status === 'enumerating' || status === 'scanning' || status === 'paused';
+
+/** User-facing label for a raw backend status. */
+export const scanStatusLabel = (status: string): string => {
+    switch (status) {
+        case 'enumerating': return 'Counting files';
+        case 'scanning': return 'Scanning';
+        case 'running': return 'Running';
+        case 'paused': return 'Paused';
+        case 'completed': return 'Completed';
+        case 'cancelled': return 'Cancelled';
+        case 'interrupted': return 'Interrupted';
+        case 'aborted': return 'Aborted';
+        case 'error': return 'Error';
+        case 'failed': return 'Failed';
+        default: return status;
+    }
+};
+
+/** Badge color classes per status family, matching the existing palette. */
+export const scanStatusBadgeClass = (status: string): string => {
+    if (status === 'completed') return 'bg-green-500/10 text-green-400 border-green-500/20';
+    if (status === 'failed' || status === 'error' || status === 'aborted') return 'bg-red-500/10 text-red-400 border-red-500/20';
+    if (status === 'paused') return 'bg-amber-500/10 text-amber-400 border-amber-500/20';
+    if (status === 'cancelled' || status === 'interrupted') return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
+    if (scanStatusIsActive(status)) return 'bg-blue-500/10 text-blue-400 border-blue-500/20';
+    return 'bg-slate-500/10 text-slate-400 border-slate-500/20';
+};

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef, createElement } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ShieldCheck, AlertOctagon, Loader2, X, Clock, AlertTriangle, EyeOff, CheckCircle2, FileSearch, TrendingUp, HandMetal, Play, ChevronDown, ScanSearch, PlayCircle, AlertCircle, ArrowRight } from 'lucide-react';
+import { ShieldCheck, AlertOctagon, Loader2, X, Clock, AlertTriangle, EyeOff, CheckCircle2, FileSearch, TrendingUp, HandMetal, Play, Pause, ChevronDown, ScanSearch, PlayCircle, AlertCircle, ArrowRight } from 'lucide-react';
 import clsx from 'clsx';
 import { useQuery } from '@tanstack/react-query';
-import { getDashboardStats, getActiveScans, cancelScan, getScanPaths, triggerScan, triggerScanAll, getPathHealth, type ScanProgress, type ScanPath } from '../lib/api';
+import { getDashboardStats, getActiveScans, cancelScan, pauseScan, resumeScan, pauseAllScans, resumeAllScans, cancelAllScans, getScanPaths, triggerScan, triggerScanAll, getPathHealth, type ScanProgress, type ScanPath } from '../lib/api';
+import { scanStatusLabel } from '../lib/scanStatus';
 import type { PathHealth } from '../types/api';
 import { FolderOpen, FolderCheck, FolderX, FolderSearch, FolderMinus } from 'lucide-react';
 import ActivityChart from '../components/charts/ActivityChart';
@@ -173,7 +174,20 @@ const ActiveScansTable = () => {
 
     const activeScansList = Object.values(scans);
 
+    // Re-snapshot active scans after a bulk action; paused scans emit no
+    // progress events, so the websocket alone won't reflect the new status.
+    const refreshScans = () => {
+        getActiveScans().then(active => {
+            const scanMap: Record<string, ScanProgress> = {};
+            active.forEach(s => scanMap[s.id] = s);
+            setScans(scanMap);
+        });
+    };
+
     if (activeScansList.length === 0) return null;
+
+    const anyPaused = activeScansList.some(s => s.status === 'paused');
+    const anyPausable = activeScansList.some(s => s.status === 'scanning' || s.status === 'enumerating');
 
     return (
         <motion.div
@@ -183,9 +197,53 @@ const ActiveScansTable = () => {
         >
             <div className="flex items-center gap-3 mb-6">
                 <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
-                    <Loader2 className="w-5 h-5 text-blue-400 animate-spin" />
+                    <Loader2 className={clsx("w-5 h-5 text-blue-400", anyPausable && "animate-spin")} />
                 </div>
                 <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Active Scans</h2>
+                {/* Bulk controls live next to the scans they act on; before,
+                    they only existed on the Config page. */}
+                <div className="ml-auto flex items-center gap-2">
+                    {anyPausable && (
+                        <button
+                            onClick={() => {
+                                pauseAllScans().then(({ paused }) => {
+                                    toast.success(`Paused ${paused} scan${paused !== 1 ? 's' : ''}`);
+                                    refreshScans();
+                                }).catch(() => toast.error('Failed to pause scans'));
+                            }}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500/10 hover:bg-amber-500/20 text-amber-500 dark:text-amber-400 border border-amber-500/20 hover:border-amber-500/30 transition-colors cursor-pointer"
+                        >
+                            <Pause className="w-3.5 h-3.5" />
+                            Pause all
+                        </button>
+                    )}
+                    {anyPaused && (
+                        <button
+                            onClick={() => {
+                                resumeAllScans().then(({ resumed }) => {
+                                    toast.success(`Resumed ${resumed} scan${resumed !== 1 ? 's' : ''}`);
+                                    refreshScans();
+                                }).catch(() => toast.error('Failed to resume scans'));
+                            }}
+                            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 dark:text-blue-400 border border-blue-500/20 hover:border-blue-500/30 transition-colors cursor-pointer"
+                        >
+                            <Play className="w-3.5 h-3.5" />
+                            Resume all
+                        </button>
+                    )}
+                    <button
+                        onClick={() => {
+                            cancelAllScans().then(({ cancelled }) => {
+                                toast.success(`Cancelled ${cancelled} scan${cancelled !== 1 ? 's' : ''}`);
+                                refreshScans();
+                            }).catch(() => toast.error('Failed to cancel scans'));
+                        }}
+                        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-red-500/10 hover:bg-red-500/20 text-red-500 dark:text-red-400 border border-red-500/20 hover:border-red-500/30 transition-colors cursor-pointer"
+                    >
+                        <X className="w-3.5 h-3.5" />
+                        Cancel all
+                    </button>
+                </div>
             </div>
 
             <div className="overflow-x-auto">
@@ -196,7 +254,7 @@ const ActiveScansTable = () => {
                             <th className="px-4 py-3 text-xs font-medium text-slate-600 dark:text-slate-400 uppercase">Path / File</th>
                             <th className="px-4 py-3 text-xs font-medium text-slate-600 dark:text-slate-400 uppercase">Status</th>
                             <th className="px-4 py-3 text-xs font-medium text-slate-600 dark:text-slate-400 uppercase w-1/3">Progress</th>
-                            <th className="px-4 py-3 text-xs font-medium text-slate-600 dark:text-slate-400 uppercase w-24">Actions</th>
+                            <th className="px-4 py-3 text-xs font-medium text-slate-600 dark:text-slate-400 uppercase w-28">Actions</th>
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-200 dark:divide-slate-800/50">
@@ -243,7 +301,14 @@ const ActiveScansTable = () => {
                                     </div>
                                 </td>
                                 <td className="px-4 py-4">
-                                    <span className="text-sm text-slate-600 dark:text-slate-300 capitalize">{scan.status}</span>
+                                    <span className={clsx(
+                                        "text-sm",
+                                        scan.status === 'paused'
+                                            ? "text-amber-500 dark:text-amber-400 font-medium"
+                                            : "text-slate-600 dark:text-slate-300"
+                                    )}>
+                                        {scanStatusLabel(scan.status)}
+                                    </span>
                                 </td>
                                 <td className="px-4 py-4">
                                     <div className="space-y-2">
@@ -262,6 +327,37 @@ const ActiveScansTable = () => {
                                     </div>
                                 </td>
                                 <td className="px-4 py-4">
+                                    <div className="flex items-center gap-2">
+                                    {scan.status === 'scanning' && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                pauseScan(scan.id).then(() => {
+                                                    setScans(prev => prev[scan.id] ? { ...prev, [scan.id]: { ...prev[scan.id], status: 'paused' } } : prev);
+                                                    toast.success('Scan paused');
+                                                }).catch(() => toast.error('Failed to pause scan'));
+                                            }}
+                                            className="p-1.5 rounded-md bg-amber-500/10 hover:bg-amber-500/20 text-amber-500 dark:text-amber-400 border border-amber-500/20 hover:border-amber-500/30 transition-colors cursor-pointer"
+                                            title="Pause Scan"
+                                        >
+                                            <Pause className="w-4 h-4" />
+                                        </button>
+                                    )}
+                                    {scan.status === 'paused' && (
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                resumeScan(scan.id).then(() => {
+                                                    setScans(prev => prev[scan.id] ? { ...prev, [scan.id]: { ...prev[scan.id], status: 'scanning' } } : prev);
+                                                    toast.success('Scan resumed');
+                                                }).catch(() => toast.error('Failed to resume scan'));
+                                            }}
+                                            className="p-1.5 rounded-md bg-blue-500/10 hover:bg-blue-500/20 text-blue-500 dark:text-blue-400 border border-blue-500/20 hover:border-blue-500/30 transition-colors cursor-pointer"
+                                            title="Resume Scan"
+                                        >
+                                            <Play className="w-4 h-4" />
+                                        </button>
+                                    )}
                                     <button
                                         onClick={(e) => {
                                             e.stopPropagation(); // Prevent row click when clicking cancel
@@ -283,6 +379,7 @@ const ActiveScansTable = () => {
                                     >
                                         <X className="w-4 h-4" />
                                     </button>
+                                    </div>
                                 </td>
                             </tr>
                         ))}

--- a/frontend/src/pages/ScanDetails.tsx
+++ b/frontend/src/pages/ScanDetails.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, FileCheck, FileX, Loader2, Filter, HardDrive, Clock, FolderOpen, AlertCircle, X, RefreshCw, ClockArrowDown, ExternalLink, Radio, SkipForward, ShieldAlert, HelpCircle } from 'lucide-react';
+import { ArrowLeft, FileCheck, FileX, Loader2, Filter, HardDrive, Clock, FolderOpen, AlertCircle, X, RefreshCw, ClockArrowDown, ExternalLink, Radio, SkipForward, ShieldAlert, HelpCircle, Pause, Play } from 'lucide-react';
 import clsx from 'clsx';
-import { getScanDetails, getScanFiles, cancelScan, rescanPath, type ScanFile, type ScanProgress } from '../lib/api';
+import { getScanDetails, getScanFiles, cancelScan, rescanPath, pauseScan, resumeScan, type ScanFile, type ScanProgress } from '../lib/api';
+import { scanStatusIsActive, scanStatusLabel } from '../lib/scanStatus';
 import DataGrid from '../components/ui/DataGrid';
 import { useDateFormat } from '../lib/useDateFormat';
 import { useToast } from '../contexts/ToastContext';
@@ -30,12 +31,15 @@ const ScanDetails = () => {
         queryFn: () => getScanDetails(scanId),
         enabled: scanId > 0,
         refetchInterval: (query) => {
-            // Refetch every 2s if scan is running
-            return query.state.data?.status === 'running' ? 2000 : false;
+            // Refetch every 2s while the scan is alive. The DB status moves
+            // running -> scanning (and can sit at paused), so checking only
+            // 'running' stopped the live refresh moments after start.
+            return scanStatusIsActive(query.state.data?.status ?? '') ? 2000 : false;
         },
     });
 
-    const isRunning = scanDetails?.status === 'running';
+    const isRunning = scanStatusIsActive(scanDetails?.status ?? '');
+    const isPaused = scanDetails?.status === 'paused';
 
     const { data: filesData, isLoading: isLoadingFiles } = useQuery({
         queryKey: ['scan-files', scanId, page, statusFilter],
@@ -83,6 +87,25 @@ const ScanDetails = () => {
         }
     };
 
+    const handlePauseResume = async () => {
+        setIsActionLoading(true);
+        try {
+            if (isPaused) {
+                await resumeScan(String(scanId));
+                toast.success('Scan resumed');
+            } else {
+                await pauseScan(String(scanId));
+                toast.success('Scan paused');
+            }
+            queryClient.invalidateQueries({ queryKey: ['scan-details', scanId] });
+            queryClient.invalidateQueries({ queryKey: ['scans'] });
+        } catch {
+            toast.error(isPaused ? 'Failed to resume scan' : 'Failed to pause scan');
+        } finally {
+            setIsActionLoading(false);
+        }
+    };
+
     const handleRescan = async () => {
         setIsActionLoading(true);
         try {
@@ -107,12 +130,26 @@ const ScanDetails = () => {
                     </span>
                 );
             case 'running':
+            case 'enumerating':
+            case 'scanning':
                 return (
                     <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-500/20 text-blue-400 border border-blue-500/30">
                         <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        Running
+                        {scanStatusLabel(status)}
                         {scanProgress && (
                             <span className="ml-1 text-blue-300">
+                                ({scanProgress.filesDone}/{scanProgress.totalFiles})
+                            </span>
+                        )}
+                    </span>
+                );
+            case 'paused':
+                return (
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                        <Pause className="w-3.5 h-3.5" />
+                        Paused
+                        {scanProgress && (
+                            <span className="ml-1 text-amber-300">
                                 ({scanProgress.filesDone}/{scanProgress.totalFiles})
                             </span>
                         )}
@@ -227,19 +264,42 @@ const ScanDetails = () => {
                 </div>
                 {/* Action Buttons */}
                 <div className="flex items-center gap-2">
-                    {scanDetails.status === 'running' ? (
-                        <button
-                            onClick={handleCancel}
-                            disabled={isActionLoading}
-                            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-300 border border-red-500/20 hover:border-red-500/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            {isActionLoading ? (
-                                <Loader2 className="w-4 h-4 animate-spin" />
-                            ) : (
-                                <X className="w-4 h-4" />
+                    {isRunning ? (
+                        <>
+                            {(scanDetails.status === 'scanning' || isPaused) && (
+                                <button
+                                    onClick={handlePauseResume}
+                                    disabled={isActionLoading}
+                                    className={clsx(
+                                        "flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
+                                        isPaused
+                                            ? "bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 hover:text-blue-300 border-blue-500/20 hover:border-blue-500/30"
+                                            : "bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 hover:text-amber-300 border-amber-500/20 hover:border-amber-500/30"
+                                    )}
+                                >
+                                    {isActionLoading ? (
+                                        <Loader2 className="w-4 h-4 animate-spin" />
+                                    ) : isPaused ? (
+                                        <Play className="w-4 h-4" />
+                                    ) : (
+                                        <Pause className="w-4 h-4" />
+                                    )}
+                                    <span className="font-medium">{isPaused ? 'Resume' : 'Pause'}</span>
+                                </button>
                             )}
-                            <span className="font-medium">Cancel</span>
-                        </button>
+                            <button
+                                onClick={handleCancel}
+                                disabled={isActionLoading}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-400 hover:text-red-300 border border-red-500/20 hover:border-red-500/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {isActionLoading ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                ) : (
+                                    <X className="w-4 h-4" />
+                                )}
+                                <span className="font-medium">Cancel</span>
+                            </button>
+                        </>
                     ) : (
                         <button
                             onClick={handleRescan}

--- a/frontend/src/pages/Scans.tsx
+++ b/frontend/src/pages/Scans.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getScans, cancelScan, rescanPath } from '../lib/api';
+import { scanStatusIsActive, scanStatusLabel, scanStatusBadgeClass } from '../lib/scanStatus';
 import DataGrid from '../components/ui/DataGrid';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -120,11 +121,9 @@ const Scans = () => {
                         accessorKey: (row) => (
                             <span className={clsx(
                                 "px-2 py-1 rounded-full text-xs font-medium border",
-                                row.status === 'completed' ? "bg-green-500/10 text-green-400 border-green-500/20" :
-                                    row.status === 'failed' ? "bg-red-500/10 text-red-400 border-red-500/20" :
-                                        "bg-blue-500/10 text-blue-400 border-blue-500/20"
+                                scanStatusBadgeClass(row.status)
                             )}>
-                                {row.status}
+                                {scanStatusLabel(row.status)}
                             </span>
                         ),
                         mobileLabel: 'Status',
@@ -154,7 +153,9 @@ const Scans = () => {
                         header: 'Actions',
                         accessorKey: (row) => (
                             <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
-                                {row.status === 'running' ? (
+                                {/* Active means any of running/enumerating/scanning/paused -
+                                    checking only 'running' offered Rescan on a live scan. */}
+                                {scanStatusIsActive(row.status) ? (
                                     <button
                                         onClick={(e) => handleCancel(e, String(row.id))}
                                         disabled={loadingAction === row.id}

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -2502,18 +2502,20 @@ func (s *ScannerService) CancelScan(scanID string) error {
 // PauseScan pauses an ongoing scan
 func (s *ScannerService) PauseScan(scanID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	scan, exists := s.findActiveScanLocked(scanID)
 	if !exists {
+		s.mu.Unlock()
 		return fmt.Errorf("scan not found: %s", scanID)
 	}
 
 	if scan.isPaused {
+		s.mu.Unlock()
 		return nil // Already paused
 	}
 
 	if scan.Status != "scanning" {
+		s.mu.Unlock()
 		return fmt.Errorf("scan is not in scanning state: %s", scan.Status)
 	}
 
@@ -2525,20 +2527,43 @@ func (s *ScannerService) PauseScan(scanID string) error {
 	scan.resumeChan = make(chan struct{})
 	scan.isPaused = true
 	scan.Status = "paused"
+	dbID := scan.ScanDBID
+	s.mu.Unlock()
+
+	// Persist the pause so DB readers (scan details page, /scans list,
+	// startup reconcile) agree with the live scanner. Without this the row
+	// stayed 'scanning' and the UI could not tell a paused scan from a
+	// running one after a reload.
+	s.persistScanStatus(dbID, string(ScanStatusPaused))
 	return nil
+}
+
+// persistScanStatus mirrors an in-memory pause/resume transition to the
+// scans row. Failure is logged, not returned: the in-memory state already
+// changed and the startup reconcile repairs any divergence.
+func (s *ScannerService) persistScanStatus(dbID int64, status string) {
+	if dbID <= 0 || s.scanRepo() == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.scanRepo().SetStatus(ctx, dbID, status); err != nil {
+		logger.Errorf("Failed to persist scan %d status %s: %v", dbID, status, err)
+	}
 }
 
 // ResumeScan resumes a paused scan
 func (s *ScannerService) ResumeScan(scanID string) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	scan, exists := s.findActiveScanLocked(scanID)
 	if !exists {
+		s.mu.Unlock()
 		return fmt.Errorf("scan not found: %s", scanID)
 	}
 
 	if !scan.isPaused {
+		s.mu.Unlock()
 		return nil // Not paused
 	}
 
@@ -2552,7 +2577,10 @@ func (s *ScannerService) ResumeScan(scanID string) error {
 	scan.isPaused = false
 	scan.Status = ScanStatusScanning
 	close(scan.resumeChan)
+	dbID := scan.ScanDBID
+	s.mu.Unlock()
 
+	s.persistScanStatus(dbID, string(ScanStatusScanning))
 	return nil
 }
 

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -811,6 +811,51 @@ func TestScannerService_PauseScan(t *testing.T) {
 		delete(scanner.activeScans, "scan-3")
 		scanner.mu.Unlock()
 	})
+
+	t.Run("pause and resume persist the DB status", func(t *testing.T) {
+		// DB readers (scan details page, /scans, startup reconcile) must
+		// agree with the live scanner: an in-memory-only pause left the row
+		// 'scanning' and the UI could not tell a paused scan from a running
+		// one after a reload.
+		res, err := db.Exec(`INSERT INTO scans (path, status, started_at) VALUES ('/media', 'scanning', datetime('now'))`)
+		if err != nil {
+			t.Fatalf("seed scan row: %v", err)
+		}
+		dbID, _ := res.LastInsertId()
+
+		scanner.mu.Lock()
+		scanner.activeScans["scan-4"] = &ScanProgress{
+			ID:       "scan-4",
+			Status:   "scanning",
+			ScanDBID: dbID,
+		}
+		scanner.mu.Unlock()
+
+		if err := scanner.PauseScan("scan-4"); err != nil {
+			t.Fatalf("PauseScan: %v", err)
+		}
+		var status string
+		if err := db.QueryRow(`SELECT status FROM scans WHERE id = ?`, dbID).Scan(&status); err != nil {
+			t.Fatalf("read scan status: %v", err)
+		}
+		if status != "paused" {
+			t.Errorf("DB status after pause = %q, want paused", status)
+		}
+
+		if err := scanner.ResumeScan("scan-4"); err != nil {
+			t.Fatalf("ResumeScan: %v", err)
+		}
+		if err := db.QueryRow(`SELECT status FROM scans WHERE id = ?`, dbID).Scan(&status); err != nil {
+			t.Fatalf("read scan status: %v", err)
+		}
+		if status != "scanning" {
+			t.Errorf("DB status after resume = %q, want scanning", status)
+		}
+
+		scanner.mu.Lock()
+		delete(scanner.activeScans, "scan-4")
+		scanner.mu.Unlock()
+	})
 }
 
 func TestScannerService_ResumeScan(t *testing.T) {


### PR DESCRIPTION
## Summary

Reduces confusion about where to see and control running scans (follow-up to the scan control-plane fixes in #336).

### What was confusing
- Per-scan **pause/resume existed in the API but had no UI anywhere** - pausing was only reachable as pause-ALL, and only on the Config page.
- Pages checked `status === 'running'`, but the DB row advances `running -> scanning` (and can sit at `paused`). Net effect: a live scan showed a **Rescan** button instead of Cancel on /scans and Scan Details, Scan Details stopped its 2s live refresh moments after start, and raw statuses like `enumerating` leaked into the UI.
- A pause was in-memory only; after a page reload the DB still said `scanning` and nothing could tell a paused scan from a running one.
- The sidebar's Active Scans count lagged up to 30s behind reality.

### Changes
- **Per-scan Pause/Resume buttons** on the Dashboard Active Scans rows and the Scan Details header, alongside Cancel.
- **Bulk Pause all / Resume all / Cancel all** on the Dashboard Active Scans header, next to the scans they act on (still on Config too).
- **Shared `scanStatus` helpers** (`scanStatusIsActive`/`Label`/`BadgeClass`) replace raw string compares on Dashboard, /scans and Scan Details: active = running/enumerating/scanning/paused, friendly labels ("Counting files", "Paused"), amber paused badge.
- **Backend: `PauseScan`/`ResumeScan` persist the status** to the scans row, so DB readers agree with the live scanner.
- **Sidebar count is live**: `['health']` invalidates on ScanStarted/Completed/Failed websocket events.

## Test plan
- New regression subtest: pause persists `paused` to the scans row, resume persists `scanning`.
- `go test ./internal/services/ ./internal/api/` green; lint 0 issues.
- Frontend: `tsc --noEmit` clean, eslint clean, `npm run build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pause and resume capabilities for individual scans during active scanning
  * Introduced bulk controls to pause, resume, or cancel all active scans from the dashboard
  * Implemented improved scan status display with standardized labels and color-coded badges for better visibility
  * Live status updates ensure scan state changes are reflected immediately across all views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->