### PR TITLE
feat(scans): inspect any scanned file's check journey, including healthy ones

### DIFF
--- a/frontend/src/components/ScanFileDetail.tsx
+++ b/frontend/src/components/ScanFileDetail.tsx
@@ -1,0 +1,173 @@
+import { useMemo } from 'react';
+import { X, FileCheck, FileX, SkipForward, ShieldAlert, Cpu, Activity, Clock, ArrowRight, HelpCircle, HardDrive } from 'lucide-react';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+import type { ScanFile, CheckDetails } from '../lib/api';
+import { formatBytes } from '../lib/formatters';
+import { useModalA11y } from '../hooks/useModalA11y';
+import { useDateFormat } from '../lib/useDateFormat';
+
+interface ScanFileDetailProps {
+    file: ScanFile;
+    onClose: () => void;
+    // Opens the remediation journey for a corrupt file that has an aggregate.
+    onViewJourney?: (corruptionId: string) => void;
+}
+
+const statusMeta: Record<string, { label: string; icon: typeof FileCheck; cls: string }> = {
+    healthy: { label: 'Healthy', icon: FileCheck, cls: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20' },
+    corrupt: { label: 'Corrupt', icon: FileX, cls: 'text-red-400 bg-red-500/10 border-red-500/20' },
+    error: { label: 'Corrupt', icon: FileX, cls: 'text-red-400 bg-red-500/10 border-red-500/20' },
+    skipped: { label: 'Skipped', icon: SkipForward, cls: 'text-amber-400 bg-amber-500/10 border-amber-500/20' },
+    inaccessible: { label: 'Inaccessible', icon: ShieldAlert, cls: 'text-orange-400 bg-orange-500/10 border-orange-500/20' },
+};
+
+// outcomeClass colours a check outcome line: green for passed, amber for a
+// fail-safe skip, red for a flag/failure, slate for "not run".
+const outcomeClass = (outcome: string): string => {
+    if (outcome.startsWith('passed')) return 'text-emerald-400';
+    if (outcome.startsWith('skipped') || outcome.startsWith('not run')) return 'text-amber-400';
+    if (outcome.startsWith('flagged') || outcome.startsWith('failed')) return 'text-red-400';
+    return 'text-slate-400';
+};
+
+const formatMs = (ms?: number): string => {
+    if (ms === undefined || ms < 0) return '';
+    if (ms < 1000) return `${ms} ms`;
+    return `${(ms / 1000).toFixed(1)} s`;
+};
+
+const DetailRow = ({ icon: Icon, label, value, valueClass }: { icon: typeof Cpu; label: string; value: string; valueClass?: string }) => (
+    <div className="flex items-start gap-2.5 py-1.5">
+        <Icon className="w-4 h-4 text-slate-500 mt-0.5 flex-shrink-0" />
+        <span className="text-sm text-slate-500 w-32 flex-shrink-0">{label}</span>
+        <span className={clsx('text-sm font-medium', valueClass || 'text-slate-700 dark:text-slate-200')}>{value}</span>
+    </div>
+);
+
+const ScanFileDetail = ({ file, onClose, onViewJourney }: ScanFileDetailProps) => {
+    const ref = useModalA11y<HTMLDivElement>(true, onClose);
+    const { formatTime } = useDateFormat();
+
+    const details = useMemo<CheckDetails | null>(() => {
+        if (!file.check_details) return null;
+        try {
+            return JSON.parse(file.check_details) as CheckDetails;
+        } catch {
+            return null;
+        }
+    }, [file.check_details]);
+
+    const meta = statusMeta[file.status] ?? statusMeta.skipped;
+    const StatusIcon = meta.icon;
+    const fileName = file.file_path.split('/').pop() || file.file_path;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
+            <motion.div
+                ref={ref}
+                tabIndex={-1}
+                role="dialog"
+                aria-modal="true"
+                aria-label={`Scan details for ${fileName}`}
+                initial={{ opacity: 0, scale: 0.96 }}
+                animate={{ opacity: 1, scale: 1 }}
+                className="w-full max-w-2xl max-h-[85vh] overflow-y-auto rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-start justify-between gap-4 p-6 border-b border-slate-200 dark:border-slate-800">
+                    <div className="min-w-0">
+                        <div className="flex items-center gap-2 mb-2">
+                            <span className={clsx('inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border', meta.cls)}>
+                                <StatusIcon className="w-3.5 h-3.5" />
+                                {meta.label}
+                            </span>
+                        </div>
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white truncate" title={file.file_path}>{fileName}</h2>
+                        <p className="text-xs text-slate-500 truncate mt-0.5" title={file.file_path}>{file.file_path}</p>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-1.5 rounded-lg text-slate-500 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors cursor-pointer flex-shrink-0"
+                        aria-label="Close"
+                    >
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                <div className="p-6 space-y-6">
+                    {/* What was checked */}
+                    <section>
+                        <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">What was checked</h3>
+                        {details ? (
+                            <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/30 px-4 py-2 divide-y divide-slate-200 dark:divide-slate-800/50">
+                                <DetailRow icon={Activity} label="Method" value={details.method || 'unknown'} />
+                                <DetailRow icon={Activity} label="Mode" value={details.mode || 'unknown'} />
+                                {details.hwaccel && (
+                                    <DetailRow icon={Cpu} label="Hardware accel" value={details.hwaccel} />
+                                )}
+                                <DetailRow
+                                    icon={FileCheck}
+                                    label="Structural check"
+                                    value={`${details.structural}${details.structural_ms ? `  (${formatMs(details.structural_ms)})` : ''}`}
+                                    valueClass={outcomeClass(details.structural)}
+                                />
+                                {details.content_analysis && (
+                                    <DetailRow
+                                        icon={Activity}
+                                        label="Content analysis"
+                                        value={`${details.content_analysis}${details.content_analysis_ms ? `  (${formatMs(details.content_analysis_ms)})` : ''}`}
+                                        valueClass={outcomeClass(details.content_analysis)}
+                                    />
+                                )}
+                            </div>
+                        ) : (
+                            <div className="flex items-start gap-2 rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/30 px-4 py-3 text-sm text-slate-500">
+                                <HelpCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                                <span>
+                                    No check details recorded. This file was either scanned before check details were captured, or skipped before detection ran (e.g. recently modified or still being written).
+                                </span>
+                            </div>
+                        )}
+                    </section>
+
+                    {/* Result / error */}
+                    {(file.status === 'corrupt' || file.status === 'error' || file.status === 'inaccessible' || file.status === 'skipped') && (file.error_details || file.corruption_type) && (
+                        <section>
+                            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">Result</h3>
+                            <div className={clsx(
+                                'rounded-xl border px-4 py-3 text-sm',
+                                file.status === 'inaccessible' ? 'text-orange-300 bg-orange-500/10 border-orange-500/20' :
+                                    file.status === 'skipped' ? 'text-amber-300 bg-amber-500/10 border-amber-500/20' :
+                                        'text-red-300 bg-red-500/10 border-red-500/20'
+                            )}>
+                                {file.corruption_type && <span className="font-semibold">{file.corruption_type}: </span>}
+                                {file.error_details || 'No further detail recorded.'}
+                            </div>
+                        </section>
+                    )}
+
+                    {/* Metadata */}
+                    <section className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/30 px-4 py-2 divide-y divide-slate-200 dark:divide-slate-800/50">
+                        <DetailRow icon={HardDrive} label="Size" value={formatBytes(file.file_size)} />
+                        <DetailRow icon={Clock} label="Scanned at" value={formatTime(file.scanned_at)} />
+                    </section>
+
+                    {/* Journey link for corrupt files that have an aggregate */}
+                    {file.corruption_id && onViewJourney && (
+                        <button
+                            onClick={() => onViewJourney(file.corruption_id!)}
+                            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 hover:text-blue-300 border border-blue-500/20 hover:border-blue-500/30 transition-colors cursor-pointer font-medium"
+                        >
+                            View remediation journey
+                            <ArrowRight className="w-4 h-4" />
+                        </button>
+                    )}
+                </div>
+            </motion.div>
+        </div>
+    );
+};
+
+export default ScanFileDetail;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,6 +135,23 @@ export interface ScanFile {
     error_details: string;
     file_size: number;
     scanned_at: string;
+    // JSON string of what was checked (method, mode, hwaccel, durations,
+    // content-analysis outcome). "" for rows scanned before this existed.
+    check_details: string;
+    // Present only on corrupt rows that have a corruption aggregate, linking
+    // the file to its remediation journey.
+    corruption_id?: string;
+}
+
+// CheckDetails is the parsed shape of ScanFile.check_details.
+export interface CheckDetails {
+    method: string;
+    mode: string;
+    hwaccel?: string;
+    structural: string;
+    structural_ms: number;
+    content_analysis?: string;
+    content_analysis_ms?: number;
 }
 
 export const getScanFiles = async (

--- a/frontend/src/pages/ScanDetails.tsx
+++ b/frontend/src/pages/ScanDetails.tsx
@@ -10,6 +10,8 @@ import { useDateFormat } from '../lib/useDateFormat';
 import { useToast } from '../contexts/ToastContext';
 import { useWebSocketEvent } from '../contexts/WebSocketProvider';
 import { formatBytes } from '../lib/formatters';
+import ScanFileDetail from '../components/ScanFileDetail';
+import RemediationJourney from '../components/RemediationJourney';
 
 const ScanDetails = () => {
     const { id } = useParams();
@@ -19,6 +21,10 @@ const ScanDetails = () => {
     const [isActionLoading, setIsActionLoading] = useState(false);
     const [currentFile, setCurrentFile] = useState<string | null>(null);
     const [scanProgress, setScanProgress] = useState<{ filesDone: number; totalFiles: number } | null>(null);
+    // Selected file row -> check-details modal; selected corruption -> its
+    // remediation journey (opened from the file modal for corrupt files).
+    const [selectedFile, setSelectedFile] = useState<ScanFile | null>(null);
+    const [journeyCorruptionId, setJourneyCorruptionId] = useState<string | null>(null);
     const limit = 50;
     const { formatCompact, formatTime } = useDateFormat();
     const toast = useToast();
@@ -497,7 +503,10 @@ const ScanDetails = () => {
             {/* Files Table */}
             <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 overflow-hidden">
                 <div className="p-4 border-b border-slate-200 dark:border-slate-800 flex items-center justify-between">
-                    <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Scanned Files</h2>
+                    <div>
+                        <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Scanned Files</h2>
+                        <p className="text-xs text-slate-500 mt-0.5">Click a file to see what was checked.</p>
+                    </div>
                     {hasScanFileData && (
                         <div className="flex items-center gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-lg">
                             <Filter className="w-4 h-4 text-slate-600 dark:text-slate-400 ml-2" />
@@ -543,6 +552,7 @@ const ScanDetails = () => {
                             isLoading={isLoadingFiles}
                             data={filesData?.data || []}
                             mobileCardTitle={(row: ScanFile) => row.file_path.split('/').pop() || row.file_path}
+                            onRowClick={(row: ScanFile) => setSelectedFile(row)}
                             columns={[
                                 {
                                     header: 'Status',
@@ -628,6 +638,26 @@ const ScanDetails = () => {
                     </>
                 )}
             </div>
+
+            {/* Per-file check details. For a corrupt file with an aggregate,
+                the modal offers a jump to its remediation journey. */}
+            {selectedFile && (
+                <ScanFileDetail
+                    file={selectedFile}
+                    onClose={() => setSelectedFile(null)}
+                    onViewJourney={(corruptionId) => {
+                        setSelectedFile(null);
+                        setJourneyCorruptionId(corruptionId);
+                    }}
+                />
+            )}
+
+            {journeyCorruptionId && (
+                <RemediationJourney
+                    corruptionId={journeyCorruptionId}
+                    onClose={() => setJourneyCorruptionId(null)}
+                />
+            )}
         </div>
     );
 };

--- a/internal/api/handlers_health_test.go
+++ b/internal/api/handlers_health_test.go
@@ -159,8 +159,8 @@ func (m *mockHealthChecker) CheckWithConfig(_ string, _ integration.DetectionCon
 	return m.healthy, m.err
 }
 
-func (m *mockHealthChecker) AnalyzeContent(_ string, _ *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
-	return m.healthy, m.err
+func (m *mockHealthChecker) AnalyzeContent(_ string, _ *integration.ScanOverrides) (bool, *integration.HealthCheckError, string) {
+	return m.healthy, m.err, "passed"
 }
 
 // mockPathMapper implements integration.PathMapper for testing

--- a/internal/api/handlers_scans.go
+++ b/internal/api/handlers_scans.go
@@ -344,9 +344,27 @@ func (s *RESTServer) getScanFiles(c *gin.Context) {
 		return
 	}
 
+	// Link corrupt rows to their remediation journey: one batched lookup of
+	// the latest corruption aggregate per file path on this page.
+	var corruptPaths []string
+	for _, row := range rows {
+		if row.Status == "corrupt" {
+			corruptPaths = append(corruptPaths, row.FilePath)
+		}
+	}
+	corruptionIDs := map[string]string{}
+	if len(corruptPaths) > 0 {
+		ids, err := s.corruptions.LatestIDsByFilePaths(c.Request.Context(), corruptPaths)
+		if err != nil {
+			logger.Debugf("Failed to resolve corruption ids for scan files: %v", err)
+		} else {
+			corruptionIDs = ids
+		}
+	}
+
 	files := make([]map[string]interface{}, 0, len(rows))
 	for _, row := range rows {
-		files = append(files, map[string]interface{}{
+		entry := map[string]interface{}{
 			"id":              row.ID,
 			"file_path":       row.FilePath,
 			"status":          row.Status,
@@ -354,7 +372,12 @@ func (s *RESTServer) getScanFiles(c *gin.Context) {
 			"error_details":   row.ErrorDetails.String,
 			"file_size":       row.FileSize.Int64,
 			"scanned_at":      row.ScannedAt,
-		})
+			"check_details":   row.CheckDetails.String,
+		}
+		if id, ok := corruptionIDs[row.FilePath]; ok {
+			entry["corruption_id"] = id
+		}
+		files = append(files, entry)
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/api/handlers_scans_test.go
+++ b/internal/api/handlers_scans_test.go
@@ -75,6 +75,7 @@ func setupScansTestDB(t *testing.T) (*sql.DB, func()) {
 			corruption_type TEXT,
 			error_details TEXT,
 			file_size INTEGER,
+			check_details TEXT,
 			scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 		-- Mirrors migration 010_scan_files_unique_index.sql.

--- a/internal/db/migrations/013_scan_files_check_details.sql
+++ b/internal/db/migrations/013_scan_files_check_details.sql
@@ -1,0 +1,19 @@
+-- 013_scan_files_check_details.sql
+--
+-- Adds a per-file check-details column to scan_files.
+--
+-- scan_files rows record each scanned file's outcome (healthy / corrupt /
+-- skipped / inaccessible) but not WHAT was checked. check_details holds a
+-- small JSON document written by the scanner: detection method, mode,
+-- hardware acceleration, structural-check duration, and the
+-- content-analysis outcome (passed / skipped with reason / flagged).
+--
+-- It backs the scan-details UI where clicking a file shows its check
+-- journey - including for healthy files, which have no corruption
+-- aggregate and therefore no event journey to fall back on.
+--
+-- Existing rows keep NULL (no backfill is possible - the information was
+-- never recorded). NULL means "scanned before this feature existed" and
+-- the UI says so.
+
+ALTER TABLE scan_files ADD COLUMN check_details TEXT;

--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -1106,28 +1106,36 @@ func (hc *CmdHealthChecker) getMediaProbeInfo(path string) (*mediaProbeInfo, err
 // ov bundles the per-scan-path overrides for the global scan tunables
 // (thorough duration / timeout / hwaccel). Pass nil to inherit every
 // value from the live globals.
-func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError) {
+//
+// The third return is a human-readable note of what the pass actually did:
+// "passed", or "skipped: <reason>" for the fail-safe paths that return
+// healthy without analyzing. The note feeds the per-file check details in
+// the scan UI — before it existed, a file whose analysis was skipped every
+// scan (e.g. probe timeouts on large 4K files) was indistinguishable from
+// one that was fully analyzed, except by grepping logs. When the result is
+// unhealthy the note is empty: the HealthCheckError carries the details.
+func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError, string) {
 	if err := validateMediaPath(path); err != nil {
 		return false, &HealthCheckError{
 			Type:    ErrorTypeInvalidConfig,
 			Message: fmt.Sprintf("invalid media path: %v", err),
-		}
+		}, ""
 	}
 
 	// Probe file for duration and stream types
 	info, err := hc.getMediaProbeInfo(path)
 	if err != nil {
 		logger.Warnf("Content analysis skipped (probe failed): %s: %v", path, err)
-		return true, nil
+		return true, nil, fmt.Sprintf("skipped: probe failed: %v", err)
 	}
 
 	if info.Duration <= 0 {
 		logger.Warnf("Content analysis skipped (invalid duration %.2f): %s", info.Duration, path)
-		return true, nil
+		return true, nil, fmt.Sprintf("skipped: probe reported invalid duration %.2f", info.Duration)
 	}
 
 	if !info.HasVideo && !info.HasAudio {
-		return true, nil
+		return true, nil, "skipped: no audio/video streams"
 	}
 
 	// Build ffmpeg command with appropriate filters. Hardware-accel args go
@@ -1153,7 +1161,14 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool
 
 	ffmpegArgs = append(ffmpegArgs, "-f", "null", "-")
 
-	// Run ffmpeg with detection filters
+	// Run ffmpeg with detection filters. This is the single heaviest
+	// detection subprocess (a full or prefix decode), and it does not go
+	// through runCommandWithTimeout, so it must take its own slot from the
+	// global limiter — otherwise lowering scan.workers would not throttle
+	// the decode that matters most.
+	toolLimiter.acquire(EffectiveScanWorkers)
+	defer toolLimiter.release()
+
 	cmd := exec.Command(hc.FFmpegPath, ffmpegArgs...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -1173,17 +1188,17 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool
 			<-done
 		}
 		logger.Warnf("Content analysis timed out after %v: %s", timeout, path)
-		return true, nil
+		return true, nil, fmt.Sprintf("skipped: timed out after %v", timeout)
 	case err := <-done:
 		if err != nil {
 			logger.Warnf("Content analysis ffmpeg error (treating as healthy): %s: %v", path, err)
-			return true, nil
+			return true, nil, fmt.Sprintf("skipped: ffmpeg error: %v", err)
 		}
 	}
 
 	// Parse results and evaluate against threshold
 	output := stderr.String()
-	return evaluateContentAnalysis(contentAnalysisResult{
+	healthy, healthErr := evaluateContentAnalysis(contentAnalysisResult{
 		BlackDuration:   parseDurations(blackDurationRe, output),
 		FreezeDuration:  parseDurations(freezeDurationRe, output),
 		SilenceDuration: parseDurations(silenceDurationRe, output),
@@ -1191,4 +1206,8 @@ func (hc *CmdHealthChecker) AnalyzeContent(path string, ov *ScanOverrides) (bool
 		HasVideo:        info.HasVideo,
 		HasAudio:        info.HasAudio,
 	})
+	if healthy {
+		return true, nil, "passed"
+	}
+	return false, healthErr, ""
 }

--- a/internal/integration/interfaces.go
+++ b/internal/integration/interfaces.go
@@ -173,7 +173,10 @@ func itoa(n int) string {
 type HealthChecker interface {
 	Check(path, mode string) (bool, *HealthCheckError)
 	CheckWithConfig(path string, config DetectionConfig) (bool, *HealthCheckError)
-	AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError)
+	// AnalyzeContent returns (healthy, error, note). The note says what the
+	// pass actually did ("passed" / "skipped: <reason>"), for the per-file
+	// check details; it is empty when the result is unhealthy.
+	AnalyzeContent(path string, ov *ScanOverrides) (bool, *HealthCheckError, string)
 }
 
 // PathMapper defines the interface for translating paths

--- a/internal/repository/corruption.go
+++ b/internal/repository/corruption.go
@@ -374,6 +374,41 @@ func (r *CorruptionRepository) CountUnresolved(ctx context.Context) (int, error)
 	return n, nil
 }
 
+// LatestIDsByFilePaths returns the corruption aggregate id per file path
+// (the most recently updated aggregate when a file has had several), so the
+// scan-details UI can link a corrupt scan row to its remediation journey.
+func (r *CorruptionRepository) LatestIDsByFilePaths(ctx context.Context, paths []string) (map[string]string, error) {
+	out := make(map[string]string, len(paths))
+	if len(paths) == 0 {
+		return out, nil
+	}
+	placeholders := strings.Repeat("?,", len(paths)-1) + "?"
+	args := make([]interface{}, len(paths))
+	for i, p := range paths {
+		args[i] = p
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT file_path, corruption_id FROM corruption_status
+		WHERE file_path IN (`+placeholders+`)
+		ORDER BY last_updated_at ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query corruption ids by file paths: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var filePath, corruptionID string
+		if err := rows.Scan(&filePath, &corruptionID); err != nil {
+			return nil, fmt.Errorf("scan corruption-id row: %w", err)
+		}
+		// Ascending order: later (more recently updated) rows overwrite.
+		out[filePath] = corruptionID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate corruption ids: %w", err)
+	}
+	return out, nil
+}
+
 // CountDetectedToday returns the number of CorruptionDetected events created
 // today, excluding aggregates the user has ignored.
 func (r *CorruptionRepository) CountDetectedToday(ctx context.Context) (int, error) {

--- a/internal/repository/corruption_test.go
+++ b/internal/repository/corruption_test.go
@@ -242,6 +242,48 @@ func TestCorruptionRepository_StateCounts(t *testing.T) {
 	}
 }
 
+func TestCorruptionRepository_LatestIDsByFilePaths(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	// Two aggregates for the same file (a re-corruption): the more recently
+	// updated one must win so the scan row links to the live journey.
+	seedCorruption(t, db, "old", "/movies/Film.mkv", "VerificationSuccess", base)
+	seedCorruption(t, db, "new", "/movies/Film.mkv", "CorruptionDetected", base.Add(time.Hour))
+	seedCorruption(t, db, "other", "/tv/Show.mkv", "DeletionFailed", base)
+
+	ids, err := repo.LatestIDsByFilePaths(context.Background(),
+		[]string{"/movies/Film.mkv", "/tv/Show.mkv", "/missing.mkv"})
+	if err != nil {
+		t.Fatalf("LatestIDsByFilePaths: %v", err)
+	}
+	if ids["/movies/Film.mkv"] != "new" {
+		t.Errorf("Film.mkv = %q, want the most recently updated aggregate %q", ids["/movies/Film.mkv"], "new")
+	}
+	if ids["/tv/Show.mkv"] != "other" {
+		t.Errorf("Show.mkv = %q, want %q", ids["/tv/Show.mkv"], "other")
+	}
+	if _, ok := ids["/missing.mkv"]; ok {
+		t.Errorf("a path with no corruption must be absent from the map, got %q", ids["/missing.mkv"])
+	}
+}
+
+// Empty input must not produce a malformed IN () query.
+func TestCorruptionRepository_LatestIDsByFilePaths_Empty(t *testing.T) {
+	t.Parallel()
+	db := newCorruptionTestDB(t)
+	repo := NewCorruptionRepository(db)
+	ids, err := repo.LatestIDsByFilePaths(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("LatestIDsByFilePaths(nil): %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected empty map, got %v", ids)
+	}
+}
+
 func TestCorruptionRepository_CountDetectedToday(t *testing.T) {
 	t.Parallel()
 	db := newCorruptionTestDB(t)

--- a/internal/repository/scan_file.go
+++ b/internal/repository/scan_file.go
@@ -17,6 +17,11 @@ type ScanFile struct {
 	ErrorDetails   sql.NullString
 	FileSize       sql.NullInt64
 	ScannedAt      string
+	// CheckDetails is the scanner's JSON record of what was checked
+	// (method, mode, hwaccel, durations, content-analysis outcome). NULL on
+	// rows from before migration 013 and on stat-level skips that never
+	// reached detection.
+	CheckDetails sql.NullString
 }
 
 // ScanFileRecord is the write shape for a per-file scan result. Empty
@@ -29,6 +34,7 @@ type ScanFileRecord struct {
 	CorruptionType string
 	ErrorDetails   string
 	FileSize       int64
+	CheckDetails   string
 }
 
 // ScanFileRepository wraps the scan_files table.
@@ -60,18 +66,21 @@ func NewScanFileRepository(sqlDB *sql.DB) *ScanFileRepository {
 // is visible in the scan-detail UI.
 func (r *ScanFileRepository) Record(ctx context.Context, scanID int64, rec ScanFileRecord) error {
 	_ = ctx // retry wrapper operates on the pool; ctx reserved for a future ExecContext variant
-	var corruptionType, errorDetails interface{}
+	var corruptionType, errorDetails, checkDetails interface{}
 	if rec.CorruptionType != "" {
 		corruptionType = rec.CorruptionType
 	}
 	if rec.ErrorDetails != "" {
 		errorDetails = rec.ErrorDetails
 	}
+	if rec.CheckDetails != "" {
+		checkDetails = rec.CheckDetails
+	}
 	_, err := db.ExecWithRetry(r.db, `
-		INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size, scanned_at)
-		VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))
+		INSERT INTO scan_files (scan_id, file_path, status, corruption_type, error_details, file_size, check_details, scanned_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', 'now'))
 		ON CONFLICT(scan_id, file_path) DO NOTHING
-	`, scanID, rec.FilePath, rec.Status, corruptionType, errorDetails, rec.FileSize)
+	`, scanID, rec.FilePath, rec.Status, corruptionType, errorDetails, rec.FileSize, checkDetails)
 	if err != nil {
 		return fmt.Errorf("record scan file: %w", err)
 	}
@@ -130,11 +139,11 @@ func (r *ScanFileRepository) ListForScan(ctx context.Context, scanID int64, stat
 	const tail = ` ORDER BY status DESC, file_path ASC LIMIT ? OFFSET ?`
 	if statusFilter == "" || statusFilter == "all" {
 		rows, err = r.db.QueryContext(ctx,
-			`SELECT id, file_path, status, corruption_type, error_details, file_size, scanned_at
+			`SELECT id, file_path, status, corruption_type, error_details, file_size, check_details, scanned_at
 			 FROM scan_files WHERE scan_id = ?`+tail, scanID, limit, offset)
 	} else {
 		rows, err = r.db.QueryContext(ctx,
-			`SELECT id, file_path, status, corruption_type, error_details, file_size, scanned_at
+			`SELECT id, file_path, status, corruption_type, error_details, file_size, check_details, scanned_at
 			 FROM scan_files WHERE scan_id = ? AND status = ?`+tail, scanID, statusFilter, limit, offset)
 	}
 	if err != nil {
@@ -145,7 +154,7 @@ func (r *ScanFileRepository) ListForScan(ctx context.Context, scanID int64, stat
 	var out []ScanFile
 	for rows.Next() {
 		var f ScanFile
-		if err := rows.Scan(&f.ID, &f.FilePath, &f.Status, &f.CorruptionType, &f.ErrorDetails, &f.FileSize, &f.ScannedAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.FilePath, &f.Status, &f.CorruptionType, &f.ErrorDetails, &f.FileSize, &f.CheckDetails, &f.ScannedAt); err != nil {
 			return nil, fmt.Errorf("scan scan_files row: %w", err)
 		}
 		out = append(out, f)

--- a/internal/repository/scan_file_test.go
+++ b/internal/repository/scan_file_test.go
@@ -17,6 +17,7 @@ CREATE TABLE scan_files (
 	corruption_type TEXT,
 	error_details   TEXT,
 	file_size       INTEGER,
+	check_details   TEXT,
 	scanned_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 -- Mirrors migration 010_scan_files_unique_index.sql so the test DB

--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/mescon/Healarr/internal/config"
 	"github.com/mescon/Healarr/internal/domain"
 	"github.com/mescon/Healarr/internal/eventbus"
 	"github.com/mescon/Healarr/internal/integration"
@@ -1322,6 +1323,13 @@ type scanFileContext struct {
 	dryRun            bool
 	detectionConfig   integration.DetectionConfig
 	activeCorruptions map[string]bool // Preloaded map of file paths with active corruptions
+
+	// checkDetails is the JSON document detectFile builds describing WHAT
+	// was checked and how it went (method, mode, hwaccel, durations,
+	// content-analysis outcome). Recorded into scan_files.check_details so
+	// the scan UI can show a per-file check journey - including for healthy
+	// files, which have no corruption aggregate and hence no event journey.
+	checkDetails string
 }
 
 // scanLoopAction indicates what the scan loop should do after checking state.
@@ -1459,6 +1467,7 @@ func (s *ScannerService) recordSkipped(sfc *scanFileContext, corruptionType, det
 		CorruptionType: corruptionType,
 		ErrorDetails:   details,
 		FileSize:       sfc.fileSize,
+		CheckDetails:   sfc.checkDetails,
 	}); err != nil {
 		logger.Errorf("Failed to record skipped file (%s): %v", corruptionType, err)
 	}
@@ -1468,9 +1477,10 @@ func (s *ScannerService) recordSkipped(sfc *scanFileContext, corruptionType, det
 func (s *ScannerService) recordHealthyFile(sfc *scanFileContext) {
 	if sfc.scanDBID > 0 {
 		err := s.scanFileRepo().Record(context.Background(), sfc.scanDBID, repository.ScanFileRecord{
-			FilePath: sfc.filePath,
-			Status:   "healthy",
-			FileSize: sfc.fileSize,
+			FilePath:     sfc.filePath,
+			Status:       "healthy",
+			FileSize:     sfc.fileSize,
+			CheckDetails: sfc.checkDetails,
 		})
 		if err != nil {
 			// scan_files rows drive the UI scan-detail screen; losing writes
@@ -1494,6 +1504,7 @@ func (s *ScannerService) handleRecoverableError(progress *ScanProgress, sfc *sca
 			CorruptionType: healthErr.Type,
 			ErrorDetails:   healthErr.Message,
 			FileSize:       sfc.fileSize,
+			CheckDetails:   sfc.checkDetails,
 		})
 		if err != nil {
 			logger.Errorf("Failed to record inaccessible file: %v", err)
@@ -1561,6 +1572,7 @@ func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *Sca
 				CorruptionType: "AlreadyProcessing",
 				ErrorDetails:   "File already has active corruption record",
 				FileSize:       sfc.fileSize,
+				CheckDetails:   sfc.checkDetails,
 			}); err != nil {
 				logger.Debugf("Failed to record skipped file (already processing): %v", err)
 			}
@@ -1576,6 +1588,7 @@ func (s *ScannerService) handleTrueCorruption(ctx context.Context, progress *Sca
 			CorruptionType: healthErr.Type,
 			ErrorDetails:   healthErr.Message,
 			FileSize:       sfc.fileSize,
+			CheckDetails:   sfc.checkDetails,
 		})
 		if err != nil {
 			logger.Debugf("Failed to record corrupt file: %v", err)
@@ -2117,15 +2130,82 @@ func (s *ScannerService) detectFile(sfc *scanFileContext, cfg scanFilesConfig) d
 		return detectionResult{outcome: outcomeSkippedSizeChanging}
 	}
 
-	healthy, healthErr := s.detector.CheckWithConfig(sfc.filePath, cfg.DetectionConfig)
-	if healthy && cfg.DetectionConfig.Mode == integration.ModeThorough {
-		// Thorough mode: structurally-healthy files get a content-analysis pass.
-		healthy, healthErr = s.detector.AnalyzeContent(sfc.filePath, cfg.DetectionConfig.Overrides)
+	details := fileCheckDetails{
+		Method:  string(cfg.DetectionConfig.Method),
+		Mode:    cfg.DetectionConfig.Mode,
+		HwAccel: effectiveHwAccelSetting(cfg.DetectionConfig.Overrides),
 	}
+
+	start := time.Now()
+	healthy, healthErr := s.detector.CheckWithConfig(sfc.filePath, cfg.DetectionConfig)
+	details.StructuralMs = time.Since(start).Milliseconds()
+	if healthy {
+		details.Structural = "passed"
+	} else if healthErr != nil {
+		details.Structural = "failed: " + healthErr.Type
+	} else {
+		details.Structural = "failed"
+	}
+
+	switch {
+	case healthy && cfg.DetectionConfig.Mode == integration.ModeThorough:
+		// Thorough mode: structurally-healthy files get a content-analysis pass.
+		var note string
+		cstart := time.Now()
+		healthy, healthErr, note = s.detector.AnalyzeContent(sfc.filePath, cfg.DetectionConfig.Overrides)
+		details.ContentAnalysisMs = time.Since(cstart).Milliseconds()
+		switch {
+		case note != "":
+			details.ContentAnalysis = note
+		case healthErr != nil:
+			details.ContentAnalysis = "flagged: " + healthErr.Type
+		default:
+			details.ContentAnalysis = "flagged"
+		}
+	case cfg.DetectionConfig.Mode == integration.ModeThorough:
+		details.ContentAnalysis = "not run (structural check failed)"
+	default:
+		details.ContentAnalysis = "not run (quick mode)"
+	}
+
+	sfc.checkDetails = details.marshal()
+
 	if healthy {
 		return detectionResult{outcome: outcomeHealthy}
 	}
 	return detectionResult{outcome: outcomeUnhealthy, healthErr: healthErr}
+}
+
+// fileCheckDetails is the per-file "what was checked" record persisted to
+// scan_files.check_details as JSON. It exists so a user can click any
+// scanned file - healthy ones included - and see which method/mode ran, how
+// long it took, and what the content-analysis pass actually did (the
+// fail-safe skip paths used to be visible only as log warnings).
+type fileCheckDetails struct {
+	Method            string `json:"method"`
+	Mode              string `json:"mode"`
+	HwAccel           string `json:"hwaccel,omitempty"`
+	Structural        string `json:"structural"`
+	StructuralMs      int64  `json:"structural_ms"`
+	ContentAnalysis   string `json:"content_analysis,omitempty"`
+	ContentAnalysisMs int64  `json:"content_analysis_ms,omitempty"`
+}
+
+func (d fileCheckDetails) marshal() string {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// effectiveHwAccelSetting reports the hwaccel setting this check runs under:
+// the per-path override when set, else the live global.
+func effectiveHwAccelSetting(ov *integration.ScanOverrides) string {
+	if ov != nil && ov.Hwaccel != nil {
+		return *ov.Hwaccel
+	}
+	return config.LiveHealthCheckHwAccel()
 }
 
 // checkAndHandleFile runs detection for a file and applies the outcome: it

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -4258,11 +4259,11 @@ func TestScannerService_ContentAnalysis_ThoroughMode(t *testing.T) {
 			return true, nil
 		},
 		// Content analysis detects black video
-		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
+		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError, string) {
 			return false, &integration.HealthCheckError{
 				Type:    integration.ErrorTypeBlackVideo,
 				Message: "video is 100% black",
-			}
+			}, ""
 		},
 	}
 
@@ -4325,9 +4326,9 @@ func TestScannerService_ContentAnalysis_QuickMode_Skipped(t *testing.T) {
 		CheckWithConfigFunc: func(path string, config integration.DetectionConfig) (bool, *integration.HealthCheckError) {
 			return true, nil
 		},
-		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
+		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError, string) {
 			t.Error("AnalyzeContent should NOT be called in quick mode")
-			return true, nil
+			return true, nil, "passed"
 		},
 	}
 
@@ -4351,6 +4352,80 @@ func TestScannerService_ContentAnalysis_QuickMode_Skipped(t *testing.T) {
 	// AnalyzeContent should not have been called
 	if mockHC.CallCount("AnalyzeContent") != 0 {
 		t.Error("AnalyzeContent should not be called in quick mode")
+	}
+}
+
+// TestScannerService_RecordsCheckDetails_HealthyFile verifies the
+// scan-file-inspection feature: a HEALTHY file (which has no corruption
+// aggregate and so no event journey) still gets a check_details JSON record
+// describing what ran, so the user can click it on the scan-details page.
+func TestScannerService_RecordsCheckDetails_HealthyFile(t *testing.T) {
+	db, err := testutil.NewTestDB()
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer db.Close()
+
+	eb := eventbus.NewEventBus(db)
+	defer eb.Shutdown()
+
+	mockHC := &testutil.MockHealthChecker{
+		CheckWithConfigFunc: func(path string, config integration.DetectionConfig) (bool, *integration.HealthCheckError) {
+			return true, nil
+		},
+		AnalyzeContentFunc: func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError, string) {
+			return true, nil, "passed"
+		},
+	}
+
+	scanner := NewScannerService(db, eb, mockHC, &testutil.MockPathMapper{})
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "healthy.mkv")
+	if err := os.WriteFile(testFile, []byte("fake media content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	os.Chtimes(testFile, oldTime, oldTime)
+
+	_, err = db.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, enabled, auto_remediate, dry_run, detection_method, detection_mode)
+		VALUES (502, ?, ?, 1, 1, 0, 0, 'ffprobe', 'thorough')`, tmpDir, tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := scanner.ScanPath(502, tmpDir); err != nil {
+		t.Fatalf("ScanPath failed: %v", err)
+	}
+
+	var status string
+	var checkDetails sql.NullString
+	if err := db.QueryRow(`SELECT status, check_details FROM scan_files WHERE file_path = ?`, testFile).
+		Scan(&status, &checkDetails); err != nil {
+		t.Fatalf("read scan_files row: %v", err)
+	}
+	if status != "healthy" {
+		t.Fatalf("status = %q, want healthy", status)
+	}
+	if !checkDetails.Valid || checkDetails.String == "" {
+		t.Fatal("healthy file recorded no check_details (the inspection feature needs them)")
+	}
+
+	var d fileCheckDetails
+	if err := json.Unmarshal([]byte(checkDetails.String), &d); err != nil {
+		t.Fatalf("check_details is not valid JSON: %v (%q)", err, checkDetails.String)
+	}
+	if d.Method != "ffprobe" {
+		t.Errorf("method = %q, want ffprobe", d.Method)
+	}
+	if d.Mode != "thorough" {
+		t.Errorf("mode = %q, want thorough", d.Mode)
+	}
+	if d.Structural != "passed" {
+		t.Errorf("structural = %q, want passed", d.Structural)
+	}
+	if d.ContentAnalysis != "passed" {
+		t.Errorf("content_analysis = %q, want passed", d.ContentAnalysis)
 	}
 }
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -538,7 +538,7 @@ func (m *MockPathMapper) CallCount(method string) int {
 type MockHealthChecker struct {
 	CheckFunc           func(path, mode string) (bool, *integration.HealthCheckError)
 	CheckWithConfigFunc func(path string, config integration.DetectionConfig) (bool, *integration.HealthCheckError)
-	AnalyzeContentFunc  func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError)
+	AnalyzeContentFunc  func(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError, string)
 
 	// Strict makes unconfigured methods panic rather than fall back to the
 	// "file is healthy" default. Opt-in (default false).
@@ -580,14 +580,14 @@ func (m *MockHealthChecker) CheckWithConfig(path string, config integration.Dete
 	return true, nil
 }
 
-func (m *MockHealthChecker) AnalyzeContent(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError) {
+func (m *MockHealthChecker) AnalyzeContent(path string, ov *integration.ScanOverrides) (bool, *integration.HealthCheckError, string) {
 	m.recordCall("AnalyzeContent", path)
 	if m.AnalyzeContentFunc != nil {
 		return m.AnalyzeContentFunc(path, ov)
 	}
 	m.unconfigured("AnalyzeContent")
 	// Default: content is healthy
-	return true, nil
+	return true, nil, "passed"
 }
 
 // CallCount returns the number of times a method was called.

--- a/internal/testutil/testdb.go
+++ b/internal/testutil/testdb.go
@@ -120,6 +120,7 @@ func initializeSchema(db *sql.DB) error {
 			corruption_type TEXT,
 			error_details TEXT,
 			file_size INTEGER,
+			check_details TEXT,
 			scanned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 		);
 		CREATE UNIQUE INDEX idx_scan_files_scan_id_file_path_unique


### PR DESCRIPTION
## Summary

Answers the request: on `/scans/:id`, clicking a scanned file now shows **what was checked and the result** - and this works for **healthy files too**, which have no corruption aggregate and so no event journey to inspect.

### Backend
- New `scan_files.check_details` column (**migration 013**) holding a small JSON document the scanner writes per file: detection method, mode, hwaccel, structural-check result + duration, and the content-analysis outcome.
- `AnalyzeContent` now returns a **note** of what it actually did (`passed` / `skipped: <reason>`), so the fail-safe skip paths - previously visible only as log warnings (e.g. the probe timeouts on large 4K files we just fixed) - are recorded against the file. Interface, mocks, and the one production implementation updated; the heavy content-analysis ffmpeg run also now takes a slot from the global concurrency limiter (#340).
- `getScanFiles` exposes `check_details`, plus `corruption_id` for corrupt rows via a new batched `CorruptionRepository.LatestIDsByFilePaths`, so a corrupt file links straight to its remediation journey.

### Frontend
- New `ScanFileDetail` modal: parsed check details with per-outcome colouring, the result/error block, file metadata, and a **"View remediation journey"** jump for corrupt files that have an aggregate.
- Scan-details file rows are clickable. Rows scanned before this feature (NULL `check_details`) show an explanatory note rather than blanks.

## Test plan
- `LatestIDsByFilePaths`: latest-aggregate-wins for a re-corrupted file, empty-input guard
- Scanner records valid `check_details` JSON (method/mode/structural/content) for a **healthy** thorough-mode file
- `scan_files` schema mirrors updated in three test fixtures
- Backend suites (services/api/repository/db/integration) + `golangci-lint` green
- Frontend `tsc --noEmit`, `eslint`, `npm run build` all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed file scan information display with check outcomes and metadata
  * View analysis method, mode, and structural/content check results for each scanned file
  * See file metadata including size and scan duration
  * Access remediation journey information for corrupted files when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->