### PR TITLE
fix(scanner): parallel scan interrupted by shutdown must not be recorded completed

### DIFF
--- a/internal/services/scanner.go
+++ b/internal/services/scanner.go
@@ -1077,24 +1077,29 @@ func (s *ScannerService) handlePathInaccessible(scanID, localPath string, access
 
 // finalizeScan handles the cleanup when a scan completes
 func (s *ScannerService) finalizeScan(scanID string, progress *ScanProgress, scanDBID int64) {
-	if progress.Status != ScanStatusInterrupted {
+	switch progress.Status {
+	case ScanStatusInterrupted:
+		// Resumable: Shutdown already persisted 'interrupted' with the saved
+		// resume index. Leave the row untouched.
+	case ScanStatusScanning, ScanStatusEnumerating:
+		// Defense in depth: a still-ACTIVE status here means a stop path
+		// reached finalize without recording a terminal status. Recording
+		// "completed" would falsely mark a partial scan done and drop the
+		// rest of the library, so persist a resumable 'interrupted' (or
+		// 'cancelled' if this is not a shutdown) instead.
+		s.finalizeActiveStatusScan(scanID, progress, scanDBID)
+	default:
+		// Terminal: completed, or cancelled/aborted preserved as-is.
 		finalStatus := ScanStatusCompleted
-		switch progress.Status {
-		case ScanStatusCancelled:
-			finalStatus = ScanStatusCancelled
-		case ScanStatusAborted:
-			// A mount-failure abort must stay ABORTED: finalizing it as
-			// completed made a failed scan masquerade as a successful one in
-			// "Last Scan" and the dashboard.
-			finalStatus = ScanStatusAborted
+		if progress.Status == ScanStatusCancelled || progress.Status == ScanStatusAborted {
+			finalStatus = progress.Status
 		}
 		if scanDBID > 0 {
 			ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
-			err := s.scanRepo().Finalize(ctx, scanDBID, finalStatus, progress.FilesDone)
-			cancel()
-			if err != nil {
+			if err := s.scanRepo().Finalize(ctx, scanDBID, finalStatus, progress.FilesDone); err != nil {
 				logger.Errorf("Failed to update scan record: %v", err)
 			}
+			cancel()
 		}
 	}
 
@@ -1112,6 +1117,43 @@ func (s *ScannerService) finalizeScan(scanID string, progress *ScanProgress, sca
 		},
 	}); err != nil {
 		logger.Errorf("Failed to publish ScanCompleted event for path scan %s: %v", scanID, err)
+	}
+}
+
+// finalizeActiveStatusScan is the backstop for a scan that reached
+// finalizeScan still flagged active (scanning/enumerating) - a stop path that
+// failed to record a terminal status. It records a resumable 'interrupted'
+// (graceful shutdown) or terminal 'cancelled' (anything else) using the
+// watermark resume index, never a false 'completed'.
+func (s *ScannerService) finalizeActiveStatusScan(scanID string, progress *ScanProgress, scanDBID int64) {
+	shuttingDown := false
+	select {
+	case <-s.shutdownCh:
+		shuttingDown = true
+	default:
+	}
+	logger.Warnf("Scan %s reached finalize with active status %q; recording %s instead of completed to avoid a false completion",
+		scanID, progress.Status, map[bool]string{true: "interrupted", false: "cancelled"}[shuttingDown])
+
+	if scanDBID <= 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), scannerQueryTimeout)
+	defer cancel()
+	if shuttingDown {
+		progress.mu.Lock()
+		resumeAt := progress.FilesDone
+		if progress.usesWatermark {
+			resumeAt = progress.resumeIndex
+		}
+		progress.mu.Unlock()
+		if err := s.scanRepo().MarkInterrupted(ctx, scanDBID, resumeAt); err != nil {
+			logger.Errorf("Failed to mark scan %s interrupted at finalize: %v", scanID, err)
+		}
+		return
+	}
+	if _, err := s.scanRepo().MarkCancelled(ctx, scanDBID, "scan stopped without a recorded terminal status"); err != nil {
+		logger.Errorf("Failed to mark scan %s cancelled at finalize: %v", scanID, err)
 	}
 }
 
@@ -1953,9 +1995,42 @@ func (s *ScannerService) scanFilesParallel(
 	close(workersDone)
 	<-watermarkDone
 
-	if !stopped.Load() {
-		progress.Status = "completed"
+	if stopped.Load() {
+		// A stop can be triggered from several break points: the top-of-loop
+		// checkScanCancellation, the semaphore-acquire select's ctx.Done
+		// case, the `if stopped` guard after a worker flipped it, or a worker
+		// observing ctx.Done mid-detection (jobStopped). Only
+		// checkScanCancellation records WHY it stopped; the others set
+		// `stopped` without touching progress.Status, leaving it "scanning".
+		// finalizeScan would then treat that as a normal completion and write
+		// "completed", clobbering the "interrupted" row Shutdown persisted and
+		// silently dropping the unscanned remainder. Normalize from the real
+		// stop cause so every stop path agrees.
+		s.normalizeStoppedStatus(progress)
+		return
 	}
+	progress.Status = "completed"
+}
+
+// normalizeStoppedStatus sets a terminal status on a scan that broke out of
+// its dispatch loop, when the break path did not record one itself. It never
+// overwrites a status a stop path already set precisely (interrupted /
+// cancelled / aborted); it only resolves a still-active status (the file pool
+// stopped without a recorded reason). Shutdown closes shutdownCh BEFORE
+// canceling the scan context, so a closed shutdownCh here means "graceful
+// shutdown -> interrupted (resumable)"; otherwise it was a user cancel.
+func (s *ScannerService) normalizeStoppedStatus(progress *ScanProgress) {
+	switch progress.Status {
+	case ScanStatusInterrupted, ScanStatusCancelled, ScanStatusAborted:
+		return
+	}
+	select {
+	case <-s.shutdownCh:
+		progress.Status = ScanStatusInterrupted
+	default:
+		progress.Status = ScanStatusCancelled
+	}
+	s.emitProgress(progress)
 }
 
 // markFileProcessedNoSync bumps the in-memory FilesDone counter without

--- a/internal/services/scanner_test.go
+++ b/internal/services/scanner_test.go
@@ -5267,6 +5267,127 @@ func TestScannerService_FinalizeScan_AbortedStaysAborted(t *testing.T) {
 	}
 }
 
+// finalizeScan must NEVER record "completed" for a scan that is still in an
+// active status (scanning/enumerating). That state means a stop path failed to
+// record a terminal status; recording completed would falsely mark a partial
+// scan done and silently drop the rest of the library. During shutdown it must
+// become a resumable 'interrupted' with the saved resume index; otherwise
+// 'cancelled'. This reproduces the parallel-scanner shutdown bug where the
+// dispatch loop, blocked on the worker semaphore, broke via ctx.Done without
+// setting the status, and the scan was finalized as completed at ~11%.
+func TestScannerService_FinalizeScan_ActiveStatusNeverCompletes(t *testing.T) {
+	t.Run("shutdown -> interrupted with resume index", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files, current_file_index) VALUES ('/p', 1, 'running', 31118, 0)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanDBID, _ := res.LastInsertId()
+
+		eb := eventbus.NewEventBus(db)
+		defer eb.Shutdown()
+		scanner := &ScannerService{db: db, eventBus: eb, activeScans: make(map[string]*ScanProgress), shutdownCh: make(chan struct{})}
+		scanner.initRepositories()
+		close(scanner.shutdownCh) // graceful shutdown in progress
+
+		// Mid-scan parallel state: watermark resume index well below total.
+		progress := &ScanProgress{ID: "s", Status: ScanStatusScanning, FilesDone: 3514, usesWatermark: true, resumeIndex: 3509}
+		scanner.activeScans["s"] = progress
+		scanner.finalizeScan("s", progress, scanDBID)
+
+		var status string
+		var idx int
+		_ = db.QueryRow(`SELECT status, current_file_index FROM scans WHERE id = ?`, scanDBID).Scan(&status, &idx)
+		if status != "interrupted" {
+			t.Errorf("status = %q, want interrupted (a partial scan must never be recorded completed)", status)
+		}
+		if idx != 3509 {
+			t.Errorf("current_file_index = %d, want 3509 (watermark resume point)", idx)
+		}
+	})
+
+	t.Run("no shutdown -> cancelled, not completed", func(t *testing.T) {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		res, err := db.Exec(`INSERT INTO scans (path, path_id, status, total_files) VALUES ('/p', 1, 'running', 100)`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanDBID, _ := res.LastInsertId()
+
+		eb := eventbus.NewEventBus(db)
+		defer eb.Shutdown()
+		scanner := &ScannerService{db: db, eventBus: eb, activeScans: make(map[string]*ScanProgress), shutdownCh: make(chan struct{})}
+		scanner.initRepositories()
+		// shutdownCh open: not a shutdown.
+
+		progress := &ScanProgress{ID: "s", Status: ScanStatusScanning, FilesDone: 10}
+		scanner.activeScans["s"] = progress
+		scanner.finalizeScan("s", progress, scanDBID)
+
+		var status string
+		_ = db.QueryRow(`SELECT status FROM scans WHERE id = ?`, scanDBID).Scan(&status)
+		if status != "cancelled" {
+			t.Errorf("status = %q, want cancelled", status)
+		}
+	})
+}
+
+// normalizeStoppedStatus resolves a still-active status from the real stop
+// cause and never overwrites a precise terminal status a stop path already set.
+func TestScannerService_NormalizeStoppedStatus(t *testing.T) {
+	// emitProgress publishes to the event bus, so the status-changing cases
+	// need a real one.
+	newScanner := func(t *testing.T, shutdown bool) *ScannerService {
+		db, err := testutil.NewTestDB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.Close() })
+		eb := eventbus.NewEventBus(db)
+		t.Cleanup(eb.Shutdown)
+		s := &ScannerService{db: db, eventBus: eb, shutdownCh: make(chan struct{})}
+		if shutdown {
+			close(s.shutdownCh)
+		}
+		return s
+	}
+
+	t.Run("active + shutdown -> interrupted", func(t *testing.T) {
+		s := newScanner(t, true)
+		p := &ScanProgress{ID: "s", Status: ScanStatusScanning}
+		s.normalizeStoppedStatus(p)
+		if p.Status != ScanStatusInterrupted {
+			t.Errorf("got %q, want interrupted", p.Status)
+		}
+	})
+	t.Run("active + no shutdown -> cancelled", func(t *testing.T) {
+		s := newScanner(t, false)
+		p := &ScanProgress{ID: "s", Status: ScanStatusScanning}
+		s.normalizeStoppedStatus(p)
+		if p.Status != ScanStatusCancelled {
+			t.Errorf("got %q, want cancelled", p.Status)
+		}
+	})
+	t.Run("preserves an already-set aborted status", func(t *testing.T) {
+		// Returns before emitProgress, so no event bus is needed.
+		s := &ScannerService{shutdownCh: make(chan struct{})}
+		close(s.shutdownCh)
+		p := &ScanProgress{Status: ScanStatusAborted}
+		s.normalizeStoppedStatus(p)
+		if p.Status != ScanStatusAborted {
+			t.Errorf("got %q, want aborted (precise status must not be overwritten)", p.Status)
+		}
+	})
+}
+
 // =============================================================================
 // Webhook stability gates + live dedup (audit findings 5+10)
 // =============================================================================


### PR DESCRIPTION
## Summary

**Found while deploying v1.3.15 to Sokaris.** A scan was running through the parallel worker pool; the container restart marked it `completed` at **file 3,514 of 31,118 (11%)** instead of `interrupted`. The result: it did not auto-resume, and ~27,600 files were silently left unscanned.

### Root cause
The parallel dispatch loop spends almost all its time **blocked on the worker semaphore**:
```go
select {
case sem <- struct{}{}:   // wait for a free worker slot
case <-ctx.Done():        // shutdown/cancel
    stopped.Store(true)   // <-- sets stopped, but NOT progress.Status
}
```
On graceful shutdown the context is cancelled, the loop breaks here, and `progress.Status` stays `scanning`. `finalizeScan` then treats any non-interrupted status as a normal completion and writes `completed`, **clobbering the `interrupted` row `Shutdown` had already persisted** via `MarkInterrupted`. Several stop paths shared this gap (the `jobStopped` worker case, the late-bail, the post-worker `stopped` break) — only the top-of-loop `checkScanCancellation` recorded a reason. The worker pool made this routine because the dispatch loop is nearly always parked on the semaphore rather than sitting in the cancellation check. (Serial scans were unaffected: they break only through `checkScanCancellation`, which sets the status.)

### Fix (two layers)
1. **`scanFilesParallel`** normalizes the status from the real stop cause when it breaks out `stopped` — `shutdownCh` closed → `interrupted` (resumable), else `cancelled` — so every stop path agrees instead of relying on each one to set it.
2. **`finalizeScan`** refuses to record `completed` for any still-active status, as defense in depth: it persists a resumable `interrupted` (with the watermark resume index) during shutdown, or `cancelled` otherwise, and logs loudly.

## Test plan
- `finalizeScan` with an active status → `interrupted` with the correct resume index under shutdown, `cancelled` otherwise, **never `completed`** (reproduces the 31,118-file scenario).
- `normalizeStoppedStatus` resolves shutdown vs cancel and preserves an already-set `aborted` status.
- Full `internal/services` suite green under `-race`; lint 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan status handling to correctly persist terminal states when scans are interrupted or cancelled during shutdown.
  * Enhanced scan finalization logic to prevent incomplete state transitions.

* **Tests**
  * Added test coverage for active scan status handling during finalization.
  * Added test coverage for scan status normalization during shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->