### PR TITLE
fix(arr): treat 404 on file delete as success (recycle-bin race)

### DIFF
--- a/internal/integration/arr_client.go
+++ b/internal/integration/arr_client.go
@@ -793,6 +793,22 @@ func (c *HTTPArrClient) deleteFileByID(instance *ArrInstance, fileID int64) erro
 	}
 	defer resp.Body.Close()
 
+	// 404 means the file ID we asked to delete no longer exists on the *arr,
+	// which is exactly the deletion goal - treat it as success, not failure.
+	// This is the recycle-bin race (issue #350): with a *arr recycling bin
+	// enabled, the DELETE can take ~1 minute while the *arr moves the file,
+	// so the request times out client-side; the *arr finishes the move
+	// server-side, and our retry then hits 404. Reporting that as a delete
+	// failure stalled remediation - the file WAS gone, but no replacement
+	// search was ever triggered. We only reach this function after resolving
+	// a concrete fileID from the *arr's own file list, so a 404 here is
+	// unambiguous (unlike a file that was never tracked, which is handled
+	// separately and deliberately refused).
+	if resp.StatusCode == http.StatusNotFound {
+		logger.Infof("File ID %d already absent from %s (404 on delete) - treating as deleted", fileID, instance.Type)
+		return nil
+	}
+
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("failed to delete file: %s", resp.Status)
 	}

--- a/internal/integration/arr_client_test.go
+++ b/internal/integration/arr_client_test.go
@@ -1029,6 +1029,55 @@ func TestHTTPArrClient_DeleteFile_Radarr(t *testing.T) {
 	}
 }
 
+// Recycle-bin race (issue #350): the file is tracked in the *arr (so a fileID
+// resolves), but the DELETE returns 404 because the *arr already moved it to
+// its recycling bin while our request timed out and retried. That 404 means
+// the file is gone - the deletion goal - so DeleteFile must succeed and return
+// metadata so the remediator proceeds to search for a replacement, NOT fail.
+func TestHTTPArrClient_DeleteFile_404OnDeleteIsSuccess(t *testing.T) {
+	client, db := setupTestClient(t)
+	defer db.Close()
+
+	deleteEndpointCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/episodefile" && r.Method == "GET":
+			// File IS still tracked when we list (the recycle-bin move
+			// hasn't been reflected in the file list yet).
+			json.NewEncoder(w).Encode([]struct {
+				ID   int64  `json:"id"`
+				Path string `json:"path"`
+			}{
+				{ID: 174475, Path: "/tv/Show/Season 02/ep07.mkv"},
+			})
+		case r.URL.Path == "/api/v3/episodefile/174475" && r.Method == "DELETE":
+			// ...but by the time the delete lands, the *arr already removed it.
+			deleteEndpointCalled = true
+			w.WriteHeader(http.StatusNotFound)
+		case strings.HasPrefix(r.URL.Path, "/api/v3/episode"):
+			json.NewEncoder(w).Encode([]struct{}{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	encryptedKey, _ := crypto.Encrypt("key")
+	db.DB.Exec(`INSERT INTO arr_instances (id, name, type, url, api_key, enabled) VALUES (1, 'Sonarr', 'sonarr', ?, ?, 1)`, server.URL, encryptedKey)
+	db.DB.Exec(`INSERT INTO scan_paths (id, local_path, arr_path, arr_instance_id, auto_remediate, is_4k) VALUES (1, '/local/tv', '/tv', 1, 0, 0)`)
+
+	metadata, err := client.DeleteFile(693, "/tv/Show/Season 02/ep07.mkv")
+	if err != nil {
+		t.Fatalf("DeleteFile must treat a 404-on-delete as success (file is gone): %v", err)
+	}
+	if !deleteEndpointCalled {
+		t.Error("delete endpoint was not called")
+	}
+	if metadata == nil {
+		t.Error("metadata must be returned so the remediator can trigger a search")
+	}
+}
+
 func TestHTTPArrClient_DeleteFile_NotFoundInArr(t *testing.T) {
 	client, db := setupTestClient(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary

Fixes #350. When a Sonarr/Radarr **recycling bin** is enabled, remediation stalls and the corrupt file is never replaced.

### What happens (from the report)
1. Healarr asks Sonarr to delete the corrupt episode file (ID 174475).
2. With the recycling bin on, Sonarr takes ~1 minute to move the file. The HTTP `DELETE` times out client-side (`context deadline exceeded`) and retries.
3. By the retry, Sonarr has finished the move server-side, so the delete returns **`404 Not Found`**.
4. Healarr treated that 404 as a **delete failure** → no `DeletionCompleted`, no replacement search.
5. The next remediation cycle finds the file genuinely gone from Sonarr → `file not tracked in sonarr; cannot remediate via API` → stuck, with the corrupt slot empty and no re-download.

### Fix
A `404` on the delete means the file ID we asked to delete no longer exists on the *arr — which **is** the deletion goal. `deleteFileByID` now treats 404 as success, so `DeleteFile` returns its metadata (built before the delete, so episode IDs survive) and the remediator proceeds to `DeletionCompleted` → search for a replacement.

Because the existing retry loop already spans ~90s across 3 attempts, the eventual 404 is reached well within the ~1 min recycle-bin move — so no timeout tuning is needed.

### Why this is safe
`deleteFileByID` is only reached **after** a concrete `fileID` is resolved from the *arr's own file list, so a 404 there is unambiguous proof the file is gone. The separate "file was never tracked in the *arr" path (`handleFileNotInArr`) keeps its deliberate refusal untouched — that case stays an honest failure because path-mapping makes an "already deleted" claim unverifiable.

## Test plan
- New `TestHTTPArrClient_DeleteFile_404OnDeleteIsSuccess`: file present at list time, `404` at delete time → `DeleteFile` succeeds and returns metadata.
- All existing `DeleteFile` tests still pass, including `NotFoundInArr` (the refuse-when-never-tracked safety case).
- `internal/integration` suite + `golangci-lint` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File deletion operations now handle already-absent files gracefully, preventing failures in race condition scenarios.

* **Tests**
  * Added test coverage for file deletion with absent files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->