### PR TITLE
fix(detector): log hardware-acceleration status once, not per scanned file

### DIFF
--- a/internal/integration/health_checker.go
+++ b/internal/integration/health_checker.go
@@ -448,6 +448,22 @@ func (hc *CmdHealthChecker) detectVideoCodec(path string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// hwAccelStatusLogged guards the process-stable hardware-acceleration status
+// lines so each is logged at most once. resolveHwAccelArgs runs per scanned
+// file (the hwaccel setting is a live tunable, and per-path overrides bypass
+// the args cache in hwAccelArgsResolved), but whether the GPU is present,
+// absent, or misconfigured does not change during a run - logging it per file
+// floods the scan log with one identical line per file.
+var hwAccelStatusLogged sync.Map
+
+// logHwAccelStatusOnce reports whether key has not been logged before,
+// recording it so the next call returns false. Safe for the concurrent scan
+// workers that all resolve hwaccel args.
+func logHwAccelStatusOnce(key string) bool {
+	_, already := hwAccelStatusLogged.LoadOrStore(key, struct{}{})
+	return !already
+}
+
 // resolveHwAccelArgs translates HEALARR_HEALTH_CHECK_HWACCEL into the actual
 // ffmpeg args to use. Split out so it can be tested without a real ffmpeg.
 //   - "off"    -> []
@@ -460,13 +476,19 @@ func resolveHwAccelArgs(ffmpegPath, setting string) []string {
 		return nil
 	case "auto":
 		if probeHwAccelAvailable(ffmpegPath) {
-			logger.Infof("Health check: ffmpeg hardware acceleration detected, enabling -hwaccel auto")
+			if logHwAccelStatusOnce("auto-enabled") {
+				logger.Infof("Health check: ffmpeg hardware acceleration detected, enabling -hwaccel auto")
+			}
 			return []string{"-hwaccel", "auto"}
 		}
-		logger.Debugf("Health check: no ffmpeg hardware acceleration available, scans will use software decode")
+		if logHwAccelStatusOnce("auto-software") {
+			logger.Debugf("Health check: no ffmpeg hardware acceleration available, scans will use software decode")
+		}
 		return nil
 	default:
-		logger.Infof("Health check: ffmpeg hardware acceleration forced via config: -hwaccel %s", setting)
+		if logHwAccelStatusOnce("forced-" + setting) {
+			logger.Infof("Health check: ffmpeg hardware acceleration forced via config: -hwaccel %s", setting)
+		}
 		return []string{"-hwaccel", setting}
 	}
 }
@@ -504,10 +526,15 @@ func probeHwAccelAvailable(ffmpegPath string) bool {
 		return false
 	}
 	if !hwAccelDeviceAvailable() {
-		logger.Warnf("Health check: ffmpeg lists hardware accelerators in its build but no usable GPU device is exposed to the container. " +
-			"Decodes will silently fall back to software. To enable hardware acceleration, map /dev/nvidia* " +
-			"(for NVIDIA NVDEC/CUVID) or /dev/dri (for VAAPI/QSV) into the container via the compose 'devices:' entry " +
-			"and re-launch. See HEALARR_HEALTH_CHECK_HWACCEL.")
+		// Once, not per file: like the status lines above, this is a
+		// process-stable condition the per-file resolution would otherwise
+		// repeat for every scanned file.
+		if logHwAccelStatusOnce("device-missing") {
+			logger.Warnf("Health check: ffmpeg lists hardware accelerators in its build but no usable GPU device is exposed to the container. " +
+				"Decodes will silently fall back to software. To enable hardware acceleration, map /dev/nvidia* " +
+				"(for NVIDIA NVDEC/CUVID) or /dev/dri (for VAAPI/QSV) into the container via the compose 'devices:' entry " +
+				"and re-launch. See HEALARR_HEALTH_CHECK_HWACCEL.")
+		}
 		return false
 	}
 	return true

--- a/internal/integration/health_checker_test.go
+++ b/internal/integration/health_checker_test.go
@@ -1659,6 +1659,36 @@ func TestResolveHwAccelArgs(t *testing.T) {
 	}
 }
 
+// TestLogHwAccelStatusOnce verifies the dedup guard that stops the
+// hardware-acceleration status line from being logged once per scanned file.
+func TestLogHwAccelStatusOnce(t *testing.T) {
+	key := "test-key-" + t.Name()
+	if !logHwAccelStatusOnce(key) {
+		t.Fatal("first call must report not-yet-logged (true)")
+	}
+	for i := 0; i < 5; i++ {
+		if logHwAccelStatusOnce(key) {
+			t.Errorf("call %d must report already-logged (false)", i+2)
+		}
+	}
+	// A different key is independent.
+	if !logHwAccelStatusOnce(key + "-other") {
+		t.Error("a distinct key must log on its own first call")
+	}
+}
+
+// TestResolveHwAccelArgs_RepeatStillReturnsArgs confirms the log-once guard
+// only suppresses logging, never the returned args: every scanned file must
+// still get its -hwaccel flags even though only the first logs.
+func TestResolveHwAccelArgs_RepeatStillReturnsArgs(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		got := resolveHwAccelArgs("/nonexistent/ffmpeg", "vdpau")
+		if !hwAccelSlicesEqual(got, []string{"-hwaccel", "vdpau"}) {
+			t.Fatalf("call %d: got %v, want [-hwaccel vdpau]", i+1, got)
+		}
+	}
+}
+
 func hwAccelSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

User report: during a scan, `/logs` fills with hundreds of identical lines:

```
Health check: ffmpeg hardware acceleration detected, enabling -hwaccel auto
Health check: ffmpeg hardware acceleration detected, enabling -hwaccel auto
... (one per scanned file)
```

The line is logged at Info level inside `resolveHwAccelArgs`, which runs **once per scanned file** - the hwaccel setting is a live tunable, and per-path overrides bypass the args cache in `hwAccelArgsResolved`. The outcome (GPU present / absent / misconfigured) is process-stable, so it has no business repeating per file.

Each distinct hwaccel status line is now logged **at most once** via a `sync.Map` guard (safe for the concurrent scan workers). The guard covers all four per-file status lines: the "detected, enabling auto" info, the "forced via config" info, the "software decode" debug, and the device-missing misconfiguration warning. Only logging is suppressed - the returned `-hwaccel` args are unchanged, so every file still decodes on the GPU.

## Test plan
- New `TestLogHwAccelStatusOnce`: first call true, subsequent false, distinct keys independent.
- New `TestResolveHwAccelArgs_RepeatStillReturnsArgs`: repeated resolution still returns the `-hwaccel` flags (dedup affects logging only).
- Full `internal/integration` suite + `golangci-lint` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate hardware-acceleration status logs during file scans to appear only once per session instead of multiple times.

* **Tests**
  * Added unit tests for hardware-acceleration logging behavior to verify correct log deduplication and argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->