### PR TITLE
fix(detector): size-aware ffprobe timeout so 4K files aren't skipped by content analysis

### DIFF
--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -1030,13 +1030,37 @@ type mediaProbeInfo struct {
 	HasAudio bool
 }
 
+// Probe timeouts for getMediaProbeInfo. A header probe normally finishes in
+// well under a second; when it doesn't, it is because the file is a large 4K
+// remux on a NAS that the parallel scan is saturating. A timed-out probe
+// skips content analysis for that file entirely, so large files get a
+// bigger budget rather than being silently under-analyzed every scan.
+// Resolution isn't known until the probe has run, so file size is the proxy
+// for "4K-class": at 4 GiB, 1080p web releases stay below, UHD episodes and
+// remuxes land above.
+const (
+	probeTimeoutDefault         = 30 * time.Second
+	probeTimeoutLargeFile       = 2 * time.Minute
+	probeLargeFileBytes   int64 = 4 << 30 // 4 GiB
+)
+
+// probeTimeoutFor picks the ffprobe timeout based on file size. Stat
+// failures fall back to the default: the probe itself will surface the real
+// error.
+func probeTimeoutFor(path string) time.Duration {
+	if info, err := os.Stat(path); err == nil && info.Size() >= probeLargeFileBytes {
+		return probeTimeoutLargeFile
+	}
+	return probeTimeoutDefault
+}
+
 // getMediaProbeInfo uses ffprobe to get file duration and stream types in a single call.
 func (hc *CmdHealthChecker) getMediaProbeInfo(path string) (*mediaProbeInfo, error) {
 	cmd := exec.Command(hc.FFprobePath, "-v", "error",
 		"-show_entries", "format=duration:stream=codec_type",
 		"-of", "json", path)
 
-	output, err := runCommandWithTimeout(cmd, 30*time.Second, "ffprobe")
+	output, err := runCommandWithTimeout(cmd, probeTimeoutFor(path), "ffprobe")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/integration/probe_timeout_test.go
+++ b/internal/integration/probe_timeout_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProbeTimeoutFor pins the size-aware probe budget: large 4K-class files
+// get a longer ffprobe timeout so a saturated NAS doesn't make every scan
+// silently skip their content analysis, while ordinary files keep the short
+// timeout so a hung probe can't stall a scan worker for minutes.
+func TestProbeTimeoutFor(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	smallFile := filepath.Join(dir, "episode-1080p.mkv")
+	if err := os.WriteFile(smallFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+
+	// Sparse file: reports 5 GiB without writing it.
+	largeFile := filepath.Join(dir, "episode-2160p.mkv")
+	f, err := os.Create(largeFile)
+	if err != nil {
+		t.Fatalf("create large file: %v", err)
+	}
+	if err := f.Truncate(5 << 30); err != nil {
+		f.Close()
+		t.Skipf("cannot create sparse 5 GiB file on this filesystem: %v", err)
+	}
+	f.Close()
+
+	if got := probeTimeoutFor(smallFile); got != probeTimeoutDefault {
+		t.Errorf("small file timeout = %v, want %v", got, probeTimeoutDefault)
+	}
+	if got := probeTimeoutFor(largeFile); got != probeTimeoutLargeFile {
+		t.Errorf("large file timeout = %v, want %v", got, probeTimeoutLargeFile)
+	}
+	if got := probeTimeoutFor(filepath.Join(dir, "missing.mkv")); got != probeTimeoutDefault {
+		t.Errorf("missing file timeout = %v, want default %v (probe surfaces the real error)", got, probeTimeoutDefault)
+	}
+}


### PR DESCRIPTION
## Summary

Observed live on Sokaris after v1.3.12: 4K DV HDR10 episodes log `Content analysis skipped (probe failed): ffprobe timed out after 30s` during scans. The probe step had a hardcoded 30s timeout while the analysis it gates gets the configurable thorough timeout (default 10m). A timed-out probe means that file's content analysis is silently skipped on every scan.

- Files >= 4 GiB now get a 2-minute probe budget (resolution isn't known until the probe has run, so size is the proxy for 4K-class).
- Smaller files keep the 30s timeout, so a hung probe can't stall a scan worker for minutes.
- Stat failure falls back to the default timeout and lets the probe surface the real error.

## Test plan
- New `TestProbeTimeoutFor`: small file -> 30s, sparse 5 GiB file -> 2m, missing file -> default.
- `go test ./internal/integration/` green; lint 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media file analysis performance by implementing adaptive timeout handling for large files (≥4 GiB).

* **Tests**
  * Added integration tests for timeout validation across various file sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->