### PR TITLE
fix(scanner): global scan concurrency cap - wire scan.workers for real, prudent auto default

### DIFF
--- a/internal/config/live.go
+++ b/internal/config/live.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -54,6 +56,23 @@ func LiveHealthCheckThoroughTimeout() time.Duration {
 		return cfg.HealthCheckThoroughTimeout
 	}
 	return 10 * time.Minute
+}
+
+// LiveScannerWorkers returns the configured max concurrent file checks.
+// 0 means "auto"; callers derive their own prudent default. Same
+// precedence rules as the other accessors (env > DB > default), with a
+// direct env read as the no-tunables fallback so the limit still works
+// in the boot window and in tests without a database.
+func LiveScannerWorkers() int {
+	if tn := liveTunables.Load(); tn != nil {
+		return tn.ScannerWorkers(context.Background()).Value
+	}
+	if v := os.Getenv("HEALARR_SCANNER_WORKERS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // LiveHealthCheckHwAccel returns the resolved hardware acceleration

--- a/internal/integration/concurrency.go
+++ b/internal/integration/concurrency.go
@@ -1,0 +1,155 @@
+package integration
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/mescon/Healarr/internal/config"
+)
+
+// Scan concurrency is bounded GLOBALLY here, at the tool-subprocess layer,
+// because the scan worker pool was never the only spawner: webhook-triggered
+// ScanFile calls, the deferred-rescan worker and post-remediation
+// verification all start detector runs outside the pool. On a 32-core host
+// the pool alone ran 32 thorough 4K decodes while webhooks stacked more on
+// top - VRAM filled, ffmpeg fell back to CPU software decode, load >120.
+// Every ffmpeg/ffprobe/HandBrake/mediainfo run now acquires a slot from one
+// shared limiter, whatever service asked for it.
+
+const (
+	// maxScanWorkers caps operator-configured concurrency to avoid thrashing
+	// storage or spawning an unreasonable number of subprocesses.
+	maxScanWorkers = 32
+
+	// autoScanWorkersDefault is the prudent "auto" concurrency. Deliberately
+	// low: a thorough check of a 4K file is a full ffmpeg decode (~1 GiB GPU
+	// VRAM, or many CPU threads in software fallback), so the safe default
+	// is one a modest host survives. Operators with strong GPUs raise
+	// scan.workers in the UI or via HEALARR_SCANNER_WORKERS.
+	autoScanWorkersDefault = 4
+
+	// perWorkerMemoryBudget is the RAM each concurrent detection worker may
+	// need; it lowers the auto default further on small containers so the
+	// default concurrency can't push them into an OOM kill.
+	perWorkerMemoryBudget = 512 * 1024 * 1024 // 512 MB
+)
+
+// EffectiveScanWorkers resolves the max number of concurrent file checks:
+// HEALARR_SCANNER_WORKERS > the scan.workers UI setting > auto (both via
+// config.LiveScannerWorkers), clamped to [1, maxScanWorkers]. Re-resolved on
+// every call so a UI change applies to the next acquisition / next scan
+// without a restart.
+func EffectiveScanWorkers() int {
+	if n := config.LiveScannerWorkers(); n > 0 {
+		if n > maxScanWorkers {
+			return maxScanWorkers
+		}
+		return n
+	}
+	return autoScanWorkers(availableMemoryBytes(), runtime.NumCPU())
+}
+
+// autoScanWorkers derives the "auto" worker count: min(prudent default, CPU
+// count, memory budget), floored at 1. Pure function for testability.
+func autoScanWorkers(memBytes uint64, cpus int) int {
+	if cpus < 1 {
+		cpus = 1
+	}
+	n := autoScanWorkersDefault
+	if cpus < n {
+		n = cpus
+	}
+	if memBytes > 0 {
+		if m := int(memBytes / perWorkerMemoryBudget); m < n {
+			n = m
+		}
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// availableMemoryBytes best-effort reports the memory ceiling the process
+// runs under: the container's cgroup memory limit when present, else total
+// system memory. Returns 0 when it can't be determined (e.g. non-Linux), so
+// callers skip the memory cap. Linux-specific paths simply don't exist
+// elsewhere, so this stays portable without build tags.
+func availableMemoryBytes() uint64 {
+	// cgroup v2: a single limit file, "max" means unlimited.
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
+		if s := strings.TrimSpace(string(b)); s != "max" {
+			if v, err := strconv.ParseUint(s, 10, 64); err == nil && v > 0 {
+				return v
+			}
+		}
+	}
+	// cgroup v1: "unlimited" is a near-max sentinel, so ignore implausibly large values.
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
+		if v, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil && v > 0 && v < (1<<62) {
+			return v
+		}
+	}
+	// Fallback: total system memory from /proc/meminfo (kB).
+	if b, err := os.ReadFile("/proc/meminfo"); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if kb, ok := strings.CutPrefix(line, "MemTotal:"); ok {
+				fields := strings.Fields(kb)
+				if len(fields) >= 1 {
+					if v, err := strconv.ParseUint(fields[0], 10, 64); err == nil {
+						return v * 1024
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// concurrencyLimiter is a counting semaphore whose limit is re-evaluated on
+// every acquisition attempt, so lowering scan.workers in the UI takes effect
+// on running workloads (queued acquirers see the new limit when they wake).
+type concurrencyLimiter struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	active int
+}
+
+func newConcurrencyLimiter() *concurrencyLimiter {
+	l := &concurrencyLimiter{}
+	l.cond = sync.NewCond(&l.mu)
+	return l
+}
+
+// acquire blocks until the number of active holders is below limit().
+// limit is re-evaluated each time the goroutine wakes, and is floored at 1
+// so a misconfigured limit can never deadlock every caller.
+func (l *concurrencyLimiter) acquire(limit func() int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for {
+		n := limit()
+		if n < 1 {
+			n = 1
+		}
+		if l.active < n {
+			break
+		}
+		l.cond.Wait()
+	}
+	l.active++
+}
+
+func (l *concurrencyLimiter) release() {
+	l.mu.Lock()
+	l.active--
+	l.cond.Broadcast()
+	l.mu.Unlock()
+}
+
+// toolLimiter is the process-wide limiter every detection subprocess goes
+// through (see runCommandWithTimeout).
+var toolLimiter = newConcurrencyLimiter()

--- a/internal/integration/concurrency_test.go
+++ b/internal/integration/concurrency_test.go
@@ -1,0 +1,190 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mescon/Healarr/internal/config"
+	"github.com/mescon/Healarr/internal/repository"
+)
+
+// TestAutoScanWorkers pins the prudent "auto" sizing: min(4, cpus, memory
+// budget), floored at 1. The previous auto (min(mem/512MB, cores, 32))
+// chose 32 on a 32-core host and ran 32 thorough 4K decodes at once.
+func TestAutoScanWorkers(t *testing.T) {
+	t.Parallel()
+	const mb = 1024 * 1024
+	const gb = 1024 * mb
+	tests := []struct {
+		name string
+		mem  uint64
+		cpus int
+		want int
+	}{
+		{"big host is capped at the prudent default", 64 * gb, 32, 4},
+		{"huge host is still capped", 1024 * gb, 128, 4},
+		{"unknown memory uses default (capped by cpu)", 0, 8, 4},
+		{"unknown memory capped by low cpu", 0, 2, 2},
+		{"512MB -> 1 worker", 512 * mb, 8, 1},
+		{"under one budget floors at 1", 256 * mb, 8, 1},
+		{"1GB -> 2 workers", 1 * gb, 8, 2},
+		{"2GB -> 4 workers", 2 * gb, 8, 4},
+		{"zero cpus treated as one", 8 * gb, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := autoScanWorkers(tt.mem, tt.cpus); got != tt.want {
+				t.Errorf("autoScanWorkers(%d, %d) = %d, want %d", tt.mem, tt.cpus, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveScanWorkers_EnvOverride verifies env precedence and clamping.
+func TestEffectiveScanWorkers_EnvOverride(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_WORKERS", "8")
+	if got := EffectiveScanWorkers(); got != 8 {
+		t.Errorf("explicit 8 = %d, want 8", got)
+	}
+
+	t.Setenv("HEALARR_SCANNER_WORKERS", "100")
+	if got := EffectiveScanWorkers(); got != maxScanWorkers {
+		t.Errorf("over-max = %d, want %d (clamped)", got, maxScanWorkers)
+	}
+
+	t.Setenv("HEALARR_SCANNER_WORKERS", "garbage")
+	if got := EffectiveScanWorkers(); got < 1 || got > autoScanWorkersDefault {
+		t.Errorf("invalid value should fall back to the prudent auto default, got %d", got)
+	}
+
+	t.Setenv("HEALARR_SCANNER_WORKERS", "")
+	if got := EffectiveScanWorkers(); got < 1 || got > autoScanWorkersDefault {
+		t.Errorf("unset should yield the prudent auto default, got %d", got)
+	}
+}
+
+// TestEffectiveScanWorkers_UISettingApplies wires a real settings repo into
+// the live tunables and verifies the UI-stored scan.workers value reaches
+// the limiter's sizing - the end-to-end path that silently did not exist.
+func TestEffectiveScanWorkers_UISettingApplies(t *testing.T) {
+	t.Setenv("HEALARR_SCANNER_WORKERS", "") // env must not lock the UI value
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE settings (
+		key TEXT PRIMARY KEY,
+		value TEXT NOT NULL,
+		updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create settings table: %v", err)
+	}
+	repo := repository.NewSettingsRepository(db)
+	if err := repo.Set(context.Background(), repository.SettingKeyScannerWorkers, "2"); err != nil {
+		t.Fatalf("store UI value: %v", err)
+	}
+
+	config.SetLiveTunables(repository.NewTunables(repo))
+	defer config.SetLiveTunables(nil)
+
+	if got := EffectiveScanWorkers(); got != 2 {
+		t.Errorf("EffectiveScanWorkers with UI value 2 = %d, want 2", got)
+	}
+}
+
+// TestConcurrencyLimiter_CapsActive hammers the limiter with more goroutines
+// than the limit and asserts the in-flight count never exceeds it.
+func TestConcurrencyLimiter_CapsActive(t *testing.T) {
+	t.Parallel()
+	l := newConcurrencyLimiter()
+	const limit = 2
+	const workers = 12
+
+	var active, maxSeen atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l.acquire(func() int { return limit })
+			defer l.release()
+
+			n := active.Add(1)
+			for {
+				m := maxSeen.Load()
+				if n <= m || maxSeen.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			active.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxSeen.Load(); got > limit {
+		t.Errorf("max concurrent holders = %d, want <= %d", got, limit)
+	}
+}
+
+// TestConcurrencyLimiter_DynamicLimit verifies that a lowered limit applies
+// to queued acquirers: with the limit dropped to 1 while 2 hold slots, the
+// next acquirer proceeds only after enough releases.
+func TestConcurrencyLimiter_DynamicLimit(t *testing.T) {
+	t.Parallel()
+	l := newConcurrencyLimiter()
+	var limit atomic.Int64
+	limit.Store(2)
+	limitFn := func() int { return int(limit.Load()) }
+
+	l.acquire(limitFn)
+	l.acquire(limitFn)
+
+	// Lower the limit to 1 while both slots are held.
+	limit.Store(1)
+
+	acquired := make(chan struct{})
+	go func() {
+		l.acquire(limitFn)
+		close(acquired)
+	}()
+
+	// One release brings active to 1, which still meets the new limit of 1 -
+	// the waiter must NOT get in.
+	l.release()
+	select {
+	case <-acquired:
+		t.Fatal("acquire succeeded while active >= lowered limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Second release frees the last slot; now the waiter proceeds.
+	l.release()
+	select {
+	case <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquire did not proceed after enough releases")
+	}
+	l.release()
+
+	// A limit that resolves to 0 or negative must be floored at 1, never
+	// deadlocking every caller.
+	limit.Store(0)
+	done := make(chan struct{})
+	go func() {
+		l.acquire(limitFn)
+		l.release()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("zero limit deadlocked the limiter (must floor at 1)")
+	}
+}

--- a/internal/integration/health_checker_tools.go
+++ b/internal/integration/health_checker_tools.go
@@ -287,7 +287,16 @@ func buildMediaInfoArgs(mode string, customArgs []string, path string) ([]string
 }
 
 // runCommandWithTimeout executes a command with a timeout, returning stdout or an error.
+//
+// Every detection subprocess passes through here, which makes it the one
+// choke point where global scan concurrency can actually be enforced: the
+// scan pool, webhook-triggered checks, deferred rescans and verification all
+// end up in this function. The slot is acquired BEFORE the timeout clock
+// starts, so queueing behind the limiter never eats a tool's time budget.
 func runCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration, toolName string) ([]byte, error) {
+	toolLimiter.acquire(EffectiveScanWorkers)
+	defer toolLimiter.release()
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/repository/tunables.go
+++ b/internal/repository/tunables.go
@@ -96,14 +96,13 @@ var Catalog = []TunableMeta{
 		MaxInt:      100,
 	},
 	{
-		Key:             SettingKeyScannerWorkers,
-		EnvVar:          "HEALARR_SCANNER_WORKERS",
-		Kind:            KindInt,
-		Default:         "auto",
-		Description:     "Number of concurrent detection workers. \"auto\" (0) tunes to container memory.",
-		RequiresRestart: true,
-		MinInt:          0,
-		MaxInt:          32,
+		Key:         SettingKeyScannerWorkers,
+		EnvVar:      "HEALARR_SCANNER_WORKERS",
+		Kind:        KindInt,
+		Default:     "auto",
+		Description: "Max concurrent file checks, shared across scans, webhook checks, rescans and verification. \"auto\" (0) = min(4, CPU cores, memory budget). Each thorough 4K check is a full ffmpeg decode (GPU VRAM or heavy CPU) - raise only if your hardware has headroom. Applies to new scans immediately; lowering also throttles scans already running.",
+		MinInt:      0,
+		MaxInt:      32,
 	},
 	{
 		Key:             SettingKeyShutdownTimeout,
@@ -258,6 +257,45 @@ func (t *Tunables) ThoroughTimeout(ctx context.Context) ResolvedDuration {
 // HwAccel selects ffmpeg hardware acceleration: "auto" / "off" / accel name.
 func (t *Tunables) HwAccel(ctx context.Context) ResolvedString {
 	return t.resolveString(ctx, "HEALARR_HEALTH_CHECK_HWACCEL", SettingKeyHwAccel, "auto", true)
+}
+
+// ScannerWorkers is the configured max concurrent file checks. 0 means
+// "auto" (the consumer derives a prudent default). This getter existed only
+// as a catalog row for a long time: the UI showed and stored scan.workers,
+// but no code ever read the DB value, so the knob was a silent no-op unless
+// set via env (the audit's settings-drift bug class).
+func (t *Tunables) ScannerWorkers(ctx context.Context) ResolvedInt {
+	return t.resolveInt(ctx, "HEALARR_SCANNER_WORKERS", SettingKeyScannerWorkers, 0)
+}
+
+// resolveInt reads env > db > default. "auto" (any case) parses as 0, the
+// catalog's auto sentinel. Parse errors at any layer fall through to the
+// next rather than crashing.
+func (t *Tunables) resolveInt(ctx context.Context, envKey, dbKey string, def int) ResolvedInt {
+	parse := func(s string) (int, bool) {
+		s = strings.TrimSpace(s)
+		if strings.EqualFold(s, "auto") {
+			return 0, true
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 0 {
+			return 0, false
+		}
+		return n, true
+	}
+	if v, ok := os.LookupEnv(envKey); ok && v != "" {
+		if n, ok := parse(v); ok {
+			return ResolvedInt{Value: n, Source: SourceEnv}
+		}
+	}
+	if t.repo != nil {
+		if v, err := t.repo.Get(ctx, dbKey); err == nil && v != "" {
+			if n, ok := parse(v); ok {
+				return ResolvedInt{Value: n, Source: SourceDB}
+			}
+		}
+	}
+	return ResolvedInt{Value: def, Source: SourceDefault}
 }
 
 // resolveString reads env > db > default. If lower is true the value is

--- a/internal/repository/tunables_test.go
+++ b/internal/repository/tunables_test.go
@@ -57,6 +57,60 @@ func TestTunables_Precedence_EnvBeatsDBBeatsDefault(t *testing.T) {
 	}
 }
 
+// TestTunables_ScannerWorkers pins the wiring that was missing for a long
+// time: the scan.workers catalog row existed and the UI stored values, but
+// no code read them - the knob was a silent no-op unless set via env.
+func TestTunables_ScannerWorkers(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestSettingsRepo(t)
+	tn := NewTunables(repo)
+
+	// Default: auto (0).
+	t.Setenv("HEALARR_SCANNER_WORKERS", "")
+	got := tn.ScannerWorkers(ctx)
+	if got.Value != 0 || got.Source != SourceDefault {
+		t.Errorf("default: got %d / %s, want 0 / default", got.Value, got.Source)
+	}
+
+	// DB value (what the UI stores) -> db wins.
+	if err := repo.Set(ctx, SettingKeyScannerWorkers, "6"); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+	got = tn.ScannerWorkers(ctx)
+	if got.Value != 6 || got.Source != SourceDB {
+		t.Errorf("db-only: got %d / %s, want 6 / db", got.Value, got.Source)
+	}
+
+	// "auto" stored in DB parses as 0 (auto sentinel).
+	if err := repo.Set(ctx, SettingKeyScannerWorkers, "auto"); err != nil {
+		t.Fatalf("seed db auto: %v", err)
+	}
+	got = tn.ScannerWorkers(ctx)
+	if got.Value != 0 || got.Source != SourceDB {
+		t.Errorf("db auto: got %d / %s, want 0 / db", got.Value, got.Source)
+	}
+
+	// Env wins over DB.
+	if err := repo.Set(ctx, SettingKeyScannerWorkers, "6"); err != nil {
+		t.Fatalf("re-seed db: %v", err)
+	}
+	t.Setenv("HEALARR_SCANNER_WORKERS", "12")
+	got = tn.ScannerWorkers(ctx)
+	if got.Value != 12 || got.Source != SourceEnv {
+		t.Errorf("env+db: got %d / %s, want 12 / env", got.Value, got.Source)
+	}
+
+	// Corrupt DB value falls through to the default.
+	t.Setenv("HEALARR_SCANNER_WORKERS", "")
+	if err := repo.Set(ctx, SettingKeyScannerWorkers, "lots"); err != nil {
+		t.Fatalf("seed corrupt: %v", err)
+	}
+	got = tn.ScannerWorkers(ctx)
+	if got.Value != 0 || got.Source != SourceDefault {
+		t.Errorf("corrupt db: got %d / %s, want 0 / default", got.Value, got.Source)
+	}
+}
+
 func TestTunables_HwAccel_DefaultLowercase(t *testing.T) {
 	ctx := context.Background()
 	repo := newTestSettingsRepo(t)

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -10,7 +10,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -389,112 +388,23 @@ type ScannerService struct {
 	// directly and leave it at the 0 zero-value — don't pay 500ms per file.
 	sizeStabilityDelay time.Duration
 
-	// scanWorkers is the number of files whose detection (ffprobe / stat
-	// stability check) runs concurrently within a scan. Set by
-	// NewScannerService from HEALARR_SCANNER_WORKERS. The 0 zero-value left by
-	// &ScannerService{}-direct test fixtures means "sequential", so those tests
-	// keep the original single-file-at-a-time path.
+	// scanWorkers is a fixed per-scan worker-pool size for test fixtures
+	// that construct &ScannerService{} directly. The 0 zero-value means
+	// "sequential", keeping those tests on the original
+	// single-file-at-a-time path. Production instances set
+	// liveScanWorkers instead.
 	scanWorkers int
+
+	// liveScanWorkers, set by NewScannerService, makes scanFiles resolve
+	// the pool size from integration.EffectiveScanWorkers (env > scan.workers
+	// UI setting > auto) at every scan start, so a UI change applies to the
+	// next scan without a restart.
+	liveScanWorkers bool
 }
 
 // defaultSizeStabilityDelay is the production re-stat interval for
 // detecting files whose size is still changing (active download/copy).
 const defaultSizeStabilityDelay = 500 * time.Millisecond
-
-// fallbackScanWorkers is used only when available memory can't be determined.
-const fallbackScanWorkers = 4
-
-// maxScanWorkers caps operator-configured concurrency to avoid thrashing
-// storage or spawning an unreasonable number of ffprobe processes.
-const maxScanWorkers = 32
-
-// perWorkerMemoryBudget is the RAM we assume each concurrent detection worker may
-// need. ffprobe (quick mode) is light, but a thorough-mode ffmpeg decode of a
-// large file can use a few hundred MB. Budgeting generously means a small
-// container won't be pushed into an OOM kill by the default concurrency — each
-// extra worker is an extra subprocess counted against the container's cgroup limit.
-const perWorkerMemoryBudget = 512 * 1024 * 1024 // 512 MB
-
-// scannerWorkers returns the detection concurrency. HEALARR_SCANNER_WORKERS wins
-// if set (clamped to [1, maxScanWorkers]); otherwise the default is tuned to the
-// memory available to the process so a memory-constrained container doesn't OOM
-// from running several ffmpeg/ffprobe subprocesses at once.
-func scannerWorkers() int {
-	if v := os.Getenv("HEALARR_SCANNER_WORKERS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
-			if n > maxScanWorkers {
-				return maxScanWorkers
-			}
-			return n
-		}
-		logger.Warnf("Invalid HEALARR_SCANNER_WORKERS %q; using a memory-aware default", v)
-	}
-	return workersForMemory(availableMemoryBytes(), runtime.NumCPU())
-}
-
-// workersForMemory derives the worker count from a memory budget and CPU count.
-// Roughly memBytes/perWorkerMemoryBudget, capped by CPU count and maxScanWorkers,
-// floored at 1. If memBytes is 0 (unknown) it returns fallbackScanWorkers. Pure
-// function for testability.
-func workersForMemory(memBytes uint64, cpus int) int {
-	if cpus < 1 {
-		cpus = 1
-	}
-	if memBytes == 0 {
-		n := fallbackScanWorkers
-		if n > cpus {
-			n = cpus
-		}
-		return n
-	}
-	n := int(memBytes / perWorkerMemoryBudget)
-	if n > cpus {
-		n = cpus
-	}
-	if n > maxScanWorkers {
-		n = maxScanWorkers
-	}
-	if n < 1 {
-		n = 1
-	}
-	return n
-}
-
-// availableMemoryBytes best-effort reports the memory ceiling the process runs
-// under: the container's cgroup memory limit when present, else total system
-// memory. Returns 0 when it can't be determined (e.g. non-Linux), so callers
-// fall back to a fixed default. Linux-specific paths simply don't exist
-// elsewhere, so this stays portable without build tags.
-func availableMemoryBytes() uint64 {
-	// cgroup v2: a single limit file, "max" means unlimited.
-	if b, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
-		if s := strings.TrimSpace(string(b)); s != "max" {
-			if v, err := strconv.ParseUint(s, 10, 64); err == nil && v > 0 {
-				return v
-			}
-		}
-	}
-	// cgroup v1: "unlimited" is a near-max sentinel, so ignore implausibly large values.
-	if b, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
-		if v, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil && v > 0 && v < (1<<62) {
-			return v
-		}
-	}
-	// Fallback: total system memory from /proc/meminfo (kB).
-	if b, err := os.ReadFile("/proc/meminfo"); err == nil {
-		for _, line := range strings.Split(string(b), "\n") {
-			if kb, ok := strings.CutPrefix(line, "MemTotal:"); ok {
-				fields := strings.Fields(kb)
-				if len(fields) >= 1 {
-					if v, err := strconv.ParseUint(fields[0], 10, 64); err == nil {
-						return v * 1024
-					}
-				}
-			}
-		}
-	}
-	return 0
-}
 
 // NewScannerService creates a new ScannerService with the given dependencies.
 func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.HealthChecker, pm integration.PathMapper) *ScannerService {
@@ -507,7 +417,7 @@ func NewScannerService(db *sql.DB, eb *eventbus.EventBus, detector integration.H
 		filesInProgress:    make(map[string]bool),
 		shutdownCh:         make(chan struct{}),
 		sizeStabilityDelay: defaultSizeStabilityDelay,
-		scanWorkers:        scannerWorkers(),
+		liveScanWorkers:    true,
 	}
 	s.initRepositories()
 	return s
@@ -1764,12 +1674,20 @@ func (s *ScannerService) scanFiles(ctx context.Context, progress *ScanProgress, 
 
 	// With a worker pool configured, run detection concurrently. The 0/1 case
 	// (default for &ScannerService{}-direct test fixtures) keeps the original
-	// single-file-at-a-time path untouched.
-	if s.scanWorkers > 1 {
+	// single-file-at-a-time path untouched. Production instances resolve the
+	// pool size live at every scan start (env > scan.workers UI setting >
+	// auto), so tuning applies without a restart; the shared subprocess
+	// limiter in integration additionally enforces lowered limits on scans
+	// already in flight.
+	workers := s.scanWorkers
+	if s.liveScanWorkers {
+		workers = integration.EffectiveScanWorkers()
+	}
+	if workers > 1 {
 		// Parallel mode: the watermark goroutine owns ALL progress
 		// persistence; workers must not write their own out-of-order index.
 		cfg.persistProgressInline = false
-		s.scanFilesParallel(ctx, progress, cfg, activeCorruptions)
+		s.scanFilesParallel(ctx, progress, cfg, activeCorruptions, workers)
 		return
 	}
 
@@ -1825,6 +1743,7 @@ func (s *ScannerService) scanFilesParallel(
 	progress *ScanProgress,
 	cfg scanFilesConfig,
 	activeCorruptions map[string]bool,
+	workers int,
 ) {
 	files := cfg.Files
 	pathID := progress.PathID
@@ -1840,7 +1759,7 @@ func (s *ScannerService) scanFilesParallel(
 	// breaks on the next iteration.
 	var stopped atomic.Bool
 
-	sem := make(chan struct{}, s.scanWorkers)
+	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
 
 	// Mark this scan watermark-managed: shutdown/pause persistence must use

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -4637,56 +4637,27 @@ func TestScannerService_ScanFilesParallel(t *testing.T) {
 	}
 }
 
-// TestWorkersForMemory covers the memory-aware default worker count derivation.
-func TestWorkersForMemory(t *testing.T) {
-	const mb = 1024 * 1024
-	const gb = 1024 * mb
-	tests := []struct {
-		name string
-		mem  uint64
-		cpus int
-		want int
-	}{
-		{"unknown memory falls back (capped by cpu)", 0, 8, fallbackScanWorkers},
-		{"unknown memory capped by low cpu", 0, 2, 2},
-		{"512MB -> 1 worker", 512 * mb, 8, 1},
-		{"under one budget floors at 1", 256 * mb, 8, 1},
-		{"1GB -> 2 workers", 1 * gb, 8, 2},
-		{"2GB -> 4 workers", 2 * gb, 8, 4},
-		{"cpu count caps it", 64 * gb, 4, 4},
-		{"max caps very large boxes", 1024 * gb, 128, maxScanWorkers},
-		{"zero cpus treated as one", 8 * gb, 0, 1},
+// Worker sizing moved to the integration package (EffectiveScanWorkers and
+// the global tool limiter); its tests live in
+// internal/integration/concurrency_test.go. What remains here is the
+// scanner-side contract: NewScannerService resolves the pool size live at
+// scan start, while &ScannerService{}-direct fixtures keep the sequential
+// path via the scanWorkers zero-value.
+func TestScanFiles_LiveWorkerResolution(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := workersForMemory(tt.mem, tt.cpus); got != tt.want {
-				t.Errorf("workersForMemory(%d, %d) = %d, want %d", tt.mem, tt.cpus, got, tt.want)
-			}
-		})
-	}
-}
+	defer db.Close()
 
-// TestScannerWorkers_EnvOverride verifies the env var wins over the memory-aware
-// default and is clamped, while invalid/unset values use the memory-aware path.
-func TestScannerWorkers_EnvOverride(t *testing.T) {
-	t.Setenv("HEALARR_SCANNER_WORKERS", "8")
-	if got := scannerWorkers(); got != 8 {
-		t.Errorf("explicit 8 = %d, want 8", got)
-	}
-
-	t.Setenv("HEALARR_SCANNER_WORKERS", "100")
-	if got := scannerWorkers(); got != maxScanWorkers {
-		t.Errorf("over-max = %d, want %d (clamped)", got, maxScanWorkers)
-	}
-
-	t.Setenv("HEALARR_SCANNER_WORKERS", "garbage")
-	if got := scannerWorkers(); got < 1 || got > maxScanWorkers {
-		t.Errorf("invalid value should fall back to a sane memory-aware default, got %d", got)
-	}
-
-	os.Unsetenv("HEALARR_SCANNER_WORKERS")
-	if got := scannerWorkers(); got < 1 || got > maxScanWorkers {
-		t.Errorf("unset should yield a sane memory-aware default, got %d", got)
+	t.Setenv("HEALARR_SCANNER_WORKERS", "1")
+	s := &ScannerService{db: db, liveScanWorkers: true}
+	// With the env forcing 1, the live path must choose serial mode: a
+	// zero-file scan completes without touching any parallel-only machinery.
+	progress := &ScanProgress{Status: "scanning"}
+	s.scanFiles(context.Background(), progress, scanFilesConfig{})
+	if progress.Status != "completed" {
+		t.Errorf("zero-file serial scan status = %q, want completed", progress.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Production incident on Sokaris (32 cores, RTX 4070): a thorough scan of a 4K library drove load average past 120 and the server ground to a halt. Three root causes, three fixes:

### 1. The `scan.workers` UI setting was a silent no-op
The catalog row existed, the Config UI rendered it and stored values - but **no code ever read the DB value**. Only the env var worked. New `Tunables.ScannerWorkers` getter + `config.LiveScannerWorkers`, resolved env > UI/DB > auto. (Same settings-drift bug class the audit hunted.)

### 2. Auto default was reckless
`min(RAM/512MB, cores, 32)` resolved to **32** on this host; 32 concurrent thorough 4K decodes = ~13 on the GPU until VRAM filled, the rest in CPU software decode. New auto: **min(4, cores, memory budget)**. Operators with strong hardware raise it in the UI or via env.

### 3. The pool was never the only spawner
Webhook-triggered checks, deferred rescans and verification all start detector runs outside the scan pool, so real concurrency exceeded even the configured count (user-observed). A process-wide limiter now sits at the tool-subprocess layer (`runCommandWithTimeout`) where every ffmpeg/ffprobe/HandBrake/mediainfo run passes, sharing one budget across all services.

### Quality-of-life
- Pool size resolves at scan start, limit re-evaluates per acquisition: UI changes apply without restart (`RequiresRestart` dropped from the catalog); **lowering the setting throttles scans already running**.
- Limiter queueing happens before the tool's timeout clock starts, so waiting never eats a check's time budget.
- Worker-sizing helpers moved to `integration` - one resolution shared by pool and limiter, no drift.

## Test plan
- Auto-sizing table (big hosts capped at 4, small containers capped by RAM/cores)
- Env precedence + clamping; UI value end-to-end through `SetLiveTunables`
- Limiter: cap under 12-goroutine hammering, dynamic lowering applies to queued acquirers, zero-limit floors at 1 (no deadlock)
- `go test` integration/repository/config/services green, `-race` pass on integration+services, lint 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrent scanner workers to optimize file scanning performance
  * Worker count can be set via environment variable or UI settings and applies immediately without restart
  * System automatically scales worker count based on available system resources when not explicitly configured
  * Enhanced resource management during file scanning operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->